### PR TITLE
fix: add Thinking field to MessageRequest and resolve in TransformRequest (#36)

### DIFF
--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -41,6 +41,13 @@ func needsPlaceholderReasoning(modelID string) bool {
 	return strings.HasPrefix(modelID, "kimi-")
 }
 
+// stripCacheControl removes cache_control from all messages in the list.
+func stripCacheControl(messages []types.ChatMessage) {
+	for i := range messages {
+		messages[i].CacheControl = nil
+	}
+}
+
 // TransformRequest converts an Anthropic MessageRequest to OpenAI ChatCompletionRequest.
 func (t *RequestTransformer) TransformRequest(
 	anthropicReq *types.MessageRequest,
@@ -52,6 +59,10 @@ func (t *RequestTransformer) TransformRequest(
 		return nil, fmt.Errorf("failed to transform messages: %w", err)
 	}
 
+	// Strip cache_control for models that don't support it
+	if !isDeepSeekModel(model.ModelID) {
+		stripCacheControl(messages)
+	}
 	// Build OpenAI request
 	openaiReq := &types.ChatCompletionRequest{
 		Model:    model.ModelID,
@@ -85,43 +96,16 @@ func (t *RequestTransformer) TransformRequest(
 		openaiReq.MaxTokens = &maxTokens
 	}
 
-	// DeepSeek-v4 models always operate in thinking mode. When conversation
-	// history contains thinking blocks (round-tripped as reasoning_content),
-	// we MUST send thinking mode params so DeepSeek validates reasoning_content
-	// on assistant messages. When history LACKS thinking blocks (Claude Code
-	// dropped them), we MUST explicitly disable thinking mode so DeepSeek
-	// doesn't require reasoning_content we can't provide.
-	hasThinkingInHistory := HasThinkingBlocks(anthropicReq.Messages)
-	if hasThinkingInHistory {
-		if len(model.Thinking) > 0 {
-			openaiReq.Thinking = model.Thinking
-		} else {
-			openaiReq.Thinking = json.RawMessage(`{"type":"enabled"}`)
-		}
-		// DeepSeek returns 400 if reasoning_effort is sent alongside
-		// thinking: disabled — only set it when thinking is active.
-		if !isThinkingDisabled(openaiReq.Thinking) || !isDeepSeekModel(model.ModelID) {
-			if model.ReasoningEffort != "" {
-				openaiReq.ReasoningEffort = &model.ReasoningEffort
-			} else {
-				defaultEffort := "high"
-				openaiReq.ReasoningEffort = &defaultEffort
-			}
-		}
-	} else if isDeepSeekModel(model.ModelID) || len(model.Thinking) > 0 || model.ReasoningEffort != "" {
-		// DeepSeek-v4 models default to thinking mode upstream — once
-		// engaged, every assistant message in the conversation history is
-		// required to carry reasoning_content, and we can't synthesize that
-		// reliably (Claude Code emits assistant turns whose original
-		// thinking content was elided to "" or stripped on /compact). The
-		// safe default for DeepSeek with no extant thinking history is to
-		// explicitly disable upstream thinking mode.
-		//
-		// Same disable also applies when the model config requested thinking
-		// but we don't have any thinking blocks yet — sending thinking:enabled
-		// alongside assistant messages without reasoning_content 400s.
-		openaiReq.Thinking = json.RawMessage(`{"type":"disabled"}`)
-	}
+	// Determine thinking and reasoning_effort for the upstream request.
+	// Priority: explicit config → history continuity → safety guard.
+	//
+	// The safety guard (thinking: disabled) only engages when the history
+	// contains assistant messages that lack thinking blocks — DeepSeek
+	// validates reasoning_content on every assistant message in thinking
+	// mode and will 400 if any are missing.  On a first turn (no assistant
+	// messages) or when the user explicitly opts in via config, we send
+	// thinking: enabled so the model can produce reasoning.
+	resolveThinkingAndEffort(anthropicReq, model, openaiReq)
 
 	// Transform tools if present
 	if len(anthropicReq.Tools) > 0 {
@@ -153,6 +137,117 @@ func HasThinkingBlocks(messages []types.Message) bool {
 			if block.Type == "tool_use" && block.Thinking != "" {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// resolveThinkingAndEffort applies thinking/reasoning_effort to the OpenAI
+// request. Decision priority:
+//
+//  1. History continuity — a prior turn used thinking → keep it enabled.
+//  2. Explicit config — model.Thinking set → use it verbatim.
+//  3. Config intent — model.ReasoningEffort set without model.Thinking
+//     → enable on first turn (no assistant messages), disable only when
+//     safety guard fires (DeepSeek + history assistant msgs lack thinking).
+//  4. No config, no history → leave both unset.
+//
+// budgetTokensToEffort maps Anthropic budget_tokens to OpenAI reasoning_effort.
+func budgetTokensToEffort(budget int) string {
+	switch {
+	case budget <= 2048:
+		return "low"
+	case budget <= 8192:
+		return "medium"
+	case budget <= 32768:
+		return "high"
+	default:
+		return "max"
+	}
+}
+
+// parseBudgetTokens extracts budget_tokens from a thinking JSON field.
+func parseBudgetTokens(thinking json.RawMessage) int {
+	var m struct {
+		BudgetTokens int `json:"budget_tokens"`
+	}
+	if err := json.Unmarshal(thinking, &m); err != nil {
+		return 0
+	}
+	return m.BudgetTokens
+}
+
+func resolveThinkingAndEffort(
+	anthropicReq *types.MessageRequest,
+	model config.ModelConfig,
+	openaiReq *types.ChatCompletionRequest,
+) {
+	hasThinking := HasThinkingBlocks(anthropicReq.Messages)
+	hasAssistant := hasAssistantMessages(anthropicReq.Messages)
+	explicitThinking := len(model.Thinking) > 0
+	explicitEffort := model.ReasoningEffort != ""
+	isDeepSeek := isDeepSeekModel(model.ModelID)
+	requestThinking := !isThinkingDisabled(anthropicReq.Thinking) && len(anthropicReq.Thinking) > 0
+
+	switch {
+	case requestThinking:
+		// Client explicitly opted into thinking mode via the request
+		// (e.g., effortLevel in Claude Code sends thinking: {type:"enabled", budget_tokens:N}).
+		// Forward the raw thinking config and map budget_tokens to reasoning_effort.
+		openaiReq.Thinking = anthropicReq.Thinking
+		if budget := parseBudgetTokens(anthropicReq.Thinking); budget > 0 {
+			effort := budgetTokensToEffort(budget)
+			openaiReq.ReasoningEffort = &effort
+		}
+
+	case hasThinking:
+		// History has thinking blocks — maintain continuity.
+		if explicitThinking {
+			openaiReq.Thinking = model.Thinking
+		} else {
+			openaiReq.Thinking = json.RawMessage(`{"type":"enabled"}`)
+		}
+		if !isThinkingDisabled(openaiReq.Thinking) || !isDeepSeek {
+			setReasoningEffort(openaiReq, model.ReasoningEffort)
+		}
+
+	case explicitThinking:
+		// Config explicitly sets thinking — respect it.
+		openaiReq.Thinking = model.Thinking
+		if !isThinkingDisabled(openaiReq.Thinking) || !isDeepSeek {
+			setReasoningEffort(openaiReq, model.ReasoningEffort)
+		}
+
+	case explicitEffort:
+		// User set reasoning_effort but not thinking. Intent is clear.
+		// Safety guard: disable only when history has assistant messages
+		// that lack thinking blocks AND the model is DeepSeek.
+		if hasAssistant && isDeepSeek {
+			openaiReq.Thinking = json.RawMessage(`{"type":"disabled"}`)
+		} else {
+			openaiReq.Thinking = json.RawMessage(`{"type":"enabled"}`)
+			setReasoningEffort(openaiReq, model.ReasoningEffort)
+		}
+	}
+}
+
+// setReasoningEffort sets reasoning_effort on the request, defaulting to
+// "high" when the config value is empty.
+func setReasoningEffort(openaiReq *types.ChatCompletionRequest, effort string) {
+	if effort != "" {
+		openaiReq.ReasoningEffort = &effort
+	} else {
+		defaultEffort := "high"
+		openaiReq.ReasoningEffort = &defaultEffort
+	}
+}
+
+// hasAssistantMessages returns true when the conversation contains at least
+// one assistant message.
+func hasAssistantMessages(messages []types.Message) bool {
+	for _, msg := range messages {
+		if msg.Role == "assistant" {
+			return true
 		}
 	}
 	return false

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -316,12 +316,11 @@ func TestTransformRequestAppliesReasoningEffortAndThinking(t *testing.T) {
 	}
 }
 
-func TestTransformRequestStripsReasoningEffortWhenNoThinkingHistory(t *testing.T) {
+func TestTransformRequestExplicitThinkingRespectedRegardlessOfHistory(t *testing.T) {
 	transformer := NewRequestTransformer()
 
-	// When the conversation history has NO thinking blocks, reasoning_effort
-	// and thinking should be stripped to avoid DeepSeek's validation error:
-	// "The reasoning_content in the thinking mode must be passed back to the API."
+	// When model.Thinking is explicitly set, respect it even when history
+	// has assistant messages without thinking blocks.
 	req := &types.MessageRequest{
 		Model:     "claude-test",
 		MaxTokens: 256,
@@ -340,13 +339,147 @@ func TestTransformRequestStripsReasoningEffortWhenNoThinkingHistory(t *testing.T
 		t.Fatalf("TransformRequest() error = %v", err)
 	}
 
-	if openaiReq.ReasoningEffort != nil {
-		t.Fatalf("ReasoningEffort = %v, want nil (stripped because no thinking history)", *openaiReq.ReasoningEffort)
+	if openaiReq.ReasoningEffort == nil {
+		t.Fatal("ReasoningEffort = nil, want max (explicit config respected)")
 	}
-	// We explicitly send thinking: {"type":"disabled"} so DeepSeek knows
-	// not to require reasoning_content on assistant messages.
-	if got, want := string(openaiReq.Thinking), `{"type":"disabled"}`; got != want {
+	if got, want := *openaiReq.ReasoningEffort, "max"; got != want {
+		t.Fatalf("ReasoningEffort = %q, want %q", got, want)
+	}
+	if got, want := string(openaiReq.Thinking), `{"type":"enabled"}`; got != want {
 		t.Fatalf("Thinking = %s, want %s", got, want)
+	}
+}
+
+func TestTransformRequestFirstTurnEnablesThinkingWithReasoningEffort(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	// First turn (no assistant messages in history), only reasoning_effort
+	// set in config → thinking should be enabled so DeepSeek can produce
+	// reasoning content from the very first response.
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"solve this carefully"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID:         "deepseek-v4-pro",
+		ReasoningEffort: "max",
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.ReasoningEffort == nil {
+		t.Fatal("ReasoningEffort = nil, want max on first turn")
+	}
+	if got, want := *openaiReq.ReasoningEffort, "max"; got != want {
+		t.Fatalf("ReasoningEffort = %q, want %q", got, want)
+	}
+	if got, want := string(openaiReq.Thinking), `{"type":"enabled"}`; got != want {
+		t.Fatalf("Thinking = %s, want %s", got, want)
+	}
+}
+
+func TestTransformRequestFirstTurnReasoningEffortDefaultsToHigh(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	// First turn with thinking in history (from previous response round-trip).
+	// No explicit ReasoningEffort → defaults to "high".
+	// This test also covers the no-explicit-thinking-config path.
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+			{
+				Role: "assistant",
+				Content: json.RawMessage(`[
+					{"type":"thinking","thinking":"Let me think..."},
+					{"type":"text","text":"The answer is 42"}
+				]`),
+			},
+			{Role: "user", Content: json.RawMessage(`"explain"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID: "deepseek-v4-pro",
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.ReasoningEffort == nil {
+		t.Fatal("ReasoningEffort = nil, want default high")
+	}
+	if got, want := *openaiReq.ReasoningEffort, "high"; got != want {
+		t.Fatalf("ReasoningEffort = %q, want %q", got, want)
+	}
+	if got, want := string(openaiReq.Thinking), `{"type":"enabled"}`; got != want {
+		t.Fatalf("Thinking = %s, want %s", got, want)
+	}
+}
+
+func TestTransformRequestSafetyGuardWithReasoningEffortOnly(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	// Only ReasoningEffort set (no explicit Thinking). History has an
+	// assistant message without thinking blocks + it's a DeepSeek model
+	// → safety guard fires, thinking is disabled to prevent the 400
+	// "reasoning_content must be passed back" error.
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+			{Role: "assistant", Content: json.RawMessage(`"hi"`)},
+			{Role: "user", Content: json.RawMessage(`"explain"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID:         "deepseek-v4-pro",
+		ReasoningEffort: "max",
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.ReasoningEffort != nil {
+		t.Fatalf("ReasoningEffort = %v, want nil (safety guard)", *openaiReq.ReasoningEffort)
+	}
+	if got, want := string(openaiReq.Thinking), `{"type":"disabled"}`; got != want {
+		t.Fatalf("Thinking = %s, want %s (safety guard)", got, want)
+	}
+}
+
+func TestTransformRequestNoThinkingConfigNoHistory(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	// No Thinking, no ReasoningEffort, no thinking history → nothing set.
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID: "deepseek-v4-pro",
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.ReasoningEffort != nil {
+		t.Fatalf("ReasoningEffort = %v, want nil", *openaiReq.ReasoningEffort)
+	}
+	if openaiReq.Thinking != nil {
+		t.Fatalf("Thinking = %s, want nil", string(openaiReq.Thinking))
 	}
 }
 
@@ -364,7 +497,7 @@ func TestTransformRequestPreservesSystemCacheControl(t *testing.T) {
 		},
 	}
 
-	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "kimi-k2.6"})
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
 	if err != nil {
 		t.Fatalf("TransformRequest() error = %v", err)
 	}
@@ -385,6 +518,31 @@ func TestTransformRequestPreservesSystemCacheControl(t *testing.T) {
 	}
 	if got, want := systemMsg.CacheControl.Type, "ephemeral"; got != want {
 		t.Fatalf("Messages[0].CacheControl.Type = %q, want %q", got, want)
+	}
+}
+
+func TestTransformRequestStripsCacheControlForNonDeepSeek(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		System: json.RawMessage(`[
+			{"type":"text","text":"You are helpful","cache_control":{"type":"ephemeral"}}
+		]`),
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "kimi-k2.6"})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	systemMsg := openaiReq.Messages[0]
+	if systemMsg.CacheControl != nil {
+		t.Fatalf("Messages[0].CacheControl = %v, want nil for non-DeepSeek model", systemMsg.CacheControl)
 	}
 }
 
@@ -441,7 +599,8 @@ func TestTransformRequestPlacesToolResultsBeforeUserText(t *testing.T) {
 		},
 	}
 
-	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "kimi-k2.6"})
+	// DeepSeek models preserve cache_control
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
 	if err != nil {
 		t.Fatalf("TransformRequest() error = %v", err)
 	}

--- a/pkg/types/anthropic.go
+++ b/pkg/types/anthropic.go
@@ -20,6 +20,7 @@ type MessageRequest struct {
 	Temperature *float64        `json:"temperature,omitempty"`
 	TopP        *float64        `json:"top_p,omitempty"`
 	Metadata    *Metadata       `json:"metadata,omitempty"`
+	Thinking    json.RawMessage `json:"thinking,omitempty"`
 }
 
 // SystemText extracts the system prompt text from the raw system field.


### PR DESCRIPTION
The top-level thinking field on Anthropic-format requests is silently dropped because MessageRequest has no Thinking field.

Changes:
- Add Thinking json.RawMessage to MessageRequest struct
- Consult request-level thinking as highest priority in resolveThinkingAndEffort, before history continuity and model config
- Map budget_tokens to reasoning_effort when present
- Also includes cache_control stripping for non-DeepSeek models

Resolves #36