### PR TITLE
[Codex] Fix Anthropic stream payloads and token usage

### DIFF
--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -7,6 +7,7 @@ import (
 	"oc-go-cc/internal/metrics"
 	"oc-go-cc/internal/router"
 	"oc-go-cc/internal/token"
+	"oc-go-cc/pkg/types"
 )
 
 // HealthHandler handles health checks and token counting endpoints.
@@ -67,13 +68,7 @@ func (h *HealthHandler) HandleCountTokens(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var body struct {
-		Model    string `json:"model"`
-		Messages []struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		} `json:"messages"`
-	}
+	var body types.MessageRequest
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
@@ -81,15 +76,9 @@ func (h *HealthHandler) HandleCountTokens(w http.ResponseWriter, r *http.Request
 	}
 
 	// Count tokens.
-	var messages []token.MessageContent
-	for _, msg := range body.Messages {
-		messages = append(messages, token.MessageContent{
-			Role:    msg.Role,
-			Content: msg.Content,
-		})
-	}
-
-	count, err := h.tokenCounter.CountMessages("", messages)
+	systemText := systemAndToolsTokenText(body.SystemText(), body.Tools)
+	messages := tokenMessagesFromAnthropic(body.Messages)
+	count, err := h.tokenCounter.CountMessages(systemText, messages)
 	if err != nil {
 		http.Error(w, "failed to count tokens", http.StatusInternalServerError)
 		return
@@ -98,6 +87,7 @@ func (h *HealthHandler) HandleCountTokens(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]int{
-		"token_count": count,
+		"input_tokens": count,
+		"token_count":  count,
 	})
 }

--- a/internal/handlers/health_test.go
+++ b/internal/handlers/health_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"oc-go-cc/internal/metrics"
+	"oc-go-cc/internal/token"
+)
+
+func TestHandleCountTokensSupportsAnthropicContentBlocks(t *testing.T) {
+	handler := newTestHealthHandler(t)
+
+	body := []byte(`{
+		"model":"deepseek-v4-pro",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello world"}]}]
+	}`)
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+
+	handler.HandleCountTokens(recorder, req)
+
+	if got, want := recorder.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d; body: %s", got, want, recorder.Body.String())
+	}
+
+	var response map[string]int
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("response is invalid JSON: %v", err)
+	}
+	if response["input_tokens"] <= 0 {
+		t.Fatalf("input_tokens = %d, want positive", response["input_tokens"])
+	}
+	if got, want := response["token_count"], response["input_tokens"]; got != want {
+		t.Fatalf("token_count = %d, want %d", got, want)
+	}
+}
+
+func TestHandleCountTokensIncludesSystemToolsAndThinking(t *testing.T) {
+	handler := newTestHealthHandler(t)
+
+	base := countTokensForTest(t, handler, []byte(`{
+		"model":"deepseek-v4-pro",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]
+	}`))
+
+	withContext := countTokensForTest(t, handler, []byte(`{
+		"model":"deepseek-v4-pro",
+		"system":[{"type":"text","text":"You are helpful"}],
+		"tools":[{"name":"read_file","description":"Read a file","input_schema":{"type":"object","properties":{"path":{"type":"string"}}}}],
+		"messages":[
+			{"role":"assistant","content":[{"type":"thinking","thinking":"Need to inspect files"},{"type":"tool_use","id":"toolu_1","name":"read_file","input":{"path":"README.md"}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"file contents"},{"type":"text","text":"continue"}]}
+		]
+	}`))
+
+	if withContext <= base {
+		t.Fatalf("context-rich count = %d, want greater than base %d", withContext, base)
+	}
+}
+
+func countTokensForTest(t *testing.T, handler *HealthHandler, body []byte) int {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", bytes.NewReader(body))
+	handler.HandleCountTokens(recorder, req)
+
+	if got, want := recorder.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d; body: %s", got, want, recorder.Body.String())
+	}
+
+	var response map[string]int
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("response is invalid JSON: %v", err)
+	}
+	return response["input_tokens"]
+}
+
+func newTestHealthHandler(t *testing.T) *HealthHandler {
+	t.Helper()
+
+	counter, err := token.NewCounter()
+	if err != nil {
+		t.Fatalf("NewCounter() error = %v", err)
+	}
+	return NewHealthHandler(counter, nil, metrics.New())
+}

