### PR TITLE
feat(config): add hot reload support for configuration file

### DIFF
--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -115,11 +116,24 @@ func serveCmd() *cobra.Command {
 			}
 			defer func() { _ = os.Remove(pidPath) }()
 
+			// Create atomic config for hot reload support.
+			atomicCfg := config.NewAtomicConfig(cfg, config.ResolveConfigPath())
+
+			// Re-apply CLI port override on every reload so it persists.
+			if port != 0 {
+				atomicCfg.OnReload(func(newCfg *config.Config) {
+					newCfg.Port = port
+				})
+			}
+
 			// Create and start server.
-			srv, err := server.NewServer(cfg)
+			srv, err := server.NewServer(atomicCfg)
 			if err != nil {
 				return fmt.Errorf("failed to create server: %w", err)
 			}
+
+			// Start config watcher for hot reload.
+			go config.WatchConfig(context.Background(), atomicCfg)
 
 			fmt.Printf("Starting %s v%s\n", appName, version)
 			fmt.Printf("Listening on %s:%d\n", cfg.Host, cfg.Port)

--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -133,7 +134,11 @@ func serveCmd() *cobra.Command {
 			}
 
 			// Start config watcher for hot reload.
-			go config.WatchConfig(context.Background(), atomicCfg)
+			go func() {
+				if err := config.WatchConfig(context.Background(), atomicCfg); err != nil {
+					slog.Error("config watcher failed", "error", err)
+				}
+			}()
 
 			fmt.Printf("Starting %s v%s\n", appName, version)
 			fmt.Printf("Listening on %s:%d\n", cfg.Host, cfg.Port)

--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -134,8 +134,10 @@ func serveCmd() *cobra.Command {
 			}
 
 			// Start config watcher for hot reload.
