### PR TITLE
fix(transformer): subtract cache tokens from input_tokens to match Anthropic spec

### DIFF
--- a/internal/transformer/response.go
+++ b/internal/transformer/response.go
@@ -11,6 +11,16 @@ import (
 // ResponseTransformer converts OpenAI responses to Anthropic format.
 type ResponseTransformer struct{}
 
+// nonNegative clamps an integer to zero. Used when subtracting cache-token
+// counts from prompt totals: defends against upstream payloads where the
+// reported parts don't consistently sum to the whole.
+func nonNegative(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
 // NewResponseTransformer creates a new response transformer.
 func NewResponseTransformer() *ResponseTransformer {
 	return &ResponseTransformer{}
@@ -46,7 +56,15 @@ func (t *ResponseTransformer) TransformResponse(
 		StopReason:   stopReason,
 		StopSequence: "",
 		Usage: types.Usage{
-			InputTokens:              openaiResp.Usage.PromptTokens,
+			// Per Anthropic Messages API spec, `input_tokens` is the count of
+			// regular input tokens — i.e. tokens that were neither read from
+			// the cache nor written to the cache this turn. OpenAI's
+			// `prompt_tokens` is the *total* prompt size including both. When
+			// the upstream reports prompt-cache fields we have to subtract
+			// them out, otherwise Claude Code's local context counter sees an
+			// inflated input_tokens on every turn and trips auto-compact ~5x
+			// too early on long-prefix sessions.
+			InputTokens:              nonNegative(openaiResp.Usage.PromptTokens - openaiResp.Usage.PromptCacheHitTokens - openaiResp.Usage.PromptCacheMissTokens),
 			OutputTokens:             openaiResp.Usage.CompletionTokens,
 			CacheCreationInputTokens: openaiResp.Usage.PromptCacheMissTokens,
 			CacheReadInputTokens:     openaiResp.Usage.PromptCacheHitTokens,

--- a/internal/transformer/response_test.go
+++ b/internal/transformer/response_test.go
@@ -297,6 +297,52 @@ func TestTransformResponseWithPartialCacheTokens(t *testing.T) {
 	}
 }
 
+// TestTransformResponseCacheExceedsPromptTokens covers the defensive edge
+// case where upstream reports cache_hit + cache_miss > prompt_tokens.
+// The nonNegative guard must clamp input_tokens to 0 instead of going negative.
+func TestTransformResponseCacheExceedsPromptTokens(t *testing.T) {
+	transformer := NewResponseTransformer()
+
+	openaiResp := &types.ChatCompletionResponse{
+		ID:     "chatcmpl-overflow",
+		Object: "chat.completion",
+		Model:  "deepseek-v4-pro",
+		Choices: []types.Choice{
+			{
+				Index: 0,
+				Message: types.ChatMessage{
+					Role:    "assistant",
+					Content: "ok",
+				},
+				FinishReason: "stop",
+			},
+		},
+		Usage: types.UsageInfo{
+			PromptTokens:         50,
+			CompletionTokens:     5,
+			TotalTokens:          55,
+			PromptCacheHitTokens: 40,
+			PromptCacheMissTokens: 20,
+			// 50 - 40 - 20 = -10, clamped to 0
+		},
+	}
+
+	anthropicResp, err := transformer.TransformResponse(openaiResp, "claude-3-sonnet")
+	if err != nil {
+		t.Fatalf("TransformResponse() error = %v", err)
+	}
+
+	if got, want := anthropicResp.Usage.InputTokens, 0; got != want {
+		t.Errorf("Usage.InputTokens = %d, want %d", got, want)
+	}
+	if got, want := anthropicResp.Usage.CacheReadInputTokens, 40; got != want {
+		t.Errorf("Usage.CacheReadInputTokens = %d, want %d", got, want)
+	}
+	if got, want := anthropicResp.Usage.CacheCreationInputTokens, 20; got != want {
+		t.Errorf("Usage.CacheCreationInputTokens = %d, want %d", got, want)
+	}
+}
+
 func TestTransformResponseWithoutCacheTokens(t *testing.T) {
 	transformer := NewResponseTransformer()
 

--- a/internal/transformer/response_test.go
+++ b/internal/transformer/response_test.go
@@ -318,10 +318,10 @@ func TestTransformResponseCacheExceedsPromptTokens(t *testing.T) {
 			},
 		},
 		Usage: types.UsageInfo{
-			PromptTokens:         50,
-			CompletionTokens:     5,
-			TotalTokens:          55,
-			PromptCacheHitTokens: 40,
+			PromptTokens:          50,
+			CompletionTokens:      5,
+			TotalTokens:           55,
+			PromptCacheHitTokens:  40,
 			PromptCacheMissTokens: 20,
 			// 50 - 40 - 20 = -10, clamped to 0
 		},

--- a/internal/transformer/response_test.go
+++ b/internal/transformer/response_test.go
@@ -233,7 +233,10 @@ func TestTransformResponseWithCacheTokens(t *testing.T) {
 		t.Fatalf("TransformResponse() error = %v", err)
 	}
 
-	if got, want := anthropicResp.Usage.InputTokens, 100; got != want {
+	// Per Anthropic spec, input_tokens excludes cache reads AND cache
+	// creations. Upstream prompt_tokens=100 split as 80 hit + 20 miss
+	// means everything was accounted for by the cache → input_tokens = 0.
+	if got, want := anthropicResp.Usage.InputTokens, 0; got != want {
 		t.Errorf("Usage.InputTokens = %d, want %d", got, want)
 	}
 	if got, want := anthropicResp.Usage.OutputTokens, 50; got != want {
@@ -243,6 +246,53 @@ func TestTransformResponseWithCacheTokens(t *testing.T) {
 		t.Errorf("Usage.CacheReadInputTokens = %d, want %d", got, want)
 	}
 	if got, want := anthropicResp.Usage.CacheCreationInputTokens, 20; got != want {
+		t.Errorf("Usage.CacheCreationInputTokens = %d, want %d", got, want)
+	}
+}
+
+// TestTransformResponseWithPartialCacheTokens covers the case where the
+// upstream's hit + miss don't fully account for prompt_tokens (e.g., a
+// portion of the prompt is below the prefix-cache minimum and reported as
+// neither cached nor newly cached). The leftover should map to input_tokens.
+func TestTransformResponseWithPartialCacheTokens(t *testing.T) {
+	transformer := NewResponseTransformer()
+
+	openaiResp := &types.ChatCompletionResponse{
+		ID:     "chatcmpl-789",
+		Object: "chat.completion",
+		Model:  "deepseek-v4-pro",
+		Choices: []types.Choice{
+			{
+				Index: 0,
+				Message: types.ChatMessage{
+					Role:    "assistant",
+					Content: "ok",
+				},
+				FinishReason: "stop",
+			},
+		},
+		Usage: types.UsageInfo{
+			PromptTokens:          100,
+			CompletionTokens:      5,
+			TotalTokens:           105,
+			PromptCacheHitTokens:  60,
+			PromptCacheMissTokens: 30,
+			// 100 - 60 - 30 = 10 tokens are neither cached nor newly cached.
+		},
+	}
+
+	anthropicResp, err := transformer.TransformResponse(openaiResp, "claude-3-sonnet")
+	if err != nil {
+		t.Fatalf("TransformResponse() error = %v", err)
+	}
+
+	if got, want := anthropicResp.Usage.InputTokens, 10; got != want {
+		t.Errorf("Usage.InputTokens = %d, want %d", got, want)
+	}
+	if got, want := anthropicResp.Usage.CacheReadInputTokens, 60; got != want {
+		t.Errorf("Usage.CacheReadInputTokens = %d, want %d", got, want)
+	}
+	if got, want := anthropicResp.Usage.CacheCreationInputTokens, 30; got != want {
 		t.Errorf("Usage.CacheCreationInputTokens = %d, want %d", got, want)
 	}
 }

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -570,7 +570,13 @@ func usageInfoToAnthropic(usage *types.UsageInfo) *types.Usage {
 		return nil
 	}
 	return &types.Usage{
-		InputTokens:              usage.PromptTokens,
+		// Per Anthropic Messages API spec, `input_tokens` is the count of
+		// regular input tokens — i.e. tokens that were neither read from the
+		// cache nor written to the cache this turn. OpenAI's `prompt_tokens`
+		// is the *total* prompt size. We must subtract the cache parts here
+		// for the same reason TransformResponse does — see the longer comment
+		// in response.go.
+		InputTokens:              nonNegative(usage.PromptTokens - usage.PromptCacheHitTokens - usage.PromptCacheMissTokens),
 		OutputTokens:             usage.CompletionTokens,
 		CacheCreationInputTokens: usage.PromptCacheMissTokens,
 		CacheReadInputTokens:     usage.PromptCacheHitTokens,

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -252,6 +252,47 @@ func TestProxyStream_UsageOnlyChunk(t *testing.T) {
 	}
 }
 
+// TestProxyStream_PartialCacheTokensStreaming covers the case where
+// hit + miss < prompt_tokens in a streaming context. The leftover tokens
+// should map to input_tokens.
+func TestProxyStream_PartialCacheTokensStreaming(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"choices":[{"delta":{"content":"Partial cache"}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"total_tokens":105,"prompt_cache_hit_tokens":60,"prompt_cache_miss_tokens":30}}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyStream(w, body, "deepseek-v4-pro", ctx); err != nil {
+		t.Fatalf("ProxyStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+	var usage *types.Usage
+	for _, event := range events {
+		if event.Usage != nil {
+			usage = event.Usage
+		}
+	}
+	if usage == nil {
+		t.Fatalf("no usage event found in stream: %+v", events)
+	}
+	// 100 - 60 - 30 = 10 tokens are neither cached nor newly cached.
+	if got, want := usage.InputTokens, 10; got != want {
+		t.Errorf("InputTokens = %d, want %d", got, want)
+	}
+	if got, want := usage.CacheReadInputTokens, 60; got != want {
+		t.Errorf("CacheReadInputTokens = %d, want %d", got, want)
+	}
+	if got, want := usage.CacheCreationInputTokens, 30; got != want {
+		t.Errorf("CacheCreationInputTokens = %d, want %d", got, want)
+	}
+}
+
 // TestProxyStream_NoDuplicateMessageDelta verifies that when finish_reason and
 // usage arrive in separate chunks, only ONE message_delta with a stop_reason
 // is emitted. Usage may arrive in a separate message_delta (without stop_reason)

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -235,7 +235,10 @@ func TestProxyStream_UsageOnlyChunk(t *testing.T) {
 	if usage == nil {
 		t.Fatalf("no usage event found in stream: %+v", events)
 	}
-	if got, want := usage.InputTokens, 123; got != want {
+	// Per Anthropic spec, input_tokens excludes cache reads AND cache
+	// creations. Upstream prompt_tokens=123 split as 100 hit + 23 miss
+	// means everything was accounted for by the cache → input_tokens = 0.
+	if got, want := usage.InputTokens, 0; got != want {
 		t.Fatalf("InputTokens = %d, want %d", got, want)
 	}
 	if got, want := usage.OutputTokens, 45; got != want {


### PR DESCRIPTION
## Summary

`oc-go-cc` currently maps OpenAI's `usage.prompt_tokens` directly into Anthropic's `usage.input_tokens` 1:1 in both the non-streaming `ResponseTransformer.TransformResponse` and the streaming `usageInfoToAnthropic` helper.

Per the [Anthropic Messages API spec](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching), `input_tokens` is the count of input tokens that were **neither read from the cache nor written to the cache this turn** — i.e. it should *exclude* the parts already accounted for by `cache_read_input_tokens` and `cache_creation_input_tokens`. OpenAI's `prompt_tokens` is the *total* prompt size including both. So the current mapping double-counts cached tokens.

This PR changes both call sites to:

```go
InputTokens: nonNegative(usage.PromptTokens - usage.PromptCacheHitTokens - usage.PromptCacheMissTokens)
```

with a small `nonNegative` helper to defend against upstream payloads where the parts don't precisely sum to the whole.

## Why this matters in practice

Claude Code's local auto-compact counter reads `input_tokens` from every response and treats it as the conversation's running size. With the current mapping, every turn reports the full prompt size (including all cached prefix), and the counter trips auto-compact at ~80% of its assumed 200k window after only a handful of turns — even though the true uncached delta per turn is tiny.

I observed this empirically on a real claude-go workflow today:

- Session compacted at `preTokens: 171,159` after only 5 minutes / 47 turns.
- Average per-turn `input_tokens` reported: **48,408**.
- A comparable claude-glm session (same harness, Anthropic-spec-conformant Z.AI proxy) ran **202 turns over 87 minutes** before compacting; per-turn `input_tokens` correctly dropped to ~106 once caching kicked in.

After this fix, oc-go-cc's `input_tokens` correctly drops to ~0 once cache hits dominate the prompt — matching what Anthropic-native providers report — and the auto-compact counter reflects real conversation growth instead of full-prompt size each turn.

## Empirical validation

A direct cache probe through oc-go-cc (deepseek-v4-pro upstream) before this PR:

| Call | prompt_tokens | cache_hit | cache_miss | Anthropic `input_tokens` (current) | Anthropic `input_tokens` (after fix) |
|------|---------------|-----------|------------|------------------------------------|--------------------------------------|
| 1 (cold)  | 4927 | 0    | 4927 | 4927 | 0 |
| 2 (warm)  | 4926 | 4864 | 62   | 4926 | 0 |

Call 2's pre-fix value of 4926 is an ~80× inflation over the actual ~62 newly-uncached tokens.

## Test changes

- **Updated** `TestTransformResponseWithCacheTokens`: when `prompt_tokens=100` is fully accounted for by `cache_hit=80 + cache_miss=20`, `input_tokens` now expects **0** instead of 100.
- **Updated** `TestProxyStream_UsageOnlyChunk`: same shape, now expects `input_tokens=0`.
- **Unchanged** `TestTransformResponseWithoutCacheTokens` and `TestProxyStream_NoDuplicateMessageDelta`: when no cache fields are reported, `input_tokens = prompt_tokens` still holds (backward-compatible for non-caching upstreams).
- **Added** `TestTransformResponseWithPartialCacheTokens`: covers the case where `cache_hit + cache_miss < prompt_tokens` (some tokens are neither cached nor newly cached). The leftover correctly maps to `input_tokens`.

Full suite passes with `-race`:

```
ok  	oc-go-cc/internal/client      1.033s
ok  	oc-go-cc/internal/config      2.270s
ok  	oc-go-cc/internal/daemon      1.041s
ok  	oc-go-cc/internal/handlers    1.725s
ok  	oc-go-cc/internal/router      1.030s
ok  	oc-go-cc/internal/transformer 1.051s
```

## Backward compatibility

- Upstreams that don't report cache fields → behavior is unchanged (`input_tokens = prompt_tokens`).
- Upstreams that do report cache fields → `input_tokens` becomes spec-conformant. Clients that were previously reading the inflated number will now see the correct (smaller) value, which is the whole point.
- The `cache_read_input_tokens` and `cache_creation_input_tokens` mappings are unchanged.