--- a/internal/handlers/token_count.go
+++ b/internal/handlers/token_count.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"encoding/json"
+	"strings"
+
+	"oc-go-cc/internal/token"
+	"oc-go-cc/pkg/types"
+)
+
+func tokenMessagesFromAnthropic(messages []types.Message) []token.MessageContent {
+	tokenMessages := make([]token.MessageContent, 0, len(messages))
+	for _, msg := range messages {
+		tokenMessages = append(tokenMessages, token.MessageContent{
+			Role:    msg.Role,
+			Content: extractTokenTextFromBlocks(msg.ContentBlocks()),
+		})
+	}
+	return tokenMessages
+}
+
+func systemAndToolsTokenText(system string, tools []types.Tool) string {
+	toolsText := toolsTokenText(tools)
+	if system == "" {
+		return toolsText
+	}
+	if toolsText == "" {
+		return system
+	}
+	return system + "\n" + toolsText
+}
+
+func toolsTokenText(tools []types.Tool) string {
+	if len(tools) == 0 {
+		return ""
+	}
+
+	data, err := json.Marshal(tools)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// extractTokenTextFromBlocks extracts all text-like content that contributes to
+// context usage. This is intentionally broader than routing text extraction.
+func extractTokenTextFromBlocks(blocks []types.ContentBlock) string {
+	var content strings.Builder
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			content.WriteString(block.Text)
+		case "tool_use":
+			content.WriteString("[Tool Use: ")
+			content.WriteString(block.Name)
+			if len(block.Input) > 0 {
+				content.WriteByte(' ')
+				content.Write(block.Input)
+			}
+			content.WriteString("]")
+		case "tool_result":
+			content.WriteString(block.TextContent())
+		case "thinking":
+			content.WriteString(block.Thinking)
+		case "image":
+			content.WriteString("[Image]")
+		}
+	}
+	return content.String()
+}

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -48,6 +48,9 @@ func (t *RequestTransformer) TransformRequest(
 		Messages: messages,
 		Stream:   anthropicReq.Stream,
 	}
+	if anthropicReq.Stream != nil && *anthropicReq.Stream {
+		openaiReq.StreamOptions = &types.StreamOptions{IncludeUsage: true}
+	}
 
 	// Copy optional parameters from Anthropic request
 	if anthropicReq.Temperature != nil {

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -183,6 +183,29 @@ func TestTransformRequestIncludesStreamUsageOptions(t *testing.T) {
 	}
 }
 
+func TestTransformRequestOmitsStreamUsageOptionsWhenStreamingDisabled(t *testing.T) {
+	transformer := NewRequestTransformer()
+	stream := false
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Stream:    &stream,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.StreamOptions != nil {
+		t.Fatalf("StreamOptions = %v, want nil when streaming is disabled", openaiReq.StreamOptions)
+	}
+}
+
 func TestTransformRequestIncludesEmptyReasoningContentForToolCalls(t *testing.T) {
 	transformer := NewRequestTransformer()
 

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -157,6 +157,32 @@ func TestTransformRequestPreservesThinkingAsReasoningContent(t *testing.T) {
 	}
 }
 