+			watchCtx, watchCancel := context.WithCancel(context.Background())
+			defer watchCancel()
 			go func() {
-				if err := config.WatchConfig(context.Background(), atomicCfg); err != nil {
+				if err := config.WatchConfig(watchCtx, atomicCfg); err != nil && err != context.Canceled {
 					slog.Error("config watcher failed", "error", err)
 				}
 			}()

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module oc-go-cc
 go 1.25.0
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/spf13/cobra v1.8.1
 )
 
 require (
 	github.com/dlclark/regexp2 v1.10.0 // indirect
-	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -18,6 +20,8 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -16,20 +16,14 @@ import (
 
 // OpenCodeClient handles communication with OpenCode Go API.
 type OpenCodeClient struct {
-	openAIConfig    EndpointConfig
-	anthropicConfig EndpointConfig
-	httpClient      *http.Client
-}
-
-// EndpointConfig holds configuration for a specific API endpoint.
-type EndpointConfig struct {
-	BaseURL string
-	APIKey  string
+	atomic     *config.AtomicConfig
+	httpClient *http.Client
 }
 
 // NewOpenCodeClient creates a new OpenCode Go client.
-func NewOpenCodeClient(cfg config.OpenCodeGoConfig, apiKey string) *OpenCodeClient {
-	timeout := time.Duration(cfg.TimeoutMs) * time.Millisecond
+func NewOpenCodeClient(atomic *config.AtomicConfig) *OpenCodeClient {
+	cfg := atomic.Get()
+	timeout := time.Duration(cfg.OpenCodeGo.TimeoutMs) * time.Millisecond
 	if timeout == 0 {
 		timeout = 5 * time.Minute
 	}
@@ -44,14 +38,7 @@ func NewOpenCodeClient(cfg config.OpenCodeGoConfig, apiKey string) *OpenCodeClie
 	}
 
 	return &OpenCodeClient{
-		openAIConfig: EndpointConfig{
-			BaseURL: cfg.BaseURL,
-			APIKey:  apiKey,
-		},
-		anthropicConfig: EndpointConfig{
-			BaseURL: cfg.AnthropicBaseURL,
-			APIKey:  apiKey,
-		},
+		atomic: atomic,
 		httpClient: &http.Client{
 			Timeout:   timeout,
 			Transport: transport,
@@ -70,11 +57,24 @@ func IsAnthropicModel(modelID string) bool {
 }
 
 // getEndpoint returns the appropriate endpoint config for a model.
-func (c *OpenCodeClient) getEndpoint(modelID string) EndpointConfig {
+func (c *OpenCodeClient) getEndpoint(modelID string) endpointConfig {
+	cfg := c.atomic.Get()
 	if IsAnthropicModel(modelID) {
-		return c.anthropicConfig
+		return endpointConfig{
+			BaseURL: cfg.OpenCodeGo.AnthropicBaseURL,
+			APIKey:  cfg.APIKey,
+		}
 	}
-	return c.openAIConfig
+	return endpointConfig{
+		BaseURL: cfg.OpenCodeGo.BaseURL,
+		APIKey:  cfg.APIKey,
+	}
+}
+
+// endpointConfig holds configuration for a specific API endpoint.
+type endpointConfig struct {
+	BaseURL string
+	APIKey  string
 }
 
 // ChatCompletion sends a chat completion request to the OpenCode Go API.
@@ -175,18 +175,20 @@ func (c *OpenCodeClient) SendAnthropicRequest(
 	body []byte,
 	stream bool,
 ) (*http.Response, error) {
-	endpoint := c.anthropicConfig
+	cfg := c.atomic.Get()
+	baseURL := cfg.OpenCodeGo.AnthropicBaseURL
+	apiKey := cfg.APIKey
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.BaseURL, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	// Set headers
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 	// Incase OpenCode Go expects x-api-key instead
-	httpReq.Header.Set("x-api-key", endpoint.APIKey)
+	httpReq.Header.Set("x-api-key", apiKey)
 
 	// Add streaming header if requested
 	if stream {

--- a/internal/config/atomic.go
+++ b/internal/config/atomic.go
@@ -52,14 +52,13 @@ func (a *AtomicConfig) Reload() error {
 		}
 	}
 
-	a.ptr.Store(cfg)
-
 	// Copy callbacks to avoid holding lock during invocation
 	a.mu.Lock()
 	callbacks := make([]func(*Config), len(a.onReload))
 	copy(callbacks, a.onReload)
 	a.mu.Unlock()
 
+	// Invoke callbacks BEFORE swapping — they may mutate cfg (e.g., port override).
 	for _, fn := range callbacks {
 		func() {
 			defer func() {
@@ -70,6 +69,9 @@ func (a *AtomicConfig) Reload() error {
 			fn(cfg)
 		}()
 	}
+
+	// Now cfg is fully prepared — safe for concurrent readers.
+	a.ptr.Store(cfg)
 
 	return nil
 }

--- a/internal/config/atomic.go
+++ b/internal/config/atomic.go
@@ -38,9 +38,7 @@ func (a *AtomicConfig) Reload() error {
 		return err
 	}
 
-	a.ptr.Store(cfg)
-
-	// Warn about changes that require a server restart
+	// Warn about changes that require a server restart before swapping.
 	if old != nil {
 		if old.Host != cfg.Host || old.Port != cfg.Port {
 			slog.Warn("host/port changed but requires server restart to take effect",
@@ -53,6 +51,8 @@ func (a *AtomicConfig) Reload() error {
 				"new_timeout", cfg.OpenCodeGo.TimeoutMs)
 		}
 	}
+
+	a.ptr.Store(cfg)
 
 	// Copy callbacks to avoid holding lock during invocation
 	a.mu.Lock()

--- a/internal/config/atomic.go
+++ b/internal/config/atomic.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+)
+
+// AtomicConfig provides thread-safe access to the configuration with support
+// for hot reloading. It uses atomic.Pointer for lock-free reads.
+type AtomicConfig struct {
+	ptr      atomic.Pointer[Config]
+	path     string
+	mu       sync.Mutex
+	onReload []func(*Config)
+}
+
+// NewAtomicConfig creates a new AtomicConfig with the given initial config and file path.
+func NewAtomicConfig(cfg *Config, path string) *AtomicConfig {
+	a := &AtomicConfig{path: path}
+	a.ptr.Store(cfg)
+	return a
+}
+
+// Get returns the current configuration pointer. This is safe for concurrent use.
+// Callers must not modify the returned Config.
+func (a *AtomicConfig) Get() *Config {
+	return a.ptr.Load()
+}
+
+// Reload reloads the configuration from disk and atomically swaps it in.
+// If the reload fails, the old configuration is preserved and an error is returned.
+// On successful reload, all registered callbacks are invoked.
+func (a *AtomicConfig) Reload() error {
+	old := a.Get()
+	cfg, err := LoadFromPath(a.path)
+	if err != nil {
+		return err
+	}
+
+	a.ptr.Store(cfg)
+
+	// Warn about changes that require a server restart
+	if old != nil {
+		if old.Host != cfg.Host || old.Port != cfg.Port {
+			slog.Warn("host/port changed but requires server restart to take effect",
+				"old_host", old.Host, "new_host", cfg.Host,
+				"old_port", old.Port, "new_port", cfg.Port)
+		}
+		if old.OpenCodeGo.TimeoutMs != cfg.OpenCodeGo.TimeoutMs {
+			slog.Warn("timeout_ms changed but requires server restart to take effect",
+				"old_timeout", old.OpenCodeGo.TimeoutMs,
+				"new_timeout", cfg.OpenCodeGo.TimeoutMs)
+		}
+	}
+
+	// Copy callbacks to avoid holding lock during invocation
+	a.mu.Lock()
+	callbacks := make([]func(*Config), len(a.onReload))
+	copy(callbacks, a.onReload)
+	a.mu.Unlock()
+
+	for _, fn := range callbacks {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("config reload callback panicked", "panic", r)
+				}
+			}()
+			fn(cfg)
+		}()
+	}
+
+	return nil
+}
+
+// OnReload registers a callback that will be invoked after each successful reload.
+func (a *AtomicConfig) OnReload(fn func(*Config)) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.onReload = append(a.onReload, fn)
+}
+
+// Path returns the config file path being watched.
+func (a *AtomicConfig) Path() string {
+	return a.path
+}

--- a/internal/config/atomic_test.go
+++ b/internal/config/atomic_test.go
@@ -1,0 +1,177 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAtomicConfig_Get(t *testing.T) {
+	cfg := &Config{APIKey: "test-key"}
+	atomic := NewAtomicConfig(cfg, "/tmp/config.json")
+
+	got := atomic.Get()
+	if got.APIKey != "test-key" {
+		t.Errorf("Get().APIKey = %q, want %q", got.APIKey, "test-key")
+	}
+}
+
+func TestAtomicConfig_Reload(t *testing.T) {
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	initialJSON := `{"api_key": "initial-key"}`
+	if err := os.WriteFile(path, []byte(initialJSON), 0644); err != nil {
+		t.Fatalf("failed to write initial config: %v", err)
+	}
+
+	cfg, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath failed: %v", err)
+	}
+
+	atomic := NewAtomicConfig(cfg, path)
+	if atomic.Get().APIKey != "initial-key" {
+		t.Fatalf("initial APIKey mismatch: got %q", atomic.Get().APIKey)
+	}
+
+	// Update file on disk
+	updatedJSON := `{"api_key": "updated-key"}`
+	if err := os.WriteFile(path, []byte(updatedJSON), 0644); err != nil {
+		t.Fatalf("failed to write updated config: %v", err)
+	}
+
+	if err := atomic.Reload(); err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+
+	if atomic.Get().APIKey != "updated-key" {
+		t.Errorf("after Reload, APIKey = %q, want %q", atomic.Get().APIKey, "updated-key")
+	}
+}
+
+func TestAtomicConfig_Reload_PreservesOldOnError(t *testing.T) {
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	initialJSON := `{"api_key": "initial-key"}`
+	if err := os.WriteFile(path, []byte(initialJSON), 0644); err != nil {
+		t.Fatalf("failed to write initial config: %v", err)
+	}
+
+	cfg, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath failed: %v", err)
+	}
+
+	atomic := NewAtomicConfig(cfg, path)
+
+	// Write invalid JSON
+	if err := os.WriteFile(path, []byte("not-json"), 0644); err != nil {
+		t.Fatalf("failed to write invalid config: %v", err)
+	}
+
+	if err := atomic.Reload(); err == nil {
+		t.Fatal("Reload() expected error for invalid JSON, got nil")
+	}
+
+	// Old config should be preserved
+	if atomic.Get().APIKey != "initial-key" {
+		t.Errorf("after failed Reload, APIKey = %q, want %q", atomic.Get().APIKey, "initial-key")
+	}
+}
+
+func TestAtomicConfig_OnReload(t *testing.T) {
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	initialJSON := `{"api_key": "initial-key"}`
+	if err := os.WriteFile(path, []byte(initialJSON), 0644); err != nil {
+		t.Fatalf("failed to write initial config: %v", err)
+	}
+
+	cfg, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath failed: %v", err)
+	}
+
+	atomic := NewAtomicConfig(cfg, path)
+
+	callbackCalled := make(chan *Config, 1)
+	atomic.OnReload(func(newCfg *Config) {
+		callbackCalled <- newCfg
+	})
+
+	updatedJSON := `{"api_key": "updated-key"}`
+	if err := os.WriteFile(path, []byte(updatedJSON), 0644); err != nil {
+		t.Fatalf("failed to write updated config: %v", err)
+	}
+
+	if err := atomic.Reload(); err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+
+	select {
+	case newCfg := <-callbackCalled:
+		if newCfg.APIKey != "updated-key" {
+			t.Errorf("callback received APIKey = %q, want %q", newCfg.APIKey, "updated-key")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnReload callback was not invoked within timeout")
+	}
+}
+
+func TestAtomicConfig_OnReload_MultipleCallbacks(t *testing.T) {
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	initialJSON := `{"api_key": "initial-key"}`
+	if err := os.WriteFile(path, []byte(initialJSON), 0644); err != nil {
+		t.Fatalf("failed to write initial config: %v", err)
+	}
+
+	cfg, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath failed: %v", err)
+	}
+
+	atomic := NewAtomicConfig(cfg, path)
+
+	var callCount int
+	atomic.OnReload(func(_ *Config) {
+		callCount++
+	})
+	atomic.OnReload(func(_ *Config) {
+		callCount++
+	})
+
+	updatedJSON := `{"api_key": "updated-key"}`
+	if err := os.WriteFile(path, []byte(updatedJSON), 0644); err != nil {
+		t.Fatalf("failed to write updated config: %v", err)
+	}
+
+	if err := atomic.Reload(); err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("callback call count = %d, want 2", callCount)
+	}
+}

