### PR TITLE
fix: use ~/.cache/oc-go-cc/tiktoken for token cache instead of /tmp (#41)

### DIFF
--- a/internal/token/counter.go
+++ b/internal/token/counter.go
@@ -33,7 +33,8 @@ func defaultCacheDir() string {
 
 // NewCounter creates a new token counter with cl100k_base encoding.
 func NewCounter() (*Counter, error) {
-	// Ensure tiktoken uses a writable cache directory before loading.
+	// Set process-wide env var before tiktoken loads any encoding files.
+	// This is safe because NewCounter is called once at startup.
 	_ = os.Setenv("TIKTOKEN_CACHE_DIR", defaultCacheDir())
 
 	enc, err := tiktoken.GetEncoding("cl100k_base")

--- a/internal/token/counter.go
+++ b/internal/token/counter.go
@@ -3,6 +3,8 @@ package token
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/pkoukk/tiktoken-go"
 )
@@ -12,8 +14,28 @@ type Counter struct {
 	tiktoken *tiktoken.Tiktoken
 }
 
+// defaultCacheDir returns a user-writable cache directory for tiktoken files.
+// Uses TIKTOKEN_CACHE_DIR or DATA_GYM_CACHE_DIR if already set; otherwise
+// defaults to ~/.cache/oc-go-cc/tiktoken to avoid /tmp permission issues.
+func defaultCacheDir() string {
+	if d := os.Getenv("TIKTOKEN_CACHE_DIR"); d != "" {
+		return d
+	}
+	if d := os.Getenv("DATA_GYM_CACHE_DIR"); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "data-gym-cache")
+	}
+	return filepath.Join(home, ".cache", "oc-go-cc", "tiktoken")
+}
+
 // NewCounter creates a new token counter with cl100k_base encoding.
 func NewCounter() (*Counter, error) {
+	// Ensure tiktoken uses a writable cache directory before loading.
+	_ = os.Setenv("TIKTOKEN_CACHE_DIR", defaultCacheDir())
+
 	enc, err := tiktoken.GetEncoding("cl100k_base")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get encoding: %w", err)

--- a/internal/token/counter_test.go
+++ b/internal/token/counter_test.go
@@ -1,0 +1,85 @@
+package token
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultCacheDir(t *testing.T) {
+	tests := []struct {
+		name          string
+		tiktokenCache string
+		datagymCache  string
+		homeDir       string
+		want          string
+	}{
+		{
+			name:          "respects TIKTOKEN_CACHE_DIR",
+			tiktokenCache: "/custom/path",
+			want:          "/custom/path",
+		},
+		{
+			name:         "respects DATA_GYM_CACHE_DIR",
+			datagymCache: "/other/path",
+			want:         "/other/path",
+		},
+		{
+			name: "falls back to home cache",
+			want: filepath.Join(mustHome(), ".cache", "oc-go-cc", "tiktoken"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.tiktokenCache != "" {
+				t.Setenv("TIKTOKEN_CACHE_DIR", tt.tiktokenCache)
+			} else {
+				t.Setenv("TIKTOKEN_CACHE_DIR", "")
+			}
+			if tt.datagymCache != "" {
+				t.Setenv("DATA_GYM_CACHE_DIR", tt.datagymCache)
+			} else {
+				t.Setenv("DATA_GYM_CACHE_DIR", "")
+			}
+
+			got := defaultCacheDir()
+			if got != tt.want {
+				t.Errorf("defaultCacheDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultCacheDir_HomeDirFallback(t *testing.T) {
+	// When UserHomeDir fails (HOME unset), fall back to temp dir.
+	t.Setenv("TIKTOKEN_CACHE_DIR", "")
+	t.Setenv("DATA_GYM_CACHE_DIR", "")
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", "")
+	t.Cleanup(func() { t.Setenv("HOME", origHome) })
+
+	got := defaultCacheDir()
+	want := filepath.Join(os.TempDir(), "data-gym-cache")
+	if got != want {
+		t.Errorf("defaultCacheDir() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultCacheDir_TiktokenTakesPrecedence(t *testing.T) {
+	t.Setenv("TIKTOKEN_CACHE_DIR", "/tiktoken/path")
+	t.Setenv("DATA_GYM_CACHE_DIR", "/datagym/path")
+
+	got := defaultCacheDir()
+	if got != "/tiktoken/path" {
+		t.Errorf("defaultCacheDir() = %q, want /tiktoken/path", got)
+	}
+}
+
+func mustHome() string {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return h
+}


### PR DESCRIPTION
Users without write permission to /tmp get "failed to create token counter" because tiktoken-go defaults cache to /tmp/data-gym-cache.

Fix: set TIKTOKEN_CACHE_DIR to ~/.cache/oc-go-cc/tiktoken when neither TIKTOKEN_CACHE_DIR nor DATA_GYM_CACHE_DIR is set. This is always user-writable and follows XDG convention.

Resolves #41