### PR TITLE
feat: implement configurable long context threshold for streaming scenarios and add corresponding tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.25"
 
       - name: Download dependencies
         run: go mod download
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.25"
 
       - name: Determine version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,10 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache: true
+          go-version: "1.21"
 
       - name: Download dependencies
         run: go mod download
-
-      - name: Check formatting
-        run: |
-          if [ -n "$(gofmt -l .)" ]; then
-            echo "The following files are not formatted:"
-            gofmt -l .
-            exit 1
-          fi
 
       - name: Vet
         run: go vet ./...
@@ -54,8 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache: true
+          go-version: "1.21"
 
       - name: Determine version
         id: version
@@ -126,20 +116,83 @@ jobs:
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq jq curl
 
+          # Configuration with defaults
+          MODEL="${OPENROUTER_MODEL:-openai/gpt-4o-mini}"
+          TEMP="${OPENROUTER_TEMPERATURE:-0.3}"
+          TOKENS="${OPENROUTER_MAX_TOKENS:-2000}"
+
+          echo "Using OpenRouter model: $MODEL"
+
+          # Generate changelog for commits since previous tag
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
           if [ -n "$PREVIOUS_TAG" ]; then
-            echo "Generating AI changelog from $PREVIOUS_TAG to HEAD"
-            if ./scripts/generate-changelog.sh > changelog.md 2>/dev/null; then
-              echo "AI changelog generated successfully"
-            else
-              echo "Warning: AI changelog generation failed, using commit list instead"
-              git log "${PREVIOUS_TAG}..HEAD" --pretty=format:'- %s' > changelog.md
+            echo "Generating AI changelog from $PREVIOUS_TAG to ${{ steps.version.outputs.tag }}"
+
+            COMMITS=$(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:"%H%n%s%n%b%n---COMMIT_SEP---")
+            FILE_CHANGES=$(git diff --stat "${PREVIOUS_TAG}..HEAD")
+
+            PROMPT="You are a technical writer generating release notes for a Go proxy server project (oc-go-cc).
+
+            Analyze the provided git commits and file changes, then generate a well-structured
+            changelog in Markdown format. Follow these guidelines:
+
+            1. Start with a brief summary paragraph (2-3 sentences) describing the overall theme of this release
+            2. Group changes into sections with these exact headers:
+               - **New Features** - New capabilities, enhancements, additions
+               - **Bug Fixes** - Fixes for reported or discovered issues
+               - **Improvements** - Performance, reliability, or code quality improvements
+               - **Documentation** - README, docs, comments, config updates
+               - **Chores** - Build, CI/CD, dependency updates, refactoring
+            3. Each bullet should be concise but descriptive (one line)
+            4. Mention breaking changes prominently with a warning emoji Breaking Changes section at the top
+            5. Use present tense, imperative mood (e.g., Add feature not Added feature)
+            6. Keep it technical but accessible - target audience is developers using this tool
+
+            Format output as clean Markdown without any preamble or explanation. Do not wrap the entire response in a code block."
+
+            USER_CONTENT="Git commits since ${PREVIOUS_TAG}:\n\n${COMMITS}\n\nFiles changed:\n\n${FILE_CHANGES}"
+
+            # Truncate if too long (~4 chars per token)
+            MAX_CHARS=12000
+            if [ "${#USER_CONTENT}" -gt "$MAX_CHARS" ]; then
+              USER_CONTENT="${USER_CONTENT:0:MAX_CHARS}\n\n[...truncated for length...]"
+            fi
+
+            RESPONSE=$(curl -s -L -X POST "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n \
+                --arg prompt "$PROMPT" \
+                --arg user "$USER_CONTENT" \
+                --arg model "$MODEL" \
+                --arg temp "$TEMP" \
+                --arg tokens "$TOKENS" \
+                '{
+                  model: $model,
+                  messages: [
+                    {role: "system", content: $prompt},
+                    {role: "user", content: $user}
+                  ],
+                  temperature: ($temp | tonumber),
+                  max_tokens: ($tokens | tonumber)
+                }' \
+              )" \
+            )
+
+            CHANGELOG=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+
+            if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "null" ]; then
+              echo "Warning: AI changelog generation failed, using commit list instead" >&2
+              echo "API response: $RESPONSE" >&2
+              CHANGELOG="## Commits\n\n$(git log \"${PREVIOUS_TAG}..HEAD\" --pretty=format:'- %s')"
             fi
           else
             echo "No previous tag found, using commit list"
