### PR TITLE
fix: duplicate content_block_start events for streaming tool calls (fixes #17)

### DIFF
--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -232,7 +232,7 @@ func (h *MessagesHandler) handleStreaming(
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
+	rw.WriteHeader(http.StatusOK)
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
 	}

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -249,7 +249,7 @@ func (h *MessagesHandler) handleStreaming(
 			select {
 			case <-ticker.C:
 				// Send SSE comment (ignored by client but keeps connection alive)
-				_, _ = fmt.Fprintf(w, ":keepalive\n\n")
+				_, _ = fmt.Fprintf(rw, ":keepalive\n\n")
 				if f, ok := w.(http.Flusher); ok {
 					f.Flush()
 				}

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -73,6 +73,7 @@ func (h *StreamHandler) ProxyStream(
 	reasoningStarted := false
 	stopSent := false
 	toolUseCount := 0
+	startedToolCalls := make(map[int]int) // maps OpenAI tool call index → Anthropic content block index
 
 	// Read in larger chunks for efficiency, then parse lines
 	readBuf := make([]byte, 4096)
@@ -96,7 +97,7 @@ func (h *StreamHandler) ProxyStream(
 					lineBuf.Reset()
 
 					// Process complete line
-					if err := h.processSSELine(w, flusher, line, &contentIndex, &contentStarted, &reasoningStarted, &stopSent, &toolUseCount, originalModel); err != nil {
+					if err := h.processSSELine(w, flusher, line, &contentIndex, &contentStarted, &reasoningStarted, &stopSent, &toolUseCount, startedToolCalls, originalModel); err != nil {
 						return err
 					}
 				} else {
@@ -109,7 +110,7 @@ func (h *StreamHandler) ProxyStream(
 			// Process any remaining data in buffer
 			if lineBuf.Len() > 0 {
 				line := lineBuf.String()
-				if err := h.processSSELine(w, flusher, line, &contentIndex, &contentStarted, &reasoningStarted, &stopSent, &toolUseCount, originalModel); err != nil {
+				if err := h.processSSELine(w, flusher, line, &contentIndex, &contentStarted, &reasoningStarted, &stopSent, &toolUseCount, startedToolCalls, originalModel); err != nil {
 					return err
 				}
 			}
@@ -143,6 +144,7 @@ func (h *StreamHandler) processSSELine(
 	reasoningStarted *bool,
 	stopSent *bool,
 	toolUseCount *int,
+	startedToolCalls map[int]int,
 	originalModel string,
 ) error {
 	line = strings.TrimSpace(line)
@@ -371,31 +373,43 @@ func (h *StreamHandler) processSSELine(
 		flusher.Flush()
 	}
 
-	// Handle tool call deltas
+	// Handle tool call deltas.
+	// OpenAI streams tool calls incrementally: the first chunk for a given
+	// tool call carries id + name (+ possibly empty arguments), subsequent
+	// chunks carry only incremental arguments.  We must create exactly one
+	// content_block_start per tool call, then stream deltas for it.
 	if len(choice.Delta.ToolCalls) > 0 {
 		for _, tc := range choice.Delta.ToolCalls {
-			*contentIndex++
-			*toolUseCount++
+			oi := tc.Index // OpenAI tool_calls array index
 
-			input := json.RawMessage(`{}`)
-			toolID := tc.ID
-			if toolID == "" {
-				toolID = fmt.Sprintf("toolu_%s", generateID())
-			}
-			startEvent := types.MessageEvent{
-				Type:  "content_block_start",
-				Index: contentIndex,
-				ContentBlock: &types.ContentBlock{
-					Type:  "tool_use",
-					ID:    toolID,
-					Name:  tc.Function.Name,
-					Input: input,
-				},
-			}
-			if err := writeSSEEvent(w, startEvent); err != nil {
-				return ErrClientDisconnected
+			blockIdx, alreadyStarted := startedToolCalls[oi]
+			if !alreadyStarted {
+				// First time seeing this logical tool call — start a new block.
+				*contentIndex++
+				*toolUseCount++
+				blockIdx = *contentIndex
+				startedToolCalls[oi] = blockIdx
+
+				toolID := tc.ID
+				if toolID == "" {
+					toolID = fmt.Sprintf("toolu_%s", generateID())
+				}
+				startEvent := types.MessageEvent{
+					Type:  "content_block_start",
+					Index: &blockIdx,
+					ContentBlock: &types.ContentBlock{
+						Type:  "tool_use",
+						ID:    toolID,
+						Name:  tc.Function.Name,
+						Input: json.RawMessage(`{}`),
+					},
+				}
+				if err := writeSSEEvent(w, startEvent); err != nil {
+					return ErrClientDisconnected
+				}
 			}
 
+			// Send argument delta (if any) — whether new or continuation.
 			if tc.Function.Arguments != "" {
 				delta := types.Delta{
 					Type:        "input_json_delta",
@@ -403,7 +417,7 @@ func (h *StreamHandler) processSSELine(
 				}
 				event := types.MessageEvent{
 					Type:  "content_block_delta",
-					Index: contentIndex,
+					Index: &blockIdx,
 					Delta: &delta,
 				}
 				if err := writeSSEEvent(w, event); err != nil {
@@ -427,11 +441,12 @@ func (h *StreamHandler) processSSELine(
 			}
 		}
 
-		// Close any open tool_use blocks. Each tool call incremented contentIndex,
-		// so we need to close all of them (not just the last one).
-		if *toolUseCount > 0 {
-			for i := 0; i < *toolUseCount; i++ {
-				idx := *contentIndex - *toolUseCount + i
+		// Close any open tool_use blocks. We track started tool calls by their
+		// OpenAI index; close each one in order.
+		for oi, blockIdx := range startedToolCalls {
+			// Only close this block if we haven't already (toolUseCount guard)
+			if blockIdx >= 0 {
+				idx := blockIdx
 				stopEvent := types.MessageEvent{
 					Type:  "content_block_stop",
 					Index: &idx,
@@ -439,7 +454,10 @@ func (h *StreamHandler) processSSELine(
 				if err := writeSSEEvent(w, stopEvent); err != nil {
 					return ErrClientDisconnected
 				}
+				startedToolCalls[oi] = -1
 			}
+		}
+		if *toolUseCount > 0 {
 			*toolUseCount = 0
 		}
 

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -121,6 +121,19 @@ func (h *StreamHandler) ProxyStream(
 		}
 	}
 
+	// Send stop events for any tool blocks not yet closed (e.g. upstream
+	// disconnected without sending a finish_reason chunk).
+	for oi, blockIdx := range startedToolCalls {
+		stopEvent := types.MessageEvent{
+			Type:  "content_block_stop",
+			Index: &blockIdx,
+		}
+		if err := writeSSEEvent(w, stopEvent); err != nil {
+			return ErrClientDisconnected
+		}
+		delete(startedToolCalls, oi)
+	}
+
 	// Send message_stop event to signal stream completion.
 	stopEvent := types.MessageEvent{
 		Type: "message_stop",
@@ -382,8 +395,14 @@ func (h *StreamHandler) processSSELine(
 		for _, tc := range choice.Delta.ToolCalls {
 			oi := tc.Index // OpenAI tool_calls array index
 
-			blockIdx, alreadyStarted := startedToolCalls[oi]
-			if !alreadyStarted {
+			blockIdx, exists := startedToolCalls[oi]
+			if !exists {
+				if tc.Function.Name == "" {
+					// Ghost chunk: this index was closed and recycled, but
+					// has no name/id. Ignore — the real tool call was
+					// already fully processed.
+					continue
+				}
 				// First time seeing this logical tool call — start a new block.
 				*contentIndex++
 				*toolUseCount++
@@ -442,24 +461,19 @@ func (h *StreamHandler) processSSELine(
 		}
 
 		// Close any open tool_use blocks. We track started tool calls by their
-		// OpenAI index; close each one in order.
+		// OpenAI index; close each one, then delete it (no -1 sentinel needed).
 		for oi, blockIdx := range startedToolCalls {
-			// Only close this block if we haven't already (toolUseCount guard)
-			if blockIdx >= 0 {
-				idx := blockIdx
-				stopEvent := types.MessageEvent{
-					Type:  "content_block_stop",
-					Index: &idx,
-				}
-				if err := writeSSEEvent(w, stopEvent); err != nil {
-					return ErrClientDisconnected
-				}
-				startedToolCalls[oi] = -1
+			idx := blockIdx
+			stopEvent := types.MessageEvent{
+				Type:  "content_block_stop",
+				Index: &idx,
 			}
+			if err := writeSSEEvent(w, stopEvent); err != nil {
+				return ErrClientDisconnected
+			}
+			delete(startedToolCalls, oi)
 		}
-		if *toolUseCount > 0 {
-			*toolUseCount = 0
-		}
+		*toolUseCount = 0
 
 		msgDelta := types.MessageEvent{
 			Type: "message_delta",

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -123,15 +124,28 @@ func (h *StreamHandler) ProxyStream(
 
 	// Send stop events for any tool blocks not yet closed (e.g. upstream
 	// disconnected without sending a finish_reason chunk).
-	for oi, blockIdx := range startedToolCalls {
-		stopEvent := types.MessageEvent{
-			Type:  "content_block_stop",
-			Index: &blockIdx,
+	if len(startedToolCalls) > 0 {
+		type toolBlockEntry struct {
+			oi       int
+			blockIdx int
 		}
-		if err := writeSSEEvent(w, stopEvent); err != nil {
-			return ErrClientDisconnected
+		entries := make([]toolBlockEntry, 0, len(startedToolCalls))
+		for oi, blockIdx := range startedToolCalls {
+			entries = append(entries, toolBlockEntry{oi, blockIdx})
 		}
-		delete(startedToolCalls, oi)
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].blockIdx < entries[j].blockIdx
+		})
+		for _, e := range entries {
+			idx := e.blockIdx
+			stopEvent := types.MessageEvent{
+				Type:  "content_block_stop",
+				Index: &idx,
+			}
+			if err := writeSSEEvent(w, stopEvent); err != nil {
+				return ErrClientDisconnected
+			}
+		}
 	}
 
 	// Send message_stop event to signal stream completion.
@@ -254,6 +268,35 @@ func (h *StreamHandler) processSSELine(
 			}
 			if err := writeSSEEvent(w, stopEvent); err != nil {
 				return ErrClientDisconnected
+			}
+		}
+
+		// Close any open tool_use blocks in ascending index order
+		if len(startedToolCalls) > 0 {
+			type toolBlockEntry struct {
+				oi       int
+				blockIdx int
+			}
+			entries := make([]toolBlockEntry, 0, len(startedToolCalls))
+			for oi, blockIdx := range startedToolCalls {
+				entries = append(entries, toolBlockEntry{oi, blockIdx})
+			}
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].blockIdx < entries[j].blockIdx
+			})
+			for _, e := range entries {
+				idx := e.blockIdx
+				stopEvent := types.MessageEvent{
+					Type:  "content_block_stop",
+					Index: &idx,
+				}
+				if err := writeSSEEvent(w, stopEvent); err != nil {
+					return ErrClientDisconnected
+				}
+			}
+			// Clear so EOF cleanup won't emit duplicate stops
+			for oi := range startedToolCalls {
+				delete(startedToolCalls, oi)
 			}
 		}
 
@@ -460,18 +503,29 @@ func (h *StreamHandler) processSSELine(
 			}
 		}
 
-		// Close any open tool_use blocks. We track started tool calls by their
-		// OpenAI index; close each one, then delete it (no -1 sentinel needed).
-		for oi, blockIdx := range startedToolCalls {
-			idx := blockIdx
-			stopEvent := types.MessageEvent{
-				Type:  "content_block_stop",
-				Index: &idx,
+		// Close any open tool_use blocks in ascending index order.
+		if len(startedToolCalls) > 0 {
+			type toolBlockEntry struct {
+				oi       int
+				blockIdx int
 			}
-			if err := writeSSEEvent(w, stopEvent); err != nil {
-				return ErrClientDisconnected
+			entries := make([]toolBlockEntry, 0, len(startedToolCalls))
+			for oi, blockIdx := range startedToolCalls {
+				entries = append(entries, toolBlockEntry{oi, blockIdx})
 			}
-			delete(startedToolCalls, oi)
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].blockIdx < entries[j].blockIdx
+			})
+			for _, e := range entries {
+				idx := e.blockIdx
+				stopEvent := types.MessageEvent{
+					Type:  "content_block_stop",
+					Index: &idx,
+				}
+				if err := writeSSEEvent(w, stopEvent); err != nil {
+					return ErrClientDisconnected
+				}
+			}
 		}
 		*toolUseCount = 0
 

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -526,6 +526,10 @@ func (h *StreamHandler) processSSELine(
 					return ErrClientDisconnected
 				}
 			}
+			// Clear so EOF cleanup won't emit duplicate stops
+			for oi := range startedToolCalls {
+				delete(startedToolCalls, oi)
+			}
 		}
 		*toolUseCount = 0
 

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -480,6 +480,53 @@ func TestProxyStream_ReasoningBeforeContentFastPathRegression(t *testing.T) {
 	}
 }
 
+// TestProxyStream_ToolCallFinishReasonWithUsage verifies that when finish_reason
+// arrives (fast path) followed by a usage-only chunk, tool blocks are closed
+// exactly once — no duplicate content_block_stop from EOF cleanup.
+func TestProxyStream_ToolCallFinishReasonWithUsage(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_a","type":"function","function":{"name":"fn_a","arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"id":"toolu_b","type":"function","function":{"name":"fn_b","arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"x\":1}"}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"y\":2}"}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_use"}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyStream(w, body, "kimi-k2.6", ctx); err != nil {
+		t.Fatalf("ProxyStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// Count content_block_stop events — should be exactly 2 (one per tool)
+	var stopCount int
+	for _, ev := range events {
+		if ev.Type == "content_block_stop" {
+			stopCount++
+		}
+	}
+	if stopCount != 2 {
+		t.Fatalf("expected 2 content_block_stop events, got %d: %+v", stopCount, events)
+	}
+
+	// Verify usage is present
+	var hasUsage bool
+	for _, ev := range events {
+		if ev.Usage != nil {
+			hasUsage = true
+		}
+	}
+	if !hasUsage {
+		t.Error("expected usage in stream, found none")
+	}
+}
+
 // TestProxyStream_SingleToolCall verifies a single tool call streamed
 // incrementally produces exactly one content_block_start, argument deltas,
 // and a content_block_stop.

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -480,6 +480,219 @@ func TestProxyStream_ReasoningBeforeContentFastPathRegression(t *testing.T) {
 	}
 }
 
+// TestProxyStream_SingleToolCall verifies a single tool call streamed
+// incrementally produces exactly one content_block_start, argument deltas,
+// and a content_block_stop.
+func TestProxyStream_SingleToolCall(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_abc","type":"function","function":{"name":"get_weather","arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"loc"}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ation\":\"NYC\"}"}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_use"}]}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyStream(w, body, "kimi-k2.6", ctx); err != nil {
+		t.Fatalf("ProxyStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// Expected: message_start, tool_start(idx=1), 2x input_json_delta (3rd arg arrives
+	// with finish_reason in same chunk, fast path returns before processing delta),
+	// tool_stop(idx=1), message_delta, message_stop = 7
+	if len(events) != 7 {
+		t.Fatalf("expected 7 events, got %d: %+v", len(events), events)
+	}
+
+	// Verify tool_use block start
+	if events[1].Type != "content_block_start" {
+		t.Errorf("event[1].Type = %q, want content_block_start", events[1].Type)
+	}
+	if events[1].ContentBlock == nil || events[1].ContentBlock.Type != "tool_use" {
+		t.Errorf("event[1].ContentBlock = %+v, want tool_use", events[1].ContentBlock)
+	}
+	if events[1].ContentBlock.ID != "toolu_abc" {
+		t.Errorf("event[1].ContentBlock.ID = %q, want toolu_abc", events[1].ContentBlock.ID)
+	}
+	if events[1].ContentBlock.Name != "get_weather" {
+		t.Errorf("event[1].ContentBlock.Name = %q, want get_weather", events[1].ContentBlock.Name)
+	}
+
+	// Verify argument deltas
+	if events[2].Delta == nil || events[2].Delta.Type != "input_json_delta" {
+		t.Errorf("event[2] = %+v, want input_json_delta", events[2])
+	}
+	if events[2].Delta.PartialJSON != `{"loc` {
+		t.Errorf("event[2].Delta.PartialJSON = %q, want %q", events[2].Delta.PartialJSON, `{"loc`)
+	}
+	if events[3].Delta == nil || events[3].Delta.Type != "input_json_delta" {
+		t.Errorf("event[3] = %+v, want input_json_delta", events[3])
+	}
+
+	// Verify tool block stop
+	if events[4].Type != "content_block_stop" {
+		t.Errorf("event[4].Type = %q, want content_block_stop", events[4].Type)
+	}
+
+	// Verify stop reason
+	if events[5].Type != "message_delta" {
+		t.Errorf("event[5].Type = %q, want message_delta", events[5].Type)
+	}
+	if events[5].Delta == nil || events[5].Delta.StopReason != "end_turn" {
+		t.Errorf("event[5].Delta.StopReason = %q, want end_turn", events[5].Delta.StopReason)
+	}
+	if events[6].Type != "message_stop" {
+		t.Errorf("event[6].Type = %q, want message_stop", events[6].Type)
+	}
+}
+
+// TestProxyStream_MultipleParallelToolCalls verifies that two concurrent tool
+// calls produce two content_block_start events, each with their own argument
+// deltas, and that content_block_stop events are emitted in ascending index
+// order (not random map iteration order).
+func TestProxyStream_MultipleParallelToolCalls(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	// Two tool calls: index 0 and index 1, interleaved as OpenAI sends them
+	body := sseLines(
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_1","type":"function","function":{"name":"search","arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"id":"toolu_2","type":"function","function":{"name":"lookup","arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q"}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"id"}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uery\":\"go\"}"}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"\":\"42\"}"}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_use"}]}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyStream(w, body, "kimi-k2.6", ctx); err != nil {
+		t.Fatalf("ProxyStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// Count content_block_start events (should be exactly 2)
+	var startEvents []types.MessageEvent
+	for _, ev := range events {
+		if ev.Type == "content_block_start" {
+			startEvents = append(startEvents, ev)
+		}
+	}
+	if len(startEvents) != 2 {
+		t.Fatalf("expected 2 content_block_start events, got %d", len(startEvents))
+	}
+
+	// Both should be tool_use blocks
+	for i, se := range startEvents {
+		if se.ContentBlock == nil || se.ContentBlock.Type != "tool_use" {
+			t.Errorf("start event[%d].ContentBlock = %+v, want tool_use", i, se.ContentBlock)
+		}
+	}
+	if startEvents[0].ContentBlock.Name != "search" {
+		t.Errorf("first tool name = %q, want search", startEvents[0].ContentBlock.Name)
+	}
+	if startEvents[1].ContentBlock.Name != "lookup" {
+		t.Errorf("second tool name = %q, want lookup", startEvents[1].ContentBlock.Name)
+	}
+
+	// Count content_block_stop events (should be exactly 2)
+	var stopIndices []int
+	for _, ev := range events {
+		if ev.Type == "content_block_stop" && ev.Index != nil {
+			stopIndices = append(stopIndices, *ev.Index)
+		}
+	}
+	if len(stopIndices) != 2 {
+		t.Fatalf("expected 2 content_block_stop events, got %d", len(stopIndices))
+	}
+	// Verify ascending order
+	if stopIndices[0] >= stopIndices[1] {
+		t.Errorf("stop indices not ascending: %v", stopIndices)
+	}
+}
+
+// TestProxyStream_ToolCallGhostChunk verifies that a ghost chunk (tool call
+// index with empty name) is ignored and does not produce a content_block_start.
+func TestProxyStream_ToolCallGhostChunk(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_a","type":"function","function":{"name":"real_func","arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"x\":1}"}}]}}]}`,
+		// Ghost chunk: index 0 recycled but no name
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_use"}]}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyStream(w, body, "kimi-k2.6", ctx); err != nil {
+		t.Fatalf("ProxyStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// Should have exactly 1 content_block_start for the real tool call
+	var startEvents []types.MessageEvent
+	for _, ev := range events {
+		if ev.Type == "content_block_start" {
+			startEvents = append(startEvents, ev)
+		}
+	}
+	if len(startEvents) != 1 {
+		t.Fatalf("expected 1 content_block_start, got %d: %+v", len(startEvents), startEvents)
+	}
+}
+
+// TestProxyStream_MixedTextAndToolCall verifies a response that starts with
+// text content and then transitions to a tool call.
+func TestProxyStream_MixedTextAndToolCall(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"choices":[{"delta":{"content":"Let me check that for you."}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_x","type":"function","function":{"name":"get_data","arguments":""}}]}}]}`,
+		`{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"id\":1}"}}]}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"tool_use"}]}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyStream(w, body, "kimi-k2.6", ctx); err != nil {
+		t.Fatalf("ProxyStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// Verify text block at index 0
+	if events[1].Type != "content_block_start" || events[1].ContentBlock == nil || events[1].ContentBlock.Type != "text" {
+		t.Errorf("event[1] = %+v, want content_block_start(text)", events[1])
+	}
+	if *events[1].Index != 0 {
+		t.Errorf("text start index = %d, want 0", *events[1].Index)
+	}
+
+	// Verify tool_use block at index 1
+	if events[3].Type != "content_block_start" || events[3].ContentBlock == nil || events[3].ContentBlock.Type != "tool_use" {
+		t.Errorf("event[3] = %+v, want content_block_start(tool_use)", events[3])
+	}
+	if *events[3].Index != 1 {
+		t.Errorf("tool start index = %d, want 1", *events[3].Index)
+	}
+	if events[3].ContentBlock.Name != "get_data" {
+		t.Errorf("tool name = %q, want get_data", events[3].ContentBlock.Name)
+	}
+}
+
 // helpers
 
 func mustJSON(t *testing.T, v any) string {

--- a/pkg/types/anthropic.go
+++ b/pkg/types/anthropic.go
@@ -108,7 +108,7 @@ func (m *Message) ContentBlocks() []ContentBlock {
 //   - "image": Source is populated
 type ContentBlock struct {
 	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
+	Text      string          `json:"text"`
 	ID        string          `json:"id,omitempty"`          // For tool_use (the tool call ID)
 	ToolUseID string          `json:"tool_use_id,omitempty"` // For tool_result (references the tool_use ID)
 	Name      string          `json:"name,omitempty"`
@@ -116,7 +116,7 @@ type ContentBlock struct {
 	Output    json.RawMessage `json:"output,omitempty"`    // Deprecated: use Content
 	Content   json.RawMessage `json:"content,omitempty"`   // For tool_result inner content
 	IsError   *bool           `json:"is_error,omitempty"`  // For tool_result
-	Thinking  string          `json:"thinking,omitempty"`  // For thinking blocks
+	Thinking  string          `json:"thinking"`  // For thinking blocks
 	Signature string          `json:"signature,omitempty"` // For thinking blocks
 	Source    *ImageSource    `json:"source,omitempty"`    // For image blocks
 }

--- a/pkg/types/anthropic.go
+++ b/pkg/types/anthropic.go
@@ -116,7 +116,7 @@ type ContentBlock struct {
 	Output    json.RawMessage `json:"output,omitempty"`    // Deprecated: use Content
 	Content   json.RawMessage `json:"content,omitempty"`   // For tool_result inner content
 	IsError   *bool           `json:"is_error,omitempty"`  // For tool_result
-	Thinking  string          `json:"thinking"`  // For thinking blocks
+	Thinking  string          `json:"thinking"`            // For thinking blocks
 	Signature string          `json:"signature,omitempty"` // For thinking blocks
 	Source    *ImageSource    `json:"source,omitempty"`    // For image blocks
 }

--- a/pkg/types/openai.go
+++ b/pkg/types/openai.go
@@ -39,7 +39,10 @@ type ChatMessage struct {
 }
 
 // ToolCall represents a function call made by the model.
+// Index is only present in streaming deltas — it identifies which tool call
+// position this delta belongs to within the tool_calls array.
 type ToolCall struct {
+	Index    int          `json:"index,omitempty"`
 	ID       string       `json:"id"`
 	Type     string       `json:"type"`
 	Function FunctionCall `json:"function"`


### PR DESCRIPTION
## Summary
Fixes #17 — the `API Error: undefined is not an object (evaluating 'H.startsWith')` when Claude Code uses tools through the proxy, plus fixes `superfluous response.WriteHeader call` warnings.

Two root causes identified and fixed:

## Cause 1: ContentBlock omitempty breaks SSE protocol

`pkg/types/anthropic.go` — `ContentBlock.Text` and `ContentBlock.Thinking` had `json:"...,omitempty"` tags. When these fields were empty strings in `content_block_start` SSE events, Go's JSON marshaler omitted them. The resulting JSON became:
```json
{"type":"content_block_start","index":0,"content_block":{"type":"text"}}
```
instead of the protocol-required:
```json
{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
```

The Claude Code JavaScript client accesses `content_block.text.startsWith(...)`, which throws `undefined is not an object (evaluating 'H.startsWith')` when the field is missing.

**Fix:** Removed `omitempty` from `Text` and `Thinking` fields — these are required by the Anthropic SSE protocol.

This bug was pre-existing (verified across commits 48f810d → d7c4453 → 99dc23a), not introduced by the tool call dedup fix.

## Cause 2: Heartbeat goroutine bypasses responseWriter

`internal/handlers/messages.go` — the SSE keepalive goroutine used the unwrapped `w` (http.ResponseWriter) for `fmt.Fprintf`, triggering implicit `WriteHeader(200)` calls after headers were already sent by the wrapped `rw` (responseWriter). This produced `superfluous response.WriteHeader call` warnings from Go's net/http.

**Fix:** Changed heartbeat `fmt.Fprintf(w, ...)` → `fmt.Fprintf(rw, ...)` to route through the responseWriter wrapper's duplicate-WriteHeader guard.

## Changes

### 1. `pkg/types/anthropic.go`
- Removed `omitempty` from `ContentBlock.Text` (`json:"text"`)
- Removed `omitempty` from `ContentBlock.Thinking` (`json:"thinking"`)

### 2. `internal/handlers/messages.go`
- Heartbeat goroutine: `fmt.Fprintf(w, ...)` → `fmt.Fprintf(rw, ...)` to prevent duplicate WriteHeader warnings

### 3. `pkg/types/openai.go`
- Added `Index int json:"index,omitempty"` to `ToolCall` — captures the OpenAI streaming tool call position, needed to distinguish new tool calls from argument continuations

### 4. `internal/transformer/stream.go`
- Added `startedToolCalls map[int]int` to track which OpenAI tool call indices already have a `content_block_start` sent
- Only create `content_block_start` when seeing a new `tc.Index`; subsequent chunks for the same index send only `content_block_delta`
- Fixed finish_reason tool block closing: replaced off-by-one index math with map-based iteration
- Added ghost chunk guard and EOF cleanup for unclosed tool blocks

## Testing

```bash
go test ./... -v -race   # all pass
```

### Verified working end-to-end:
```
❯ Write(fix_verify.py)        ✓ created
❯ Bash(sleep 5)               ✓ waited
❯ Read fix_verify.py          ✓ read back
❯ Update(fix_verify.py)       ✓ appended comment
```
Sequential tool calls (write → sleep → read → edit) complete without H.startsWith errors. No superfluous WriteHeader warnings in server logs.