### PR TITLE
fix(router): use scenario detection for streaming requests

### DIFF
--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -179,18 +179,13 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 		tokenCount = 0
 	}
 
-	// Route to appropriate model.
-	// For streaming, use faster models to minimize TTFT (time-to-first-token)
+	// Route to appropriate model using scenario detection for both streaming and non-streaming.
 	var routeResult router.RouteResult
-	if isStreaming {
-		routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount)
-	} else {
-		var err error
-		routeResult, err = h.modelRouter.Route(routerMessages, tokenCount)
-		if err != nil {
-			h.sendError(w, http.StatusInternalServerError, "routing failed", err)
-			return
-		}
+	var routeErr error
+	routeResult, routeErr = h.modelRouter.Route(routerMessages, tokenCount)
+	if routeErr != nil {
+		h.sendError(w, http.StatusInternalServerError, "routing failed", routeErr)
+		return
 	}
 
 	h.logger.Info("routing request",


### PR DESCRIPTION
## Problem

`RouteForStreaming()` unconditionally downgrades all streaming requests to the `"fast"` scenario, bypassing the entire scenario-based model routing system (`DetectScenario()`). This means:

- All streaming requests use only one model (the `"fast"` scenario configuration)
- Every other scenario (`default`, `think`, `complex`, `long_context`, `background`) is dead code for streaming clients
- Users cannot take advantage of scenario-specific model selection when using streaming

This is particularly impactful for **Claude Code**, which sends all requests as streaming. With this limitation, sophisticated model routing configurations become entirely ineffective — every request hits the `"fast"` model regardless of context size, task complexity, or reasoning requirements.

## Fix

Route streaming requests through the same `DetectScenario()` → `Route()` path as non-streaming requests. This allows the full scenario detection logic to select the appropriate model based on:
- Token count (long context → 1M window models)
- Task complexity (complex → capable reasoning models)
- Background/trivial tasks (background → cheap fast models)
- Default behavior (balanced default model)

## What's preserved

`RouteForStreaming()` remains in the codebase as a public function for latency-sensitive clients that explicitly want fast routing. The change only affects the handler-level decision of which routing function to call.

## Tested

- Builds successfully (`make build`)
- Tested with Claude Code streaming conversations — scenario routing now correctly selects models based on content analysis

## Before / After

**Before:** 100% of streaming requests → `scenario=fast`
```
routing request scenario=fast model=deepseek-v4-flash
routing request scenario=fast model=deepseek-v4-flash
routing request scenario=fast model=deepseek-v4-flash
```

**After:** Requests routed based on actual content
```
routing request scenario=default model=deepseek-v4-pro
routing request scenario=background model=deepseek-v4-flash
routing request scenario=complex model=deepseek-v4-pro
routing request scenario=think model=deepseek-v4-pro
```