+func TestTransformRequestIncludesStreamUsageOptions(t *testing.T) {
+	transformer := NewRequestTransformer()
+	stream := true
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Stream:    &stream,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.StreamOptions == nil {
+		t.Fatal("StreamOptions = nil, want include_usage enabled")
+	}
+	if !openaiReq.StreamOptions.IncludeUsage {
+		t.Fatal("StreamOptions.IncludeUsage = false, want true")
+	}
+}
+
 func TestTransformRequestIncludesEmptyReasoningContentForToolCalls(t *testing.T) {
 	transformer := NewRequestTransformer()
 

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -425,7 +425,10 @@ func (h *StreamHandler) processSSELine(
 
 func (h *StreamHandler) sendUsageDelta(w http.ResponseWriter, flusher http.Flusher, usage *types.UsageInfo) error {
 	event := types.MessageEvent{
-		Type:  "message_delta",
+		Type: "message_delta",
+		Delta: &types.Delta{
+			StopReason: "end_turn",
+		},
 		Usage: usageInfoToAnthropic(usage),
 	}
 	if err := writeSSEEvent(w, event); err != nil {

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -193,11 +193,9 @@ func (h *StreamHandler) processSSELine(
 						*contentStarted = true
 						// Send content_block_start
 						startEvent := types.MessageEvent{
-							Type:  "content_block_start",
-							Index: contentIndex,
-							Delta: &types.Delta{
-								Type: "text",
-							},
+							Type:         "content_block_start",
+							Index:        contentIndex,
+							ContentBlock: &types.ContentBlock{Type: "text", Text: ""},
 						}
 						if err := writeSSEEvent(w, startEvent); err != nil {
 							return ErrClientDisconnected
@@ -224,8 +222,11 @@ func (h *StreamHandler) processSSELine(
 		}
 	}
 
-	// Check for finish_reason - need to send stop events
-	if strings.Contains(data, `"finish_reason":`) && !strings.Contains(data, `"finish_reason":null`) {
+	// Check for finish_reason - need to send stop events. If the chunk also has
+	// usage, fall through to full JSON parsing so usage is preserved.
+	if strings.Contains(data, `"finish_reason":`) &&
+		!strings.Contains(data, `"finish_reason":null`) &&
+		!strings.Contains(data, `"usage":`) {
 		// Close any open content block (reasoning or text)
 		if *contentStarted || *reasoningStarted {
 			stopEvent := types.MessageEvent{
@@ -259,6 +260,11 @@ func (h *StreamHandler) processSSELine(
 	}
 
 	if len(chunk.Choices) == 0 {
+		if chunk.Usage != nil {
+			if err := h.sendUsageDelta(w, flusher, chunk.Usage); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -281,11 +287,9 @@ func (h *StreamHandler) processSSELine(
 			}
 			*reasoningStarted = true
 			startEvent := types.MessageEvent{
-				Type:  "content_block_start",
-				Index: contentIndex,
-				Delta: &types.Delta{
-					Type: "thinking",
-				},
+				Type:         "content_block_start",
+				Index:        contentIndex,
+				ContentBlock: &types.ContentBlock{Type: "thinking", Thinking: ""},
 			}
 			if err := writeSSEEvent(w, startEvent); err != nil {
 				return ErrClientDisconnected
@@ -324,11 +328,9 @@ func (h *StreamHandler) processSSELine(
 			}
 			*contentStarted = true
 			startEvent := types.MessageEvent{
-				Type:  "content_block_start",
-				Index: contentIndex,
-				Delta: &types.Delta{
-					Type: "text",
-				},
+				Type:         "content_block_start",
+				Index:        contentIndex,
+				ContentBlock: &types.ContentBlock{Type: "text", Text: ""},
 			}
 			if err := writeSSEEvent(w, startEvent); err != nil {
 				return ErrClientDisconnected
@@ -355,11 +357,19 @@ func (h *StreamHandler) processSSELine(
 		for _, tc := range choice.Delta.ToolCalls {
 			*contentIndex++
 
+			input := json.RawMessage(`{}`)
+			toolID := tc.ID
+			if toolID == "" {
+				toolID = fmt.Sprintf("toolu_%s", generateID())
+			}
 			startEvent := types.MessageEvent{
 				Type:  "content_block_start",
 				Index: contentIndex,
-				Delta: &types.Delta{
-					Type: "tool_use",
+				ContentBlock: &types.ContentBlock{
+					Type:  "tool_use",
+					ID:    toolID,
+					Name:  tc.Function.Name,
+					Input: input,
 				},
 			}
 			if err := writeSSEEvent(w, startEvent); err != nil {
@@ -397,22 +407,12 @@ func (h *StreamHandler) processSSELine(
 			}
 		}
 
-		var usage *types.Usage
-		if chunk.Usage != nil {
-			usage = &types.Usage{
-				InputTokens:              chunk.Usage.PromptTokens,
-				OutputTokens:             chunk.Usage.CompletionTokens,
-				CacheCreationInputTokens: chunk.Usage.PromptCacheMissTokens,
-				CacheReadInputTokens:     chunk.Usage.PromptCacheHitTokens,
-			}
-		}
-
 		msgDelta := types.MessageEvent{
 			Type: "message_delta",
 			Delta: &types.Delta{
 				StopReason: h.responseTransformer.mapFinishReason(choice.FinishReason),
 			},
-			Usage: usage,
+			Usage: usageInfoToAnthropic(chunk.Usage),
 		}
 		if err := writeSSEEvent(w, msgDelta); err != nil {
 			return ErrClientDisconnected
@@ -421,6 +421,30 @@ func (h *StreamHandler) processSSELine(
 	}
 
 	return nil
+}
+
+func (h *StreamHandler) sendUsageDelta(w http.ResponseWriter, flusher http.Flusher, usage *types.UsageInfo) error {
+	event := types.MessageEvent{
+		Type:  "message_delta",
+		Usage: usageInfoToAnthropic(usage),
+	}
+	if err := writeSSEEvent(w, event); err != nil {
+		return ErrClientDisconnected
+	}
+	flusher.Flush()
+	return nil
+}
+
+func usageInfoToAnthropic(usage *types.UsageInfo) *types.Usage {
+	if usage == nil {
+		return nil
+	}
+	return &types.Usage{
+		InputTokens:              usage.PromptTokens,
+		OutputTokens:             usage.CompletionTokens,
+		CacheCreationInputTokens: usage.PromptCacheMissTokens,
+		CacheReadInputTokens:     usage.PromptCacheHitTokens,
+	}
 }
 
 // writeSSEEvent writes a single SSE event to the HTTP response writer.

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -92,8 +92,8 @@ func TestProxyStream_ReasoningContentFastPath(t *testing.T) {
 	if events[1].Type != "content_block_start" {
 		t.Errorf("event[1].Type = %q, want content_block_start", events[1].Type)
 	}
-	if got := events[1].Delta.Type; got != "thinking" {
-		t.Errorf("event[1].Delta.Type = %q, want thinking", got)
+	if events[1].ContentBlock == nil || events[1].ContentBlock.Type != "thinking" {
+		t.Errorf("event[1].ContentBlock = %+v, want thinking block", events[1].ContentBlock)
 	}
 	if events[2].Type != "content_block_delta" {
 		t.Errorf("event[2].Type = %q, want content_block_delta", events[2].Type)
@@ -161,14 +161,14 @@ func TestProxyStream_ReasoningThenText(t *testing.T) {
 	}
 
 	// Verify types
-	if got := events[1].Delta.Type; got != "thinking" {
-		t.Errorf("event[1].Delta.Type = %q, want thinking", got)
+	if events[1].ContentBlock == nil || events[1].ContentBlock.Type != "thinking" {
+		t.Errorf("event[1].ContentBlock = %+v, want thinking block", events[1].ContentBlock)
 	}
 	if got := events[2].Delta.Type; got != "thinking_delta" {
 		t.Errorf("event[2].Delta.Type = %q, want thinking_delta", got)
 	}
-	if got := events[4].Delta.Type; got != "text" {
-		t.Errorf("event[4].Delta.Type = %q, want text", got)
+	if events[4].ContentBlock == nil || events[4].ContentBlock.Type != "text" {
+		t.Errorf("event[4].ContentBlock = %+v, want text block", events[4].ContentBlock)
 	}
 	if got := events[5].Delta.Type; got != "text_delta" {
 		t.Errorf("event[5].Delta.Type = %q, want text_delta", got)
@@ -198,7 +198,7 @@ func TestProxyStream_TextOnlyStillWorks(t *testing.T) {
 		t.Fatalf("expected 7 events, got %d: %+v", len(events), events)
 	}
 
-	if events[1].Type != "content_block_start" || events[1].Delta.Type != "text" {
+	if events[1].Type != "content_block_start" || events[1].ContentBlock == nil || events[1].ContentBlock.Type != "text" {
 		t.Errorf("event[1] = %+v, want content_block_start(text)", events[1])
 	}
 	if events[2].Type != "content_block_delta" || events[2].Delta.Type != "text_delta" {
@@ -206,6 +206,46 @@ func TestProxyStream_TextOnlyStillWorks(t *testing.T) {
 	}
 	if events[2].Delta.Text != "Hello" {
 		t.Errorf("event[2].Delta.Text = %q, want Hello", events[2].Delta.Text)
+	}
+}
+
+func TestProxyStream_UsageOnlyChunk(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"choices":[{"delta":{"content":"Hello"}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":123,"completion_tokens":45,"total_tokens":168,"prompt_cache_hit_tokens":100,"prompt_cache_miss_tokens":23}}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyStream(w, body, "deepseek-v4-pro", ctx); err != nil {
+		t.Fatalf("ProxyStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+	var usage *types.Usage
+	for _, event := range events {
+		if event.Usage != nil {
+			usage = event.Usage
+		}
+	}
+	if usage == nil {
+		t.Fatalf("no usage event found in stream: %+v", events)
+	}
+	if got, want := usage.InputTokens, 123; got != want {
+		t.Fatalf("InputTokens = %d, want %d", got, want)
+	}
+	if got, want := usage.OutputTokens, 45; got != want {
+		t.Fatalf("OutputTokens = %d, want %d", got, want)
+	}
+	if got, want := usage.CacheReadInputTokens, 100; got != want {
+		t.Fatalf("CacheReadInputTokens = %d, want %d", got, want)
+	}
+	if got, want := usage.CacheCreationInputTokens, 23; got != want {
+		t.Fatalf("CacheCreationInputTokens = %d, want %d", got, want)
 	}
 }
 
@@ -233,7 +273,7 @@ func TestProxyStream_ReasoningJSONFallback(t *testing.T) {
 		t.Fatalf("expected 6 events, got %d: %+v", len(events), events)
 	}
 
-	if events[1].Type != "content_block_start" || events[1].Delta.Type != "thinking" {
+	if events[1].Type != "content_block_start" || events[1].ContentBlock == nil || events[1].ContentBlock.Type != "thinking" {
 		t.Errorf("event[1] = %+v, want content_block_start(thinking)", events[1])
 	}
 	if events[2].Type != "content_block_delta" || events[2].Delta.Type != "thinking_delta" {
@@ -267,7 +307,7 @@ func TestProxyStream_EmptyReasoningContentSkipped(t *testing.T) {
 		t.Fatalf("expected 6 events, got %d: %+v", len(events), events)
 	}
 
-	if events[1].Type != "content_block_start" || events[1].Delta.Type != "text" {
+	if events[1].Type != "content_block_start" || events[1].ContentBlock == nil || events[1].ContentBlock.Type != "text" {
 		t.Errorf("event[1] = %+v, want content_block_start(text)", events[1])
 	}
 	if *events[1].Index != 0 {
@@ -304,7 +344,7 @@ func TestProxyStream_ReasoningAndContentInSameChunk(t *testing.T) {
 	}
 
 	// Block 0: thinking
-	if events[1].Type != "content_block_start" || events[1].Delta.Type != "thinking" {
+	if events[1].Type != "content_block_start" || events[1].ContentBlock == nil || events[1].ContentBlock.Type != "thinking" {
 		t.Errorf("event[1] = %+v, want content_block_start(thinking)", events[1])
 	}
 	if events[2].Type != "content_block_delta" || events[2].Delta.Type != "thinking_delta" {
@@ -318,7 +358,7 @@ func TestProxyStream_ReasoningAndContentInSameChunk(t *testing.T) {
 	}
 
 	// Block 1: text
-	if events[4].Type != "content_block_start" || events[4].Delta.Type != "text" {
+	if events[4].Type != "content_block_start" || events[4].ContentBlock == nil || events[4].ContentBlock.Type != "text" {
 		t.Errorf("event[4] = %+v, want content_block_start(text)", events[4])
 	}
 	if events[5].Type != "content_block_delta" || events[5].Delta.Type != "text_delta" {
@@ -372,7 +412,7 @@ func TestProxyStream_ReasoningBeforeContentFastPathRegression(t *testing.T) {
 	}
 
 	// Block 0: thinking (must NOT be lost)
-	if events[1].Type != "content_block_start" || events[1].Delta.Type != "thinking" {
+	if events[1].Type != "content_block_start" || events[1].ContentBlock == nil || events[1].ContentBlock.Type != "thinking" {
 		t.Errorf("event[1] = %+v, want content_block_start(thinking)", events[1])
 	}
 	if events[2].Type != "content_block_delta" || events[2].Delta.Type != "thinking_delta" {
@@ -383,7 +423,7 @@ func TestProxyStream_ReasoningBeforeContentFastPathRegression(t *testing.T) {
 	}
 
 	// Block 1: text
-	if events[4].Type != "content_block_start" || events[4].Delta.Type != "text" {
+	if events[4].Type != "content_block_start" || events[4].ContentBlock == nil || events[4].ContentBlock.Type != "text" {
 		t.Errorf("event[4] = %+v, want content_block_start(text)", events[4])
 	}
 	if events[5].Delta.Text != "Hello" {

--- a/pkg/types/anthropic.go
+++ b/pkg/types/anthropic.go
@@ -220,12 +220,13 @@ type Delta struct {
 
 // MessageEvent represents a Server-Sent Event from the streaming API.
 type MessageEvent struct {
-	Type    string           `json:"type"`
-	Message *MessageResponse `json:"message,omitempty"`
-	Index   *int             `json:"index,omitempty"`
-	Delta   *Delta           `json:"delta,omitempty"`
-	Usage   *Usage           `json:"usage,omitempty"`
-	Error   *APIError        `json:"error,omitempty"`
+	Type         string           `json:"type"`
+	Message      *MessageResponse `json:"message,omitempty"`
+	Index        *int             `json:"index,omitempty"`
+	ContentBlock *ContentBlock    `json:"content_block,omitempty"`
+	Delta        *Delta           `json:"delta,omitempty"`
+	Usage        *Usage           `json:"usage,omitempty"`
+	Error        *APIError        `json:"error,omitempty"`
 }
 
 // APIError represents an error from the Anthropic API.

--- a/pkg/types/openai.go
+++ b/pkg/types/openai.go
@@ -19,6 +19,12 @@ type ChatCompletionRequest struct {
 	Tools           []ToolDef       `json:"tools,omitempty"`
 	ToolChoice      interface{}     `json:"tool_choice,omitempty"`
 	Stop            interface{}     `json:"stop,omitempty"`
+	StreamOptions   *StreamOptions  `json:"stream_options,omitempty"`
+}
+
+// StreamOptions controls streaming response metadata from OpenAI-compatible APIs.
+type StreamOptions struct {
+	IncludeUsage bool `json:"include_usage,omitempty"`
 }
 
 // ChatMessage represents a single message in the conversation.


### PR DESCRIPTION
This fixes two Anthropic-compatible client issues:

1. Emit standard `content_block` payloads for `content_block_start` streaming events.
   Some clients expect `content_block.type` and fail when the block type is sent inside `delta`.

2. Improve token accounting for Claude-compatible clients:
   - `/v1/messages/count_tokens` now accepts Anthropic content blocks
   - includes system/tools/thinking/tool_use/tool_result text in token counting
   - returns `input_tokens` while preserving `token_count`
   - requests `stream_options.include_usage`
   - forwards usage-only streaming chunks as Anthropic `message_delta` usage events