### PR TITLE
feat(config): add enable_streaming_scenario_routing option

### DIFF
--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -360,6 +360,7 @@ func getDefaultConfig() string {
   "api_key": "${OC_GO_CC_API_KEY}",
   "host": "127.0.0.1",
   "port": 3456,
+  "enable_streaming_scenario_routing": false,
   "models": {
     "background": {
       "provider": "opencode-go",

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -3,6 +3,8 @@
   "host": "127.0.0.1",
   "port": 3456,
 
+  "enable_streaming_scenario_routing": false,
+
   "models": {
     "background": {
       "provider": "opencode-go",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,13 +5,14 @@ import "encoding/json"
 
 // Config holds the complete application configuration.
 type Config struct {
-	APIKey     string                   `json:"api_key"`
-	Host       string                   `json:"host"`
-	Port       int                      `json:"port"`
-	Models     map[string]ModelConfig   `json:"models"`
-	Fallbacks  map[string][]ModelConfig `json:"fallbacks"`
-	OpenCodeGo OpenCodeGoConfig         `json:"opencode_go"`
-	Logging    LoggingConfig            `json:"logging"`
+	APIKey                         string                   `json:"api_key"`
+	Host                           string                   `json:"host"`
+	Port                           int                      `json:"port"`
+	EnableStreamingScenarioRouting bool                     `json:"enable_streaming_scenario_routing"`
+	Models                         map[string]ModelConfig   `json:"models"`
+	Fallbacks                      map[string][]ModelConfig `json:"fallbacks"`
+	OpenCodeGo                     OpenCodeGoConfig         `json:"opencode_go"`
+	Logging                        LoggingConfig            `json:"logging"`
 }
 
 // ModelConfig defines routing rules for a specific model.

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -180,15 +180,16 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Route to appropriate model.
-	// For streaming, use faster models to minimize TTFT (time-to-first-token)
+	// By default, streaming requests use RouteForStreaming() to prioritize low TTFT.
+	// Set "enable_streaming_scenario_routing": true in config to use full scenario detection for streaming.
 	var routeResult router.RouteResult
-	if isStreaming {
+	if isStreaming && !h.config.EnableStreamingScenarioRouting {
 		routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount)
 	} else {
-		var err error
-		routeResult, err = h.modelRouter.Route(routerMessages, tokenCount)
-		if err != nil {
-			h.sendError(w, http.StatusInternalServerError, "routing failed", err)
+		var routeErr error
+		routeResult, routeErr = h.modelRouter.Route(routerMessages, tokenCount)
+		if routeErr != nil {
+			h.sendError(w, http.StatusInternalServerError, "routing failed", routeErr)
 			return
 		}
 	}


### PR DESCRIPTION
## Problem

`RouteForStreaming()` unconditionally downgrades all streaming requests to the `"fast"` scenario, bypassing the full scenario-based model routing system (`DetectScenario()` + `Route()`).

For **Claude Code** (and similar clients that send all requests as streaming), this means:

- Every request uses only the `"fast"` scenario model
- All other scenario configurations (`default`, `think`, `complex`, `long_context`, `background`) are unreachable
- Users cannot benefit from scenario-specific model selection (e.g., use DeepSeek V4 Pro for complex tasks, Qwen for background tasks)

### Log evidence (Claude Code session)

```
scenario=fast model=deepseek-v4-flash
scenario=fast model=deepseek-v4-flash
scenario=fast model=deepseek-v4-flash  ← 100% of requests
```

Complex coding tasks, long-context files, and reasoning prompts all hit the same fast model — regardless of the scenario configuration.

## Fix

Added `enable_streaming_scenario_routing` (bool, default `false`) to `Config`. When set to `true`, streaming requests follow the same `DetectScenario()` → `Route()` path as non-streaming requests.

```json
{
  "api_key": "${OC_GO_CC_API_KEY}",
  "enable_streaming_scenario_routing": true,
  "models": { ... }
}
```

### Routing decisions

| Config value | Streaming behavior | Non-streaming behavior |
|---|---|---|
| `false` (default) | `RouteForStreaming()` — always `fast` | `DetectScenario()` → `Route()` |
| `true` | `DetectScenario()` → `Route()` | `DetectScenario()` → `Route()` |

### After opt-in (Claude Code session)

```
scenario=default     model=deepseek-v4-pro
scenario=complex     model=deepseek-v4-pro
scenario=background  model=deepseek-v4-flash
scenario=think       model=deepseek-v4-pro
scenario=long_context model=deepseek-v4-pro
```

## Changes

| File | Change |
|---|---|
| `internal/config/config.go` | Added `EnableStreamingScenarioRouting bool` field |
| `internal/handlers/messages.go` | Check config flag before routing decision |
| `cmd/oc-go-cc/main.go` | Added field to default config template |
| `configs/config.example.json` | Added field with comment |

## Backward compatibility

- **Default is `false`**: all existing users keep the current streaming-to-fast behavior
- `RouteForStreaming()` remains a public function for direct callers
- No config migration needed — existing configs work unchanged
- Users opt in by adding one line: `"enable_streaming_scenario_routing": true`

## Design rationale

This preserves the original design intent (low-TTFT streaming by default) while giving users who need scenario-aware routing a simple opt-in. It does not remove or deprecate `RouteForStreaming()`, keeping the codebase's original architecture intact.