### PR TITLE
fix: skip reasoning_effort when DeepSeek thinking mode is disabled

### DIFF
--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -97,7 +97,7 @@ func (t *RequestTransformer) TransformRequest(
 		}
 		// DeepSeek returns 400 if reasoning_effort is sent alongside
 		// thinking: disabled — only set it when thinking is active.
-		if !(isThinkingDisabled(openaiReq.Thinking) && isDeepSeekModel(model.ModelID)) {
+		if !isThinkingDisabled(openaiReq.Thinking) || !isDeepSeekModel(model.ModelID) {
 			if model.ReasoningEffort != "" {
 				openaiReq.ReasoningEffort = &model.ReasoningEffort
 			} else {

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -19,6 +19,16 @@ func NewRequestTransformer() *RequestTransformer {
 	return &RequestTransformer{}
 }
 
+// isThinkingDisabled checks if the thinking JSON config explicitly sets type to "disabled".
+func isThinkingDisabled(thinking json.RawMessage) bool {
+	var m map[string]interface{}
+	if err := json.Unmarshal(thinking, &m); err != nil {
+		return false
+	}
+	t, ok := m["type"].(string)
+	return ok && t == "disabled"
+}
+
 // isDeepSeekModel returns true for DeepSeek models that require thinking mode handling.
 func isDeepSeekModel(modelID string) bool {
 	return strings.HasPrefix(modelID, "deepseek-")
@@ -80,17 +90,20 @@ func (t *RequestTransformer) TransformRequest(
 	// doesn't require reasoning_content we can't provide.
 	hasThinkingInHistory := HasThinkingBlocks(anthropicReq.Messages)
 	if hasThinkingInHistory {
-		// Thinking mode required — use model config values or defaults.
-		if model.ReasoningEffort != "" {
-			openaiReq.ReasoningEffort = &model.ReasoningEffort
-		} else {
-			defaultEffort := "high"
-			openaiReq.ReasoningEffort = &defaultEffort
-		}
 		if len(model.Thinking) > 0 {
 			openaiReq.Thinking = model.Thinking
 		} else {
 			openaiReq.Thinking = json.RawMessage(`{"type":"enabled"}`)
+		}
+		// DeepSeek returns 400 if reasoning_effort is sent alongside
+		// thinking: disabled — only set it when thinking is active.
+		if !(isThinkingDisabled(openaiReq.Thinking) && isDeepSeekModel(model.ModelID)) {
+			if model.ReasoningEffort != "" {
+				openaiReq.ReasoningEffort = &model.ReasoningEffort
+			} else {
+				defaultEffort := "high"
+				openaiReq.ReasoningEffort = &defaultEffort
+			}
 		}
 	} else if len(model.Thinking) > 0 || model.ReasoningEffort != "" {
 		// Model config wants thinking mode but history has no thinking blocks.

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -455,7 +455,6 @@ func TestTransformRequestSkipsReasoningEffortWhenThinkingDisabled(t *testing.T) 
 	}
 }
 
-
 func TestTransformRequestOmitsPlaceholderForDeepSeek(t *testing.T) {
 	transformer := NewRequestTransformer()
 

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -418,6 +418,44 @@ func TestTransformRequestPlacesToolResultsBeforeUserText(t *testing.T) {
 	}
 }
 
+func TestTransformRequestSkipsReasoningEffortWhenThinkingDisabled(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	// When thinking is explicitly disabled in model config, reasoning_effort
+	// must NOT be set — DeepSeek returns 400 if both are present.
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"think carefully"`)},
+			{
+				Role: "assistant",
+				Content: json.RawMessage(`[
+					{"type":"thinking","thinking":"Let me think..."},
+					{"type":"text","text":"The answer is 42"}
+				]`),
+			},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID:         "deepseek-v4-pro",
+		ReasoningEffort: "max",
+		Thinking:        json.RawMessage(`{"type":"disabled"}`),
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.ReasoningEffort != nil {
+		t.Fatalf("ReasoningEffort = %v, want nil (stripped because thinking is disabled)", *openaiReq.ReasoningEffort)
+	}
+	if got, want := string(openaiReq.Thinking), `{"type":"disabled"}`; got != want {
+		t.Fatalf("Thinking = %s, want %s", got, want)
+	}
+}
+
+
 func TestTransformRequestOmitsPlaceholderForDeepSeek(t *testing.T) {
 	transformer := NewRequestTransformer()
 


### PR DESCRIPTION
## Summary

- DeepSeek API returns a 400 error when `reasoning_effort` is sent alongside `thinking: {"type":"disabled"}`.
- Added `isThinkingDisabled()` helper to parse the thinking JSON config.
- Adjusted `TransformRequest` logic: resolve the `Thinking` value first, then conditionally set `reasoning_effort` — only when thinking is not disabled for DeepSeek models.
- Added test coverage for the `thinking: disabled` + `reasoning_effort` scenario.

## Bug details

When a DeepSeek model has thinking mode disabled but `reasoning_effort` is still present in the request, the DeepSeek API rejects it with a 400 error:

```
time=2026-05-06T11:07:19.129+08:00 level=INFO msg="routing request" scenario=fast model=deepseek-v4-flash tokens=33341
time=2026-05-06T11:07:19.129+08:00 level=INFO msg="attempting streaming model" model=deepseek-v4-flash
time=2026-05-06T11:07:21.159+08:00 level=WARN msg="streaming request failed" model=deepseek-v4-flash error="API error 400: {\"error\":{\"message\":\"Error from provider (DeepSeek): The reasoning_content in the thinking mode must be passed back to the API.\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":\"invalid_request_error\"}"
time=2026-05-06T11:07:21.159+08:00 level=INFO msg="attempting streaming model" model=deepseek-v4-pro
time=2026-05-06T11:07:23.162+08:00 level=WARN msg="streaming request failed" model=deepseek-v4-pro error="API error 400: {\"error\":{\"message\":\"Error from provider (DeepSeek): The reasoning_content in the thinking mode must be passed back to the API.\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":\"invalid_request_error\"}"
time=2026-05-06T11:07:23.162+08:00 level=INFO msg="attempting streaming model" model=kimi-k2.6
```

Per [DeepSeek Thinking Mode docs](https://api-docs.deepseek.com/guides/thinking_mode), `reasoning_effort` must not be included when thinking mode is disabled. The fix ensures `reasoning_effort` is omitted for DeepSeek models when `thinking` resolves to `{"type":"disabled"}`.

## Root cause

The config below defines `reasoning_effort` and `thinking` on DeepSeek models. When the router detects no thinking blocks in conversation history (e.g. Claude Code dropped them), `TransformRequest` sets `thinking: {"type":"disabled"}` but **also** kept `reasoning_effort` from the model config or its default (`"high"`). DeepSeek rejects this combination with a 400.

```json
{
    "fast": {
        "provider": "opencode-go",
        "model_id": "deepseek-v4-pro",
        "thinking": {
            "type": "disabled"
        }
    },
    "background": {
        "provider": "opencode-go",
        "model_id": "deepseek-v4-pro",
        "thinking": {
            "type": "disabled"
        }
    },
    "long_context": {
        "provider": "opencode-go",
        "model_id": "deepseek-v4-pro",
        "reasoning_effort": "max",
        "thinking": { "type": "enabled" }
    },
    "think": {
        "provider": "opencode-go",
        "model_id": "deepseek-v4-pro",
        "reasoning_effort": "max",
        "thinking": { "type": "enabled" }
    }
}
```

When conversation history lacks thinking blocks, the `else if` branch correctly sets `thinking: {"type":"disabled"}`, but the original code would still forward `reasoning_effort` from the model config — causing the 400.

## Test plan

- [x] `TestTransformRequestSkipsReasoningEffortWhenThinkingDisabled` — verifies DeepSeek + thinking disabled does not set reasoning_effort
- [x] All existing tests pass with no regressions
- [ ] Manual verification: configure a DeepSeek model with thinking disabled, confirm no more 400 errors