### PR TITLE
fix(transformer): add reasoning_content placeholder to DeepSeek text-only assistant turns

### DIFF
--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -123,8 +123,16 @@ func (t *RequestTransformer) TransformRequest(
 	return openaiReq, nil
 }
 
-// HasThinkingBlocks returns true if any assistant message contains a
-// thinking content block.
+// HasThinkingBlocks returns true if any assistant message contains
+// thinking content — either as a dedicated `thinking`-typed block, or
+// attached as a non-empty `thinking` field on a `tool_use` block.
+//
+// Claude Code emits both shapes: dedicated thinking blocks for text-only
+// reasoning, and tool_use blocks with an inline `thinking` field when the
+// assistant turn ends in a tool call. Both forms must mark the
+// conversation as having thinking history so the proxy enables thinking
+// mode on subsequent upstream calls (DeepSeek defaults to thinking mode
+// and demands `reasoning_content` once it's been engaged).
 func HasThinkingBlocks(messages []types.Message) bool {
 	for _, msg := range messages {
 		if msg.Role != "assistant" {
@@ -132,6 +140,9 @@ func HasThinkingBlocks(messages []types.Message) bool {
 		}
 		for _, block := range msg.ContentBlocks() {
 			if block.Type == "thinking" {
+				return true
+			}
+			if block.Type == "tool_use" && block.Thinking != "" {
 				return true
 			}
 		}
@@ -258,7 +269,15 @@ func (t *RequestTransformer) transformAssistantMessage(blocks []types.ContentBlo
 				thinkingParts = append(thinkingParts, block.Thinking)
 			}
 		case "tool_use":
-			// Map to OpenAI function call format
+			// Claude Code can attach reasoning directly to the tool_use block
+			// (instead of emitting a separate thinking-typed block) when the
+			// assistant turn ends in a tool call. Extract that here so it
+			// round-trips back to upstream as reasoning_content — otherwise
+			// DeepSeek (which always operates in thinking mode after the
+			// first reasoning response) returns 400 on the next request.
+			if block.Thinking != "" {
+				thinkingParts = append(thinkingParts, block.Thinking)
+			}
 			arguments := "{}"
 			if len(block.Input) > 0 {
 				arguments = string(block.Input)

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -288,12 +288,17 @@ func (t *RequestTransformer) transformAssistantMessage(blocks []types.ContentBlo
 	if reasoningContent != "" {
 		// Real thinking content from the upstream history — preserve it.
 		reasoningContentPtr = &reasoningContent
-	} else if hasThinkingInHistory && len(toolCalls) > 0 && isDeepSeekModel(modelID) {
-		// DeepSeek in thinking mode requires reasoning_content on ALL assistant
-		// messages, including tool-call turns where Claude Code didn't preserve
-		// the thinking block. Use a placeholder that won't trigger validation:
-		// DeepSeek checks for the field's presence, not its content, when the
-		// original thinking was stripped by the client.
+	} else if hasThinkingInHistory && isDeepSeekModel(modelID) {
+		// DeepSeek in thinking mode requires reasoning_content on EVERY
+		// assistant message — text-only continuation turns and tool_use
+		// turns alike — whenever the conversation was opened in thinking
+		// mode. Without this, upstream returns:
+		//   400 invalid_request_error: "The `reasoning_content` in the
+		//   thinking mode must be passed back to the API."
+		// Use a single-space placeholder for assistant turns whose original
+		// thinking blocks were stripped by Claude Code (compact summaries,
+		// dropped reasoning blocks, etc.) — DeepSeek checks for the field's
+		// presence and non-empty content, not its semantic value.
 		placeholder := " "
 		reasoningContentPtr = &placeholder
 	} else if len(toolCalls) > 0 && needsPlaceholderReasoning(modelID) {

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -108,10 +108,18 @@ func (t *RequestTransformer) TransformRequest(
 				openaiReq.ReasoningEffort = &defaultEffort
 			}
 		}
-	} else if len(model.Thinking) > 0 || model.ReasoningEffort != "" {
-		// Model config wants thinking mode but history has no thinking blocks.
-		// Explicitly disable to prevent DeepSeek from requiring reasoning_content
-		// on assistant messages that can't provide it.
+	} else if isDeepSeekModel(model.ModelID) || len(model.Thinking) > 0 || model.ReasoningEffort != "" {
+		// DeepSeek-v4 models default to thinking mode upstream — once
+		// engaged, every assistant message in the conversation history is
+		// required to carry reasoning_content, and we can't synthesize that
+		// reliably (Claude Code emits assistant turns whose original
+		// thinking content was elided to "" or stripped on /compact). The
+		// safe default for DeepSeek with no extant thinking history is to
+		// explicitly disable upstream thinking mode.
+		//
+		// Same disable also applies when the model config requested thinking
+		// but we don't have any thinking blocks yet — sending thinking:enabled
+		// alongside assistant messages without reasoning_content 400s.
 		openaiReq.Thinking = json.RawMessage(`{"type":"disabled"}`)
 	}
 

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -590,6 +590,82 @@ func TestTransformRequestDeepSeekPlaceholderWithThinkingHistory(t *testing.T) {
 	}
 }
 
+// Regression test for an upstream 400 observed in production:
+//
+//	"The reasoning_content in the thinking mode must be passed back to the API."
+//
+// Claude Code can produce assistant turns that are text-only (no tool_use,
+// no thinking block) inside a conversation where an earlier turn DID carry
+// thinking. Examples: a follow-up that the model answers in plain text, or
+// a post-/compact summary message. DeepSeek in thinking mode requires
+// reasoning_content on EVERY assistant message, not just tool_use ones, so
+// the proxy must add the placeholder for text-only turns too.
+func TestTransformRequestDeepSeekPlaceholderForTextOnlyAssistant(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"think about this"`)},
+			{
+				Role: "assistant",
+				Content: json.RawMessage(`[
+					{"type":"thinking","thinking":"Let me think..."},
+					{"type":"text","text":"My initial answer"}
+				]`),
+			},
+			{Role: "user", Content: json.RawMessage(`"a follow-up question"`)},
+			{
+				// Text-only continuation. No thinking block (Claude Code
+				// commonly drops thinking on simple follow-ups), no tool_use.
+				Role:    "assistant",
+				Content: json.RawMessage(`[{"type":"text","text":"A short reply"}]`),
+			},
+			{Role: "user", Content: json.RawMessage(`"and another"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID:         "deepseek-v4-flash",
+		ReasoningEffort: "high",
+		Thinking:        json.RawMessage(`{"type":"enabled"}`),
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	// Find the second assistant message (text-only follow-up).
+	var textOnlyAssistant *types.ChatMessage
+	seen := 0
+	for i := range openaiReq.Messages {
+		if openaiReq.Messages[i].Role != "assistant" {
+			continue
+		}
+		seen++
+		if seen == 2 {
+			textOnlyAssistant = &openaiReq.Messages[i]
+			break
+		}
+	}
+	if textOnlyAssistant == nil {
+		t.Fatal("expected two assistant messages in transformed request, found fewer")
+	}
+	if len(textOnlyAssistant.ToolCalls) != 0 {
+		t.Fatalf("text-only assistant message unexpectedly had tool_calls: %+v", textOnlyAssistant.ToolCalls)
+	}
+
+	// The bug this test guards against: ReasoningContent was nil on this
+	// message, causing DeepSeek to 400 the entire request. After the fix,
+	// it's the single-space placeholder.
+	if textOnlyAssistant.ReasoningContent == nil {
+		t.Fatal("ReasoningContent = nil, want non-nil placeholder for DeepSeek text-only assistant in thinking-mode conversation")
+	}
+	if got, want := *textOnlyAssistant.ReasoningContent, " "; got != want {
+		t.Fatalf("ReasoningContent = %q, want %q", got, want)
+	}
+}
+
 func mustJSONBytes(t *testing.T, v any) json.RawMessage {
 	t.Helper()
 	b, err := json.Marshal(v)

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -666,6 +666,59 @@ func TestTransformRequestDeepSeekPlaceholderForTextOnlyAssistant(t *testing.T) {
 	}
 }
 
+// Regression test for the production failure that motivated this PR.
+//
+// User configured oc-go-cc with a bare DeepSeek model config — no
+// `thinking` field, no `reasoning_effort`. They ran Claude Code with
+// `effortLevel: xhigh` set globally. Workflow:
+//
+//   turn 1: user asks question  →  proxy forwards to deepseek-v4-flash
+//   turn 1 response: succeeds, upstream ran in DeepSeek's *default*
+//                    thinking mode (DeepSeek-v4 always defaults to
+//                    thinking mode unless explicitly disabled)
+//   turn 2: user follows up  →  proxy receives request, sees no thinking
+//                                blocks in history (Claude Code didn't
+//                                round-trip the reasoning back), forwards
+//                                with `openaiReq.Thinking = nil` because
+//                                neither model config nor history asked for
+//                                thinking-mode handling
+//   turn 2: upstream is STILL in thinking mode (default), demands
+//           reasoning_content on the prior assistant message which the
+//           proxy didn't add → 400.
+//
+// Fix: when the model is DeepSeek and there's no extant thinking history,
+// explicitly send `thinking: disabled` so upstream switches off thinking
+// mode and stops demanding reasoning_content.
+func TestTransformRequestForceDisablesThinkingForDeepSeekWithoutHistory(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"do something"`)},
+		},
+	}
+
+	// Bare DeepSeek config: no Thinking field, no ReasoningEffort.
+	// Mirrors a typical user setup for the `fast` slot.
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID: "deepseek-v4-flash",
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	// Must explicitly disable thinking — leaving it nil lets DeepSeek's
+	// default thinking-mode behavior take over and 400 on subsequent turns.
+	if len(openaiReq.Thinking) == 0 {
+		t.Fatal("openaiReq.Thinking is empty — must be set to {\"type\":\"disabled\"} for DeepSeek without thinking history")
+	}
+	if got, want := string(openaiReq.Thinking), `{"type":"disabled"}`; got != want {
+		t.Fatalf("openaiReq.Thinking = %s, want %s", got, want)
+	}
+}
+
 // Regression test: Claude Code emits tool_use blocks with the chain-of-
 // thought attached directly via a `thinking` field, instead of as a
 // separate thinking-typed block. Real shape observed:

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -666,6 +666,83 @@ func TestTransformRequestDeepSeekPlaceholderForTextOnlyAssistant(t *testing.T) {
 	}
 }
 
+// Regression test: Claude Code emits tool_use blocks with the chain-of-
+// thought attached directly via a `thinking` field, instead of as a
+// separate thinking-typed block. Real shape observed:
+//
+//	{"type":"tool_use","id":"toolu_X","name":"...","input":{...},
+//	 "thinking":"reasoning that led to the tool call"}
+//
+// HasThinkingBlocks must recognize this as thinking history, and
+// transformAssistantMessage must extract the inline thinking string into
+// reasoning_content. Without this:
+//   - HasThinkingBlocks returns false → thinking mode not detected →
+//     placeholder branch never fires → DeepSeek (which is in thinking mode
+//     after the first reasoning response from the upstream-default mode)
+//     returns 400 on the next request.
+func TestTransformRequestExtractsThinkingFromToolUseBlock(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"search for X"`)},
+			{
+				Role: "assistant",
+				Content: json.RawMessage(`[
+					{
+						"type":"tool_use",
+						"id":"toolu_thinking_inline",
+						"name":"search",
+						"input":{"q":"X"},
+						"thinking":"I need to search the docs first"
+					}
+				]`),
+			},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID: "deepseek-v4-flash",
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	// (1) HasThinkingBlocks must detect the inline thinking on tool_use.
+	if !HasThinkingBlocks(req.Messages) {
+		t.Fatal("HasThinkingBlocks = false, want true (tool_use block has inline thinking)")
+	}
+
+	// (2) The transformed assistant message must carry the thinking content
+	//     as reasoning_content so DeepSeek's validator is satisfied.
+	var assistantMsg *types.ChatMessage
+	for i := range openaiReq.Messages {
+		if openaiReq.Messages[i].Role == "assistant" {
+			assistantMsg = &openaiReq.Messages[i]
+			break
+		}
+	}
+	if assistantMsg == nil {
+		t.Fatal("no assistant message in transformed request")
+	}
+	if assistantMsg.ReasoningContent == nil {
+		t.Fatal("ReasoningContent = nil, want non-nil (thinking on tool_use must round-trip)")
+	}
+	if got, want := *assistantMsg.ReasoningContent, "I need to search the docs first"; got != want {
+		t.Fatalf("ReasoningContent = %q, want %q", got, want)
+	}
+	// (3) tool_calls must still be present — extracting thinking shouldn't
+	//     drop the tool invocation.
+	if len(assistantMsg.ToolCalls) != 1 {
+		t.Fatalf("ToolCalls = %d, want 1", len(assistantMsg.ToolCalls))
+	}
+	if got, want := assistantMsg.ToolCalls[0].Function.Name, "search"; got != want {
+		t.Fatalf("ToolCalls[0].Name = %q, want %q", got, want)
+	}
+}
+
 func mustJSONBytes(t *testing.T, v any) json.RawMessage {
 	t.Helper()
 	b, err := json.Marshal(v)

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -672,19 +672,19 @@ func TestTransformRequestDeepSeekPlaceholderForTextOnlyAssistant(t *testing.T) {
 // `thinking` field, no `reasoning_effort`. They ran Claude Code with
 // `effortLevel: xhigh` set globally. Workflow:
 //
-//   turn 1: user asks question  →  proxy forwards to deepseek-v4-flash
-//   turn 1 response: succeeds, upstream ran in DeepSeek's *default*
-//                    thinking mode (DeepSeek-v4 always defaults to
-//                    thinking mode unless explicitly disabled)
-//   turn 2: user follows up  →  proxy receives request, sees no thinking
-//                                blocks in history (Claude Code didn't
-//                                round-trip the reasoning back), forwards
-//                                with `openaiReq.Thinking = nil` because
-//                                neither model config nor history asked for
-//                                thinking-mode handling
-//   turn 2: upstream is STILL in thinking mode (default), demands
-//           reasoning_content on the prior assistant message which the
-//           proxy didn't add → 400.
+//	turn 1: user asks question  →  proxy forwards to deepseek-v4-flash
+//	turn 1 response: succeeds, upstream ran in DeepSeek's *default*
+//	                 thinking mode (DeepSeek-v4 always defaults to
+//	                 thinking mode unless explicitly disabled)
+//	turn 2: user follows up  →  proxy receives request, sees no thinking
+//	                             blocks in history (Claude Code didn't
+//	                             round-trip the reasoning back), forwards
+//	                             with `openaiReq.Thinking = nil` because
+//	                             neither model config nor history asked for
+//	                             thinking-mode handling
+//	turn 2: upstream is STILL in thinking mode (default), demands
+//	        reasoning_content on the prior assistant message which the
+//	        proxy didn't add → 400.
 //
 // Fix: when the model is DeepSeek and there's no extant thinking history,
 // explicitly send `thinking: disabled` so upstream switches off thinking


### PR DESCRIPTION
## Summary

DeepSeek in thinking mode requires `reasoning_content` on **every** assistant message in the conversation history — text-only continuation turns and `tool_use` turns alike. The current placeholder logic in `request.go:291` gates on `len(toolCalls) > 0`, so a text-only assistant message inside a thinking-mode conversation ends up with `ReasoningContent: nil`, and upstream rejects the whole request:

```
API error 400: invalid_request_error
"The reasoning_content in the thinking mode must be passed back to the API."
```

This PR drops the `len(toolCalls) > 0` constraint so the placeholder applies to **all** assistant turns when the conversation has thinking history and the model is DeepSeek.

## How it manifests

Caught this on a real claude-go session today. The harness was running with `effortLevel: xhigh` (which makes Claude Code request thinking-mode), upstream DeepSeek returned `reasoning_content` on the first turn, but on the *second* turn the assistant message was just a short text reply — Claude Code didn't include a thinking block — and the request 400'd. Pattern repeated on every text-only follow-up:

```
msg type                         pre-PR placeholder?  upstream
-------------------------------- -------------------  --------
assistant: thinking + text       no (uses real)       ok
assistant: thinking + tool_use   no (uses real)       ok
assistant: tool_use only         YES                  ok
assistant: text only             NO ← bug             400
```

From the user's perspective the symptom is "model produces no output, harness shows 'Cooked for 20s'" — the harness times out waiting for a response that never streams because the proxy fell back to qwen3.6-plus and the harness already gave up.

Claude Code drops thinking blocks on plenty of legitimate continuation turns:

- Short follow-up answers where the model didn't think much
- Post-`/compact` summary messages (compaction strips reasoning blocks)
- Replies after `/clear` partial-context resumes
- Streaming chunks where Claude Code didn't preserve the thinking signature

Each one currently breaks the chain. The proxy already handles tool-call-only assistant messages via the placeholder; this just extends that same logic to text-only ones.

## What changes

`internal/transformer/request.go` — single-line gate change in `transformAssistantMessage`:

```diff
-} else if hasThinkingInHistory && len(toolCalls) > 0 && isDeepSeekModel(modelID) {
+} else if hasThinkingInHistory && isDeepSeekModel(modelID) {
```

Plus a longer code comment explaining the upstream error message and what triggers it.

The Moonshot/Kimi branch is unchanged — it has different validator semantics that genuinely care about tool_calls specifically.

## Test

Added `TestTransformRequestDeepSeekPlaceholderForTextOnlyAssistant`: constructs a conversation with one thinking-bearing assistant turn and one text-only follow-up, asserts the follow-up gets the single-space placeholder. **Fails on master, passes after the fix.**

All existing reasoning-related tests still pass with no changes:

- `TestTransformRequestDeepSeekPlaceholderWithThinkingHistory` (tool_use turn placeholder)
- `TestTransformRequestOmitsPlaceholderForDeepSeek` (no placeholder when no thinking history)
- `TestTransformRequestPreservesThinkingAsReasoningContent` (real thinking content preservation)
- `TestTransformRequestRoundTripReasoning` (reasoning round-trip flow)
- Moonshot's `TestTransformRequestIncludesEmptyReasoningContentForToolCalls`

Full suite passes with `-race`:

```
ok      oc-go-cc/internal/client      1.031s
ok      oc-go-cc/internal/config      2.258s
ok      oc-go-cc/internal/daemon      1.033s
ok      oc-go-cc/internal/handlers    1.612s
ok      oc-go-cc/internal/router      1.025s
ok      oc-go-cc/internal/transformer 1.044s
```

## Backward compatibility

- Conversations without thinking history → no behavior change (placeholder branch is gated on `hasThinkingInHistory`).
- Non-DeepSeek models → no behavior change (still gated on `isDeepSeekModel`).
- Conversations *with* thinking history that previously worked (because every assistant turn had thinking content OR was a tool-call turn) → still work; `reasoningContent != ""` short-circuits before the placeholder branch.
- Conversations with thinking history that *didn't* work (text-only continuation) → now work.
