### PR TITLE
feat(config): add respect_requested_model option to honor user-specif…

### DIFF
--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -385,6 +385,7 @@ func getDefaultConfig() string {
   "port": 3456,
   "hot_reload": false,
   "enable_streaming_scenario_routing": false,
+  "respect_requested_model": false,
   "models": {
     "background": {
       "provider": "opencode-go",

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -4,6 +4,7 @@
   "port": 3456,
   "hot_reload": false,
   "enable_streaming_scenario_routing": false,
+  "respect_requested_model": false,
 
   "models": {
     "background": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Port                           int                      `json:"port"`
 	HotReload                      bool                     `json:"hot_reload"`
 	EnableStreamingScenarioRouting bool                     `json:"enable_streaming_scenario_routing"`
+	RespectRequestedModel          bool                     `json:"respect_requested_model"`
 	Models                         map[string]ModelConfig   `json:"models"`
 	Fallbacks                      map[string][]ModelConfig `json:"fallbacks"`
 	OpenCodeGo                     OpenCodeGoConfig         `json:"opencode_go"`

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -177,13 +177,17 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Route to appropriate model.
+	// If the request specifies a model (from cc-switch), use it directly.
+	// Otherwise, use scenario-based routing.
+	requestedModel := anthropicReq.Model
+
 	var routeResult router.RouteResult
 	if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
 		// Streaming: use faster models to minimize TTFT (time-to-first-token)
-		routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount)
+		routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount, requestedModel)
 	} else {
 		var err error
-		routeResult, err = h.modelRouter.Route(routerMessages, tokenCount)
+		routeResult, err = h.modelRouter.Route(routerMessages, tokenCount, requestedModel)
 		if err != nil {
 			h.sendError(w, http.StatusInternalServerError, "routing failed", err)
 			return

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -177,7 +177,7 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Route to appropriate model.
-	// If the request specifies a model (from cc-switch), use it directly.
+	// If the request specifies a model override, use it directly.
 	// Otherwise, use scenario-based routing.
 	requestedModel := anthropicReq.Model
 

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -26,8 +26,29 @@ type RouteResult struct {
 }
 
 // Route determines which model to use for a request.
-func (r *ModelRouter) Route(messages []MessageContent, tokenCount int) (RouteResult, error) {
+// If respect_requested_model is enabled and requestedModel is provided, it overrides scenario-based routing.
+func (r *ModelRouter) Route(messages []MessageContent, tokenCount int, requestedModel string) (RouteResult, error) {
 	cfg := r.atomic.Get()
+
+	// If configured to respect user's model choice and user specified a model, use it directly
+	if cfg.RespectRequestedModel && requestedModel != "" {
+		// Create model config from the requested model
+		primary := config.ModelConfig{
+			Provider: "opencode-go",
+			ModelID:  requestedModel,
+		}
+
+		// Get default fallbacks
+		fallbacks := cfg.Fallbacks["default"]
+
+		return RouteResult{
+			Primary:   primary,
+			Fallbacks: fallbacks,
+			Scenario:  ScenarioDefault,
+		}, nil
+	}
+
+	// Otherwise, use scenario-based routing
 	result := DetectScenario(messages, tokenCount, cfg)
 
 	// Get primary model for scenario
@@ -69,8 +90,26 @@ func (rr *RouteResult) GetModelChain() []config.ModelConfig {
 
 // RouteForStreaming determines which model to use for streaming requests.
 // Prioritizes fast TTFT (time-to-first-token) over capability.
-func (r *ModelRouter) RouteForStreaming(messages []MessageContent, tokenCount int) RouteResult {
+// If respect_requested_model is enabled and requestedModel is provided, it overrides scenario-based routing.
+func (r *ModelRouter) RouteForStreaming(messages []MessageContent, tokenCount int, requestedModel string) RouteResult {
 	cfg := r.atomic.Get()
+
+	// If configured to respect user's model choice and user specified a model, use it directly
+	if cfg.RespectRequestedModel && requestedModel != "" {
+		primary := config.ModelConfig{
+			Provider: "opencode-go",
+			ModelID:  requestedModel,
+		}
+		fallbacks := cfg.Fallbacks["default"]
+
+		return RouteResult{
+			Primary:   primary,
+			Fallbacks: fallbacks,
+			Scenario:  ScenarioDefault,
+		}
+	}
+
+	// Otherwise, use scenario-based routing for streaming
 	result := RouteForStreaming(messages, tokenCount, cfg)
 
 	// Get primary model for scenario

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -25,27 +25,44 @@ type RouteResult struct {
 	Scenario  Scenario
 }
 
+// resolveRequestedModel checks if the user-specified model should override
+// scenario-based routing. Returns the route result and true if it matched,
+// or zero value and false if scenario routing should proceed normally.
+func (r *ModelRouter) resolveRequestedModel(cfg *config.Config, requestedModel string) (RouteResult, bool) {
+	if !cfg.RespectRequestedModel || requestedModel == "" {
+		return RouteResult{}, false
+	}
+
+	// Look up the requested model in config to inherit its settings
+	primary, ok := cfg.Models[requestedModel]
+	if !ok {
+		// Unknown model — create a bare config and inherit defaults
+		primary = config.ModelConfig{
+			Provider: "opencode-go",
+			ModelID:  requestedModel,
+		}
+		if def, ok := cfg.Models["default"]; ok {
+			primary.Temperature = def.Temperature
+			primary.MaxTokens = def.MaxTokens
+		}
+	}
+
+	fallbacks := cfg.Fallbacks["default"]
+
+	return RouteResult{
+		Primary:   primary,
+		Fallbacks: fallbacks,
+		Scenario:  ScenarioDefault,
+	}, true
+}
+
 // Route determines which model to use for a request.
 // If respect_requested_model is enabled and requestedModel is provided, it overrides scenario-based routing.
 func (r *ModelRouter) Route(messages []MessageContent, tokenCount int, requestedModel string) (RouteResult, error) {
 	cfg := r.atomic.Get()
 
-	// If configured to respect user's model choice and user specified a model, use it directly
-	if cfg.RespectRequestedModel && requestedModel != "" {
-		// Create model config from the requested model
-		primary := config.ModelConfig{
-			Provider: "opencode-go",
-			ModelID:  requestedModel,
-		}
-
-		// Get default fallbacks
-		fallbacks := cfg.Fallbacks["default"]
-
-		return RouteResult{
-			Primary:   primary,
-			Fallbacks: fallbacks,
-			Scenario:  ScenarioDefault,
-		}, nil
+	if result, ok := r.resolveRequestedModel(cfg, requestedModel); ok {
+		return result, nil
 	}
 
 	// Otherwise, use scenario-based routing
@@ -94,19 +111,8 @@ func (rr *RouteResult) GetModelChain() []config.ModelConfig {
 func (r *ModelRouter) RouteForStreaming(messages []MessageContent, tokenCount int, requestedModel string) RouteResult {
 	cfg := r.atomic.Get()
 
-	// If configured to respect user's model choice and user specified a model, use it directly
-	if cfg.RespectRequestedModel && requestedModel != "" {
-		primary := config.ModelConfig{
-			Provider: "opencode-go",
-			ModelID:  requestedModel,
-		}
-		fallbacks := cfg.Fallbacks["default"]
-
-		return RouteResult{
-			Primary:   primary,
-			Fallbacks: fallbacks,
-			Scenario:  ScenarioDefault,
-		}
+	if result, ok := r.resolveRequestedModel(cfg, requestedModel); ok {
+		return result
 	}
 
 	// Otherwise, use scenario-based routing for streaming

--- a/internal/router/model_router_test.go
+++ b/internal/router/model_router_test.go
@@ -1,0 +1,234 @@
+package router
+
+import (
+	"testing"
+
+	"oc-go-cc/internal/config"
+)
+
+func newTestAtomicConfig(cfg *config.Config) *config.AtomicConfig {
+	return config.NewAtomicConfig(cfg, "/tmp/test-config.json")
+}
+
+func TestRoute_RespectRequestedModel_BypassesScenarioRouting(t *testing.T) {
+	cfg := &config.Config{
+		RespectRequestedModel: true,
+		Models: map[string]config.ModelConfig{
+			"default": {
+				Provider: "opencode-go",
+				ModelID:  "kimi-k2.6",
+			},
+			"kimi-k2.6": {
+				Provider:         "opencode-go",
+				ModelID:          "kimi-k2.6",
+				Temperature:      0.7,
+				MaxTokens:        4096,
+				ContextThreshold: 80000,
+			},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {
+				{Provider: "opencode-go", ModelID: "qwen3.5-plus"},
+			},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	// Complex message that would normally route to GLM-5.1
+	messages := []MessageContent{
+		{Role: "user", Content: "Architect a new microservice"},
+	}
+
+	result, err := router.Route(messages, 100, "kimi-k2.6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Primary.ModelID != "kimi-k2.6" {
+		t.Errorf("expected model kimi-k2.6, got %s", result.Primary.ModelID)
+	}
+	if result.Primary.Temperature != 0.7 {
+		t.Errorf("expected temperature 0.7, got %f", result.Primary.Temperature)
+	}
+	if result.Primary.MaxTokens != 4096 {
+		t.Errorf("expected max_tokens 4096, got %d", result.Primary.MaxTokens)
+	}
+	if result.Scenario != ScenarioDefault {
+		t.Errorf("expected ScenarioDefault, got %s", result.Scenario)
+	}
+}
+
+func TestRoute_RespectRequestedModel_False_UsesScenarioRouting(t *testing.T) {
+	cfg := &config.Config{
+		RespectRequestedModel: false,
+		Models: map[string]config.ModelConfig{
+			"default": {ModelID: "kimi-k2.6"},
+			"complex": {ModelID: "glm-5.1"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {{ModelID: "qwen3.5-plus"}},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	messages := []MessageContent{
+		{Role: "user", Content: "Architect a new microservice"},
+	}
+
+	result, err := router.Route(messages, 100, "kimi-k2.6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should use scenario routing, not the requested model
+	if result.Primary.ModelID != "glm-5.1" {
+		t.Errorf("expected scenario-routed model glm-5.1, got %s", result.Primary.ModelID)
+	}
+}
+
+func TestRoute_RespectRequestedModel_EmptyModel_FallsThrough(t *testing.T) {
+	cfg := &config.Config{
+		RespectRequestedModel: true,
+		Models: map[string]config.ModelConfig{
+			"default": {ModelID: "kimi-k2.6"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {{ModelID: "qwen3.5-plus"}},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	messages := []MessageContent{
+		{Role: "user", Content: "Hello"},
+	}
+
+	result, err := router.Route(messages, 100, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Empty model should fall through to scenario routing
+	if result.Primary.ModelID != "kimi-k2.6" {
+		t.Errorf("expected default model kimi-k2.6, got %s", result.Primary.ModelID)
+	}
+}
+
+func TestRoute_RespectRequestedModel_UnknownModel_UsesDefaults(t *testing.T) {
+	cfg := &config.Config{
+		RespectRequestedModel: true,
+		Models: map[string]config.ModelConfig{
+			"default": {
+				Provider:    "opencode-go",
+				ModelID:     "kimi-k2.6",
+				Temperature: 0.5,
+				MaxTokens:   8192,
+			},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {{ModelID: "qwen3.5-plus"}},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	messages := []MessageContent{
+		{Role: "user", Content: "Hello"},
+	}
+
+	result, err := router.Route(messages, 100, "some-unknown-model")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Primary.ModelID != "some-unknown-model" {
+		t.Errorf("expected model some-unknown-model, got %s", result.Primary.ModelID)
+	}
+	// Unknown model should inherit default temperature/max_tokens
+	if result.Primary.Temperature != 0.5 {
+		t.Errorf("expected inherited temperature 0.5, got %f", result.Primary.Temperature)
+	}
+	if result.Primary.MaxTokens != 8192 {
+		t.Errorf("expected inherited max_tokens 8192, got %d", result.Primary.MaxTokens)
+	}
+}
+
+func TestRouteForStreaming_RespectRequestedModel_BypassesScenarioRouting(t *testing.T) {
+	cfg := &config.Config{
+		RespectRequestedModel: true,
+		Models: map[string]config.ModelConfig{
+			"default": {ModelID: "qwen3.6-plus"},
+			"kimi-k2.6": {
+				Provider: "opencode-go",
+				ModelID:  "kimi-k2.6",
+			},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {{ModelID: "qwen3.5-plus"}},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	messages := []MessageContent{
+		{Role: "user", Content: "Hello"},
+	}
+
+	result := router.RouteForStreaming(messages, 100, "kimi-k2.6")
+	if result.Primary.ModelID != "kimi-k2.6" {
+		t.Errorf("expected model kimi-k2.6, got %s", result.Primary.ModelID)
+	}
+	if result.Scenario != ScenarioDefault {
+		t.Errorf("expected ScenarioDefault, got %s", result.Scenario)
+	}
+}
+
+func TestRouteForStreaming_RespectRequestedModel_False_UsesScenarioRouting(t *testing.T) {
+	cfg := &config.Config{
+		RespectRequestedModel: false,
+		Models: map[string]config.ModelConfig{
+			"default": {ModelID: "qwen3.6-plus"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {{ModelID: "qwen3.5-plus"}},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	messages := []MessageContent{
+		{Role: "user", Content: "Hello"},
+	}
+
+	result := router.RouteForStreaming(messages, 100, "kimi-k2.6")
+	// Should use streaming scenario routing, not the requested model
+	if result.Primary.ModelID != "qwen3.6-plus" {
+		t.Errorf("expected streaming model qwen3.6-plus, got %s", result.Primary.ModelID)
+	}
+}
+
+func TestResolveRequestedModel_UsesFallbacks(t *testing.T) {
+	cfg := &config.Config{
+		RespectRequestedModel: true,
+		Models: map[string]config.ModelConfig{
+			"kimi-k2.6": {ModelID: "kimi-k2.6"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {
+				{Provider: "opencode-go", ModelID: "qwen3.5-plus"},
+				{Provider: "opencode-go", ModelID: "glm-5.1"},
+			},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	result, ok := router.resolveRequestedModel(cfg, "kimi-k2.6")
+	if !ok {
+		t.Fatal("expected resolveRequestedModel to match")
+	}
+	if len(result.Fallbacks) != 2 {
+		t.Errorf("expected 2 fallbacks, got %d", len(result.Fallbacks))
+	}
+	if result.Fallbacks[0].ModelID != "qwen3.5-plus" {
+		t.Errorf("expected first fallback qwen3.5-plus, got %s", result.Fallbacks[0].ModelID)
+	}
+}


### PR DESCRIPTION
…ied model

Add a new config option `respect_requested_model` that, when enabled, allows users to override scenario-based routing via the model field in the request (e.g., set via cc-switch).Routing model is selected by user's cc-switch,ignore default scene routing strategy by config respect_requested_model.

When `respect_requested_model` is true and the request includes a model name, the proxy uses that model directly instead of running scenario detection.

Files changed:
- Config struct: add RespectRequestedModel field
- ModelRouter: check config + requested model in Route() and RouteForStreaming()
- MessagesHandler: pass anthropicReq.Model to router
- Default config template & example: add respect_requested_model: false