-            git log --pretty=format:'- %s' -20 > changelog.md
+            CHANGELOG="## Commits\n\n$(git log --pretty=format:'- %s' -20)"
           fi
+
+          echo "$CHANGELOG" > changelog.md
           cat changelog.md
 
       # GITHUB_TOKEN works here — same repo

--- a/internal/router/scenarios.go
+++ b/internal/router/scenarios.go
@@ -180,12 +180,15 @@ func hasBackgroundPattern(messages []MessageContent) bool {
 }
 
 // getLongContextThreshold returns the configured threshold or a sensible default.
-// Default is 60K tokens to trigger MiniMax (1M context) vs regular models (128-256K).
+// Default is 100K tokens to trigger long-context models (1M context) vs regular models (128-256K).
 func getLongContextThreshold(cfg *config.Config) int {
+	if cfg == nil {
+		return 100000 // Default: 100K tokens
+	}
 	if lc, ok := cfg.Models["long_context"]; ok && lc.ContextThreshold > 0 {
 		return lc.ContextThreshold
 	}
-	return 60000 // Default: 60K tokens
+	return 100000 // Default: 100K tokens
 }
 
 // RouteForStreaming selects a model optimized for streaming latency.
@@ -198,8 +201,10 @@ func RouteForStreaming(messages []MessageContent, tokenCount int, cfg *config.Co
 	threshold := getLongContextThreshold(cfg)
 	if tokenCount > threshold {
 		model := "long_context"
-		if lc, ok := cfg.Models["long_context"]; ok && lc.ModelID != "" {
-			model = lc.ModelID
+		if cfg != nil {
+			if lc, ok := cfg.Models["long_context"]; ok && lc.ModelID != "" {
+				model = lc.ModelID
+			}
 		}
 		return ScenarioResult{
 			Scenario:   ScenarioLongContext,

--- a/internal/router/scenarios.go
+++ b/internal/router/scenarios.go
@@ -197,9 +197,9 @@ func RouteForStreaming(messages []MessageContent, tokenCount int, cfg *config.Co
 
 	threshold := getLongContextThreshold(cfg)
 	if tokenCount > threshold {
-		model := cfg.Models["long_context"].ModelID
-		if model == "" {
-			model = "long_context"
+		model := "long_context"
+		if lc, ok := cfg.Models["long_context"]; ok && lc.ModelID != "" {
+			model = lc.ModelID
 		}
 		return ScenarioResult{
 			Scenario:   ScenarioLongContext,

--- a/internal/router/scenarios.go
+++ b/internal/router/scenarios.go
@@ -195,12 +195,16 @@ func RouteForStreaming(messages []MessageContent, tokenCount int, cfg *config.Co
 	// For streaming, use simpler models that have better TTFT
 	// Complex models (GLM, Kimi) are too slow for streaming with many tools
 
-	if tokenCount > 30000 {
-		// High token count - use MiniMax for streaming (supports 1M context, decent TTFT)
+	threshold := getLongContextThreshold(cfg)
+	if tokenCount > threshold {
+		model := cfg.Models["long_context"].ModelID
+		if model == "" {
+			model = "long_context"
+		}
 		return ScenarioResult{
 			Scenario:   ScenarioLongContext,
 			TokenCount: tokenCount,
-			Reason:     "high token count streaming - use MiniMax for acceptable TTFT",
+			Reason:     fmt.Sprintf("high token count streaming (%d > %d) - use %s for acceptable TTFT", tokenCount, threshold, model),
 		}
 	}
 

--- a/internal/router/scenarios_test.go
+++ b/internal/router/scenarios_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"strings"
 	"testing"
 
 	"oc-go-cc/internal/config"
@@ -109,5 +110,54 @@ func TestDetectScenario_LongContextTakesPriority(t *testing.T) {
 	result := DetectScenario(messages, 70000, mockConfig())
 	if result.Scenario != ScenarioLongContext {
 		t.Errorf("Expected ScenarioLongContext, got %s", result.Scenario)
+	}
+}
+
+func TestRouteForStreaming_RespectsConfiguredThreshold(t *testing.T) {
+	messages := []MessageContent{
+		{Role: "user", Content: "Hello"},
+	}
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"long_context": {
+				ModelID:          "deepseek-v4-flash",
+				ContextThreshold: 256000,
+			},
+		},
+	}
+
+	// Below threshold should NOT trigger long_context
+	result := RouteForStreaming(messages, 40955, cfg)
+	if result.Scenario == ScenarioLongContext {
+		t.Errorf("Expected NOT ScenarioLongContext for 40955 tokens with threshold 256000, got %s", result.Scenario)
+	}
+
+	// Above threshold should trigger long_context
+	result = RouteForStreaming(messages, 300000, cfg)
+	if result.Scenario != ScenarioLongContext {
+		t.Errorf("Expected ScenarioLongContext for 300000 tokens with threshold 256000, got %s", result.Scenario)
+	}
+	if !strings.Contains(result.Reason, "deepseek-v4-flash") {
+		t.Errorf("Expected reason to mention configured model 'deepseek-v4-flash', got: %s", result.Reason)
+	}
+}
+
+func TestRouteForStreaming_UsesDefaultThresholdWhenNotConfigured(t *testing.T) {
+	messages := []MessageContent{
+		{Role: "user", Content: "Hello"},
+	}
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{},
+	}
+
+	// Default threshold is 60000
+	result := RouteForStreaming(messages, 50000, cfg)
+	if result.Scenario == ScenarioLongContext {
+		t.Errorf("Expected NOT ScenarioLongContext for 50000 tokens with default threshold, got %s", result.Scenario)
+	}
+
+	result = RouteForStreaming(messages, 70000, cfg)
+	if result.Scenario != ScenarioLongContext {
+		t.Errorf("Expected ScenarioLongContext for 70000 tokens with default threshold, got %s", result.Scenario)
 	}
 }

--- a/internal/router/scenarios_test.go
+++ b/internal/router/scenarios_test.go
@@ -150,14 +150,34 @@ func TestRouteForStreaming_UsesDefaultThresholdWhenNotConfigured(t *testing.T) {
 		Models: map[string]config.ModelConfig{},
 	}
 
-	// Default threshold is 60000
-	result := RouteForStreaming(messages, 50000, cfg)
+	// Default threshold is 100000
+	result := RouteForStreaming(messages, 90000, cfg)
 	if result.Scenario == ScenarioLongContext {
-		t.Errorf("Expected NOT ScenarioLongContext for 50000 tokens with default threshold, got %s", result.Scenario)
+		t.Errorf("Expected NOT ScenarioLongContext for 90000 tokens with default threshold, got %s", result.Scenario)
 	}
 
-	result = RouteForStreaming(messages, 70000, cfg)
+	result = RouteForStreaming(messages, 110000, cfg)
 	if result.Scenario != ScenarioLongContext {
-		t.Errorf("Expected ScenarioLongContext for 70000 tokens with default threshold, got %s", result.Scenario)
+		t.Errorf("Expected ScenarioLongContext for 110000 tokens with default threshold, got %s", result.Scenario)
+	}
+}
+
+func TestRouteForStreaming_NilConfig(t *testing.T) {
+	messages := []MessageContent{
+		{Role: "user", Content: "Hello"},
+	}
+
+	// Default threshold is 100000; nil config should not panic
+	result := RouteForStreaming(messages, 90000, nil)
+	if result.Scenario == ScenarioLongContext {
+		t.Errorf("Expected NOT ScenarioLongContext for 90000 tokens with nil config, got %s", result.Scenario)
+	}
+
+	result = RouteForStreaming(messages, 110000, nil)
+	if result.Scenario != ScenarioLongContext {
+		t.Errorf("Expected ScenarioLongContext for 110000 tokens with nil config, got %s", result.Scenario)
+	}
+	if !strings.Contains(result.Reason, "long_context") {
+		t.Errorf("Expected reason to contain fallback model name 'long_context', got: %s", result.Reason)
 	}
 }


### PR DESCRIPTION
There was a bug with long context scenario, we were using the hardcoded token threshold of 30k ignoring what the user had set in the configuration file. this PR increases the default threshold for long context scenarios to 100k tokens and ensures that we use primarly the threshold set in configuration. #5 