--- a/internal/config/atomic_test.go
+++ b/internal/config/atomic_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -174,4 +175,59 @@ func TestAtomicConfig_OnReload_MultipleCallbacks(t *testing.T) {
 	if callCount != 2 {
 		t.Errorf("callback call count = %d, want 2", callCount)
 	}
+}
+
+func TestAtomicConfig_ConcurrentGetAndReload(t *testing.T) {
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	initialJSON := `{"api_key": "initial-key"}`
+	if err := os.WriteFile(path, []byte(initialJSON), 0644); err != nil {
+		t.Fatalf("failed to write initial config: %v", err)
+	}
+
+	cfg, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath failed: %v", err)
+	}
+
+	at := NewAtomicConfig(cfg, path)
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// Spawn readers.
+	for range 10 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = at.Get()
+				}
+			}
+		})
+	}
+
+	// Writer: reload repeatedly.
+	wg.Go(func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = at.Reload()
+			}
+		}
+	})
+
+	// Let it race for a bit.
+	time.Sleep(500 * time.Millisecond)
+	close(done)
+	wg.Wait()
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -28,11 +28,14 @@ var envVarPattern = regexp.MustCompile(`\$\{([A-Za-z0-9_]+)\}`)
 //  1. OC_GO_CC_CONFIG env var (explicit override)
 //  2. ~/.config/oc-go-cc/config.json (default)
 func Load() (*Config, error) {
-	configPath := resolveConfigPath()
+	return LoadFromPath(ResolveConfigPath())
+}
 
