### PR TITLE
feat(daemon): add Windows support for background mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ The proxy exposes these endpoints that Claude Code expects:
 
 ## Troubleshooting
 
+### Windows Scoop Background Mode
+
+On Windows, `oc-go-cc serve -b` uses the native Windows process APIs and keeps
+the Scoop shim path intact. This means background mode does not require `nohup`
+or a Unix-like shell, and Scoop-provided environment variables continue to work.
+
 ### "invalid request body" Error
 
 This means the proxy couldn't parse the request from Claude Code. Enable debug logging to see the raw request:

--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -82,7 +82,21 @@ func serveCmd() *cobra.Command {
 				cfg.Port = port
 			}
 
-			// Daemonize setup (child process after re-exec)
+			pidPath := getPIDPath()
+
+			// Check if already running before writing this process' PID.
+			if !daemonize {
+				if pid, err := daemon.GetPID(pidPath); err == nil {
+					// Check if process is still running.
+					if daemon.IsProcessRunning(pid) {
+						return fmt.Errorf("server is already running (PID %d)", pid)
+					}
+					// Stale PID file, clean up.
+					_ = os.Remove(pidPath)
+				}
+			}
+
+			// Daemonize setup (child process after re-exec).
 			if daemonize {
 				paths, err := daemon.DefaultPaths()
 				if err != nil {
@@ -94,22 +108,11 @@ func serveCmd() *cobra.Command {
 				if err := daemon.DaemonizeSetup(paths); err != nil {
 					return err
 				}
-			}
-
-			// Check if already running.
-			pidPath := getPIDPath()
-			if pid, err := daemon.GetPID(pidPath); err == nil {
-				// Check if process is still running.
-				if daemon.IsProcessRunning(pid) {
-					return fmt.Errorf("server is already running (PID %d)", pid)
+			} else {
+				// Write PID file for foreground mode.
+				if err := daemon.WritePID(pidPath, os.Getpid()); err != nil {
+					return fmt.Errorf("failed to write PID file: %w", err)
 				}
-				// Stale PID file, clean up.
-				_ = os.Remove(pidPath)
-			}
-
-			// Write PID file.
-			if err := daemon.WritePID(pidPath, os.Getpid()); err != nil {
-				return fmt.Errorf("failed to write PID file: %w", err)
 			}
 			defer func() { _ = os.Remove(pidPath) }()
 

--- a/internal/daemon/background.go
+++ b/internal/daemon/background.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
+	"path/filepath"
 	"strconv"
 )
 
@@ -15,7 +15,6 @@ type BackgroundOpts struct {
 }
 
 // ForkIntoBackground starts the current binary as a detached background process.
-// Uses nohup to detach from terminal and redirect output.
 func ForkIntoBackground(opts BackgroundOpts) error {
 	paths, err := DefaultPaths()
 	if err != nil {
@@ -24,11 +23,21 @@ func ForkIntoBackground(opts BackgroundOpts) error {
 	if err := paths.EnsureConfigDir(); err != nil {
 		return fmt.Errorf("cannot create config directory: %w", err)
 	}
+	if pid, err := GetPID(paths.PIDFile); err == nil {
+		if IsProcessRunning(pid) {
+			return fmt.Errorf("server is already running (PID %d)", pid)
+		}
+		_ = os.Remove(paths.PIDFile)
+	}
 
-	// Build args for nohup: nohup oc-go-cc serve --_daemonize [--config X] [--port N]
+	// Build args for the child process: oc-go-cc serve --_daemonize [--config X] [--port N]
 	args := []string{"serve", "--_daemonize"}
 	if opts.ConfigPath != "" {
-		args = append(args, "--config", opts.ConfigPath)
+		configPath, err := filepath.Abs(opts.ConfigPath)
+		if err != nil {
+			return fmt.Errorf("cannot resolve config path: %w", err)
+		}
+		args = append(args, "--config", configPath)
 	}
 	if opts.Port != 0 {
 		args = append(args, "--port", strconv.Itoa(opts.Port))
@@ -41,24 +50,18 @@ func ForkIntoBackground(opts BackgroundOpts) error {
 	}
 	defer func() { _ = logFile.Close() }()
 
-	// Use nohup to detach from terminal - works cross-platform
-	cmd := exec.Command("nohup", append([]string{paths.BinaryPath}, args...)...)
+	cmd := newBackgroundCommand(paths.BinaryPath, args)
 	cmd.Env = os.Environ()
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
-	cmd.Dir = "/" // Run from root to avoid any working directory issues
+	cmd.Dir = paths.ConfigDir // Run from a stable directory to avoid caller cwd issues
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start background process: %w", err)
 	}
 
-	// Write PID file
-	pid := cmd.Process.Pid
-	if err := WritePID(paths.PIDFile, pid); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not write PID file: %v\n", err)
-	}
-
-	fmt.Printf("Started %s in background (PID %d)\n", AppName, pid)
+	fmt.Printf("Started %s in background\n", AppName)
+	fmt.Printf("  Launcher PID: %d\n", cmd.Process.Pid)
 	fmt.Printf("  Log file: %s\n", paths.LogFile)
 	fmt.Printf("  PID file: %s\n", paths.PIDFile)
 	fmt.Printf("  Stop with: %s stop\n", AppName)

--- a/internal/daemon/background_unix.go
+++ b/internal/daemon/background_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func newBackgroundCommand(binaryPath string, args []string) *exec.Cmd {
+	cmd := exec.Command("nohup", append([]string{binaryPath}, args...)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd
+}

--- a/internal/daemon/background_windows.go
+++ b/internal/daemon/background_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const (
+	windowsDetachedProcess       = 0x00000008
+	windowsCreateNewProcessGroup = 0x00000200
+)
+
+func newBackgroundCommand(binaryPath string, args []string) *exec.Cmd {
+	cmd := exec.Command(binaryPath, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windowsDetachedProcess | windowsCreateNewProcessGroup,
+		HideWindow:    true,
+	}
+	return cmd
+}

--- a/internal/daemon/paths.go
+++ b/internal/daemon/paths.go
@@ -5,8 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
-	"syscall"
+	"runtime"
 )
 
 const (
@@ -35,11 +34,7 @@ func DefaultPaths() (*Paths, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot determine executable path: %w", err)
 	}
-	// Resolve symlinks so launchd gets the real binary
-	execPath, err = filepath.EvalSymlinks(execPath)
-	if err != nil {
-		return nil, fmt.Errorf("cannot resolve executable path: %w", err)
-	}
+	execPath = resolveExecutablePath(execPath)
 
 	configDir := filepath.Join(home, ConfigDir)
 	return &Paths{
@@ -75,49 +70,33 @@ func WritePID(pidPath string, pid int) error {
 	return os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", pid)), 0644)
 }
 
-// IsProcessRunning checks if a process with the given PID is running.
-func IsProcessRunning(pid int) bool {
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	// Send signal 0 to check if process exists
-	err = process.Signal(os.Signal(nil))
-	return err == nil
-}
-
-// StopProcess sends SIGTERM to a process and waits for it to exit.
-func StopProcess(pid int) error {
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return fmt.Errorf("cannot find process: %w", err)
-	}
-
-	if err := process.Signal(os.Signal(syscall.SIGTERM)); err != nil {
-		return fmt.Errorf("cannot send SIGTERM: %w", err)
-	}
-
-	// Wait for the process to exit
-	_, _ = process.Wait()
-	return nil
-}
-
 // FindBinary returns the absolute path to the oc-go-cc binary.
 func FindBinary() (string, error) {
 	// First try to use the current executable
 	execPath, err := os.Executable()
 	if err == nil {
-		execPath, err = filepath.EvalSymlinks(execPath)
-		if err == nil {
-			return execPath, nil
-		}
+		return resolveExecutablePath(execPath), nil
 	}
 
 	// Fallback: search PATH for oc-go-cc
-	cmd := exec.Command("which", AppName)
-	output, err := cmd.Output()
+	execPath, err = exec.LookPath(AppName)
 	if err != nil {
 		return "", fmt.Errorf("cannot find oc-go-cc binary: %w", err)
 	}
-	return strings.TrimSpace(string(output)), nil
+	return resolveExecutablePath(execPath), nil
+}
+
+func resolveExecutablePath(execPath string) string {
+	// Scoop on Windows launches applications through shims. Resolving those paths
+	// can fail or bypass the shim behavior, so keep the executable path exactly
+	// as Windows reported it.
+	if runtime.GOOS == "windows" {
+		return execPath
+	}
+
+	resolved, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return execPath
+	}
+	return resolved
 }

--- a/internal/daemon/process_unix.go
+++ b/internal/daemon/process_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// IsProcessRunning checks if a process with the given PID is running.
+func IsProcessRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Send signal 0 to check if process exists.
+	err = process.Signal(os.Signal(nil))
+	return err == nil
+}
+
+// StopProcess sends SIGTERM to a process and waits for it to exit.
+func StopProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("cannot find process: %w", err)
+	}
+
+	if err := process.Signal(os.Signal(syscall.SIGTERM)); err != nil {
+		return fmt.Errorf("cannot send SIGTERM: %w", err)
+	}
+
+	// Wait for the process to exit.
+	_, _ = process.Wait()
+	return nil
+}

--- a/internal/daemon/process_windows.go
+++ b/internal/daemon/process_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const windowsSynchronize = 0x00100000
+
+// IsProcessRunning checks if a process with the given PID is running.
+func IsProcessRunning(pid int) bool {
+	handle, err := syscall.OpenProcess(windowsSynchronize, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer func() { _ = syscall.CloseHandle(handle) }()
+
+	event, err := syscall.WaitForSingleObject(handle, 0)
+	return err == nil && event == syscall.WAIT_TIMEOUT
+}
+
+// StopProcess terminates a process on Windows.
+func StopProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("cannot find process: %w", err)
+	}
+
+	if err := process.Kill(); err != nil {
+		return fmt.Errorf("cannot terminate process: %w", err)
+	}
+
+	_, _ = process.Wait()
+	return nil
+}


### PR DESCRIPTION
Split daemon package into platform-specific files for process management and background forking. Windows uses native process APIs (DETACHED_PROCESS, OpenProcess) instead of nohup/signal. Preserve Scoop shim paths by skipping symlink resolution on Windows. Improve PID file handling: check for running instance before daemonize, write PID in foreground mode too.