-	cfg, err := loadJSON(configPath)
+// LoadFromPath reads configuration from the given JSON file path.
+func LoadFromPath(path string) (*Config, error) {
+	cfg, err := loadJSON(path)
 	if err != nil {
-		return nil, fmt.Errorf("loading config from %s: %w", configPath, err)
+		return nil, fmt.Errorf("loading config from %s: %w", path, err)
 	}
 
 	applyEnvOverrides(cfg)
@@ -45,8 +48,8 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
-// resolveConfigPath determines which config file to load.
-func resolveConfigPath() string {
+// ResolveConfigPath determines which config file to load.
+func ResolveConfigPath() string {
 	if path := os.Getenv("OC_GO_CC_CONFIG"); path != "" {
 		return path
 	}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// WatchConfig monitors the config file for changes and reloads it automatically.
+// It watches the directory containing the config file (not the file itself) to
+// handle editors that save by renaming/creating a new file. It also listens for
+// SIGHUP to allow manual reload triggers on Unix systems.
+func WatchConfig(ctx context.Context, atomic *AtomicConfig) error {
+	path := atomic.Path()
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(absPath)
+	filename := filepath.Base(absPath)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(dir); err != nil {
+		return err
+	}
+
+	slog.Info("config watcher started", "path", absPath)
+
+	// SIGHUP handler for manual reload triggers
+	sighup := make(chan os.Signal, 1)
+	signal.Notify(sighup, syscall.SIGHUP)
+	defer signal.Stop(sighup)
+
+	var debounceTimer *time.Timer
+	defer func() {
+		if debounceTimer != nil {
+			debounceTimer.Stop()
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			// Only care about events for our specific config file
+			if filepath.Base(event.Name) != filename {
+				continue
+			}
+			// Filter for relevant event types
+			if !event.Has(fsnotify.Write) && !event.Has(fsnotify.Create) && !event.Has(fsnotify.Rename) {
+				continue
+			}
+
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(500*time.Millisecond, func() {
+				slog.Info("config file changed, reloading", "path", absPath)
+				if err := atomic.Reload(); err != nil {
+					slog.Error("config reload failed", "error", err)
+				} else {
+					slog.Info("config reloaded successfully")
+				}
+			})
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			slog.Error("config watcher error", "error", err)
+
+		case <-sighup:
+			slog.Info("received SIGHUP, reloading config")
+			if err := atomic.Reload(); err != nil {
+				slog.Error("config reload failed", "error", err)
+			} else {
+				slog.Info("config reloaded successfully")
+			}
+		}
+	}
+}

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -29,7 +29,9 @@ func WatchConfig(ctx context.Context, atomic *AtomicConfig) error {
 	if err != nil {
 		return err
 	}
-	defer watcher.Close()
+	defer func() {
+		_ = watcher.Close()
+	}()
 
 	if err := watcher.Add(dir); err != nil {
 		return err

--- a/internal/config/watcher.go
+++ b/internal/config/watcher.go
@@ -20,6 +20,7 @@ func WatchConfig(ctx context.Context, atomic *AtomicConfig) error {
 	path := atomic.Path()
 	absPath, err := filepath.Abs(path)
 	if err != nil {
+		slog.Error("failed to get absolute path", "error", err)
 		return err
 	}
 	dir := filepath.Dir(absPath)
@@ -27,6 +28,7 @@ func WatchConfig(ctx context.Context, atomic *AtomicConfig) error {
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
+		slog.Error("failed to create watcher", "error", err)
 		return err
 	}
 	defer func() {

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -22,14 +22,20 @@ func TestWatchConfig_DetectsFileChange(t *testing.T) {
 		t.Fatalf("LoadFromPath failed: %v", err)
 	}
 
-	atomic := NewAtomicConfig(cfg, path)
+	at := NewAtomicConfig(cfg, path)
+
+	// Watch for reload via callback instead of polling.
+	reloaded := make(chan struct{}, 1)
+	at.OnReload(func(_ *Config) {
+		select {
+		case reloaded <- struct{}{}:
+		default:
+		}
+	})
 
 	// Start watcher in background
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	go func() {
-		if err := WatchConfig(ctx, atomic); err != nil && err != context.Canceled {
+		if err := WatchConfig(t.Context(), at); err != nil && err != context.Canceled {
 			t.Logf("WatchConfig returned: %v", err)
 		}
 	}()
@@ -43,14 +49,13 @@ func TestWatchConfig_DetectsFileChange(t *testing.T) {
 		t.Fatalf("failed to write updated config: %v", err)
 	}
 
-	// Wait for reload with timeout
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if atomic.Get().APIKey == "watcher-updated" {
-			return // success
+	// Wait for reload notification with timeout
+	select {
+	case <-reloaded:
+		if at.Get().APIKey != "watcher-updated" {
+			t.Errorf("after reload, APIKey = %q, want %q", at.Get().APIKey, "watcher-updated")
 		}
-		time.Sleep(50 * time.Millisecond)
+	case <-time.After(5 * time.Second):
+		t.Fatal("config was not reloaded after file change")
 	}
-
-	t.Errorf("config was not reloaded after file change, got APIKey = %q", atomic.Get().APIKey)
 }

--- a/internal/config/watcher_test.go
+++ b/internal/config/watcher_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatchConfig_DetectsFileChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	initialJSON := `{"api_key": "watcher-test"}`
+	if err := os.WriteFile(path, []byte(initialJSON), 0644); err != nil {
+		t.Fatalf("failed to write initial config: %v", err)
+	}
+
+	cfg, err := LoadFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadFromPath failed: %v", err)
+	}
+
+	atomic := NewAtomicConfig(cfg, path)
+
+	// Start watcher in background
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := WatchConfig(ctx, atomic); err != nil && err != context.Canceled {
+			t.Logf("WatchConfig returned: %v", err)
+		}
+	}()
+
+	// Give watcher time to set up
+	time.Sleep(200 * time.Millisecond)
+
+	// Modify config file
+	updatedJSON := `{"api_key": "watcher-updated"}`
+	if err := os.WriteFile(path, []byte(updatedJSON), 0644); err != nil {
+		t.Fatalf("failed to write updated config: %v", err)
+	}
+
+	// Wait for reload with timeout
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.Get().APIKey == "watcher-updated" {
+			return // success
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Errorf("config was not reloaded after file change, got APIKey = %q", atomic.Get().APIKey)
+}

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -23,7 +23,7 @@ import (
 
 // MessagesHandler handles /v1/messages requests.
 type MessagesHandler struct {
-	config              *config.Config
+	atomic              *config.AtomicConfig
 	client              *client.OpenCodeClient
 	modelRouter         *router.ModelRouter
 	fallbackHandler     *router.FallbackHandler
@@ -67,7 +67,7 @@ func (w *responseWriter) Flush() {
 
 // NewMessagesHandler creates a new messages handler.
 func NewMessagesHandler(
-	cfg *config.Config,
+	atomic *config.AtomicConfig,
 	openCodeClient *client.OpenCodeClient,
 	modelRouter *router.ModelRouter,
 	fallbackHandler *router.FallbackHandler,
@@ -75,7 +75,7 @@ func NewMessagesHandler(
 	metrics *metrics.Metrics,
 ) *MessagesHandler {
 	return &MessagesHandler{
-		config:              cfg,
+		atomic:              atomic,
 		client:              openCodeClient,
 		modelRouter:         modelRouter,
 		fallbackHandler:     fallbackHandler,

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -23,7 +23,6 @@ import (
 
 // MessagesHandler handles /v1/messages requests.
 type MessagesHandler struct {
-	atomic              *config.AtomicConfig
 	client              *client.OpenCodeClient
 	modelRouter         *router.ModelRouter
 	fallbackHandler     *router.FallbackHandler
@@ -67,7 +66,6 @@ func (w *responseWriter) Flush() {
 
 // NewMessagesHandler creates a new messages handler.
 func NewMessagesHandler(
-	atomic *config.AtomicConfig,
 	openCodeClient *client.OpenCodeClient,
 	modelRouter *router.ModelRouter,
 	fallbackHandler *router.FallbackHandler,
@@ -75,7 +73,6 @@ func NewMessagesHandler(
 	metrics *metrics.Metrics,
 ) *MessagesHandler {
 	return &MessagesHandler{
-		atomic:              atomic,
 		client:              openCodeClient,
 		modelRouter:         modelRouter,
 		fallbackHandler:     fallbackHandler,

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -10,12 +10,12 @@ import (
 
 // ModelRouter handles model selection based on scenarios.
 type ModelRouter struct {
-	config *config.Config
+	atomic *config.AtomicConfig
 }
 
 // NewModelRouter creates a new model router.
-func NewModelRouter(cfg *config.Config) *ModelRouter {
-	return &ModelRouter{config: cfg}
+func NewModelRouter(atomic *config.AtomicConfig) *ModelRouter {
+	return &ModelRouter{atomic: atomic}
 }
 
 // RouteResult contains the selected model and fallback chain.
@@ -27,23 +27,24 @@ type RouteResult struct {
 
 // Route determines which model to use for a request.
 func (r *ModelRouter) Route(messages []MessageContent, tokenCount int) (RouteResult, error) {
-	result := DetectScenario(messages, tokenCount, r.config)
+	cfg := r.atomic.Get()
+	result := DetectScenario(messages, tokenCount, cfg)
 
 	// Get primary model for scenario
-	primary, ok := r.config.Models[string(result.Scenario)]
+	primary, ok := cfg.Models[string(result.Scenario)]
 	if !ok {
 		// Fall back to default if scenario model not configured
-		primary, ok = r.config.Models["default"]
+		primary, ok = cfg.Models["default"]
 		if !ok {
 			return RouteResult{}, fmt.Errorf("no default model configured")
 		}
 	}
 
 	// Get fallbacks for scenario
-	fallbacks := r.config.Fallbacks[string(result.Scenario)]
+	fallbacks := cfg.Fallbacks[string(result.Scenario)]
 	if len(fallbacks) == 0 {
 		// Fall back to default fallbacks
-		fallbacks = r.config.Fallbacks["default"]
+		fallbacks = cfg.Fallbacks["default"]
 	}
 
 	return RouteResult{
@@ -63,24 +64,25 @@ func (rr *RouteResult) GetModelChain() []config.ModelConfig {
 // RouteForStreaming determines which model to use for streaming requests.
 // Prioritizes fast TTFT (time-to-first-token) over capability.
 func (r *ModelRouter) RouteForStreaming(messages []MessageContent, tokenCount int) RouteResult {
-	result := RouteForStreaming(messages, tokenCount, r.config)
+	cfg := r.atomic.Get()
+	result := RouteForStreaming(messages, tokenCount, cfg)
 
 	// Get primary model for scenario
-	primary, ok := r.config.Models[string(result.Scenario)]
+	primary, ok := cfg.Models[string(result.Scenario)]
 	if !ok {
 		// Fall back to fast scenario if not configured
-		primary, ok = r.config.Models["fast"]
+		primary, ok = cfg.Models["fast"]
 		if !ok {
 			// Fall back to default
-			primary = r.config.Models["default"]
+			primary = cfg.Models["default"]
 		}
 	}
 
 	// Get fallbacks for scenario
-	fallbacks := r.config.Fallbacks[string(result.Scenario)]
+	fallbacks := cfg.Fallbacks[string(result.Scenario)]
 	if len(fallbacks) == 0 {
 		// Fall back to fast fallbacks
-		fallbacks = r.config.Fallbacks["fast"]
+		fallbacks = cfg.Fallbacks["fast"]
 	}
 
 	return RouteResult{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,15 +21,20 @@ import (
 
 // Server represents the proxy server.
 type Server struct {
-	config  *config.Config
+	atomic  *config.AtomicConfig
 	httpSrv *http.Server
 	logger  *slog.Logger
+	levelVar *slog.LevelVar
 }
 
 // NewServer creates a new proxy server.
-func NewServer(cfg *config.Config) (*Server, error) {
+func NewServer(atomic *config.AtomicConfig) (*Server, error) {
+	cfg := atomic.Get()
+	levelVar := new(slog.LevelVar)
+	levelVar.Set(parseLogLevel(cfg.Logging.Level))
+
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: parseLogLevel(cfg.Logging.Level),
+		Level: levelVar,
 	}))
 	slog.SetDefault(logger)
 
@@ -42,13 +47,13 @@ func NewServer(cfg *config.Config) (*Server, error) {
 	// Create metrics
 	metrics := metrics.New()
 
-	openCodeClient := client.NewOpenCodeClient(cfg.OpenCodeGo, cfg.APIKey)
-	modelRouter := router.NewModelRouter(cfg)
+	openCodeClient := client.NewOpenCodeClient(atomic)
+	modelRouter := router.NewModelRouter(atomic)
 	fallbackHandler := router.NewFallbackHandler(logger, 3, 30*time.Second)
 
 	// Create handlers.
 	messagesHandler := handlers.NewMessagesHandler(
-		cfg,
+		atomic,
 		openCodeClient,
 		modelRouter,
 		fallbackHandler,
@@ -75,19 +80,29 @@ func NewServer(cfg *config.Config) (*Server, error) {
 		IdleTimeout:  120 * time.Second,
 	}
 
-	return &Server{
-		config:  cfg,
-		httpSrv: httpSrv,
-		logger:  logger,
-	}, nil
+	srv := &Server{
+		atomic:   atomic,
+		httpSrv:  httpSrv,
+		logger:   logger,
+		levelVar: levelVar,
+	}
+
+	// Register callback to update log level on config reload
+	atomic.OnReload(func(newCfg *config.Config) {
+		levelVar.Set(parseLogLevel(newCfg.Logging.Level))
+		logger.Info("log level updated", "level", newCfg.Logging.Level)
+	})
+
+	return srv, nil
 }
 
 // Start starts the server with graceful shutdown.
 func (s *Server) Start() error {
+	cfg := s.atomic.Get()
 	s.logger.Info("starting oc-go-cc proxy",
-		"host", s.config.Host,
-		"port", s.config.Port,
-		"base_url", s.config.OpenCodeGo.BaseURL,
+		"host", cfg.Host,
+		"port", cfg.Port,
+		"base_url", cfg.OpenCodeGo.BaseURL,
 	)
 
 	// Graceful shutdown.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,7 +53,6 @@ func NewServer(atomic *config.AtomicConfig) (*Server, error) {
 
 	// Create handlers.
 	messagesHandler := handlers.NewMessagesHandler(
-		atomic,
 		openCodeClient,
 		modelRouter,
 		fallbackHandler,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,9 +21,9 @@ import (
 
 // Server represents the proxy server.
 type Server struct {
-	atomic  *config.AtomicConfig
-	httpSrv *http.Server
-	logger  *slog.Logger
+	atomic   *config.AtomicConfig
+	httpSrv  *http.Server
+	logger   *slog.Logger
 	levelVar *slog.LevelVar
 }
 


### PR DESCRIPTION
implement #21 

- Add fsnotify-based file watcher for automatic config reloading
- Introduce AtomicConfig with atomic.Pointer for lock-free reads
- Support SIGHUP as manual reload trigger (Unix)
- Dynamic log level updates via slog.LevelVar
- API key, base URLs, model routing, and fallbacks reload live
- Preserve --port CLI override across reloads
- Protect reload callbacks with recover() to prevent watcher crash
- Add comprehensive tests for atomic config and watcher