### PR TITLE
feat: add model_overrides for per-request model selection

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -187,7 +187,7 @@ Each model also has a **circuit breaker** that tracks consecutive failures. Afte
 
 `model_overrides` lets you map a specific client-requested model name (the value of the `model` field in `/v1/messages`) to a fixed `ModelConfig`. This is useful when you want clients to be able to request a particular model (e.g. `claude-sonnet-4.5`) without that model going through the scenario router.
 
-When a request arrives, the proxy checks `model_overrides[<model>]` **first**. If the requested model has an entry, the override is used as the primary. The scenario-routed chain is then appended as a **safety-net fallback** (deduplicated by `model_id`).
+When a request arrives, the proxy checks `model_overrides[<model>]` **first**. If the requested model has an entry, the override is used as the primary. The fallback chain is `fallbacks[<model>]`, falling back to `fallbacks["default"]` if no override-specific entry exists. The scenario-routed chain is then appended as a **safety-net fallback** (deduplicated by `model_id`).
 
 ```json
 {

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -66,6 +66,15 @@ Override with `OC_GO_CC_CONFIG` environment variable.
     "fast": [{ "provider": "opencode-go", "model_id": "qwen3.5-plus" }]
   },
 
+  "model_overrides": {
+    "claude-sonnet-4.5": {
+      "provider": "opencode-zen",
+      "model_id": "claude-sonnet-4.5",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    }
+  },
+
   "opencode_go": {
     "base_url": "https://opencode.ai/zen/go/v1/chat/completions",
     "anthropic_base_url": "https://opencode.ai/zen/go/v1/messages",
@@ -173,3 +182,34 @@ Primary model -> Fallback 1 -> Fallback 2 -> ... -> Error (all failed)
 ```
 
 Each model also has a **circuit breaker** that tracks consecutive failures. After 3 failures, the circuit opens and that model is skipped for 30 seconds, then tested again (half-open state).
+
+## Model Overrides (`model_overrides`)
+
+`model_overrides` lets you map a specific client-requested model name (the value of the `model` field in `/v1/messages`) to a fixed `ModelConfig`. This is useful when you want clients to be able to request a particular model (e.g. `claude-sonnet-4.5`) without that model going through the scenario router.
+
+When a request arrives, the proxy checks `model_overrides[<model>]` **first**. If the requested model has an entry, the override is used as the primary. The scenario-routed chain is then appended as a **safety-net fallback** (deduplicated by `model_id`).
+
+```json
+{
+  "model_overrides": {
+    "claude-sonnet-4.5": {
+      "provider": "opencode-zen",
+      "model_id": "claude-sonnet-4.5",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    }
+  }
+}
+```
+
+Each entry accepts the same fields as a `ModelConfig` (`provider`, `model_id`, `temperature`, `max_tokens`, `reasoning_effort`, `thinking`, etc.). `model_id` is required; `provider` must be `"opencode-go"` or `"opencode-zen"` (or omitted to inherit the default).
+
+### Routing precedence
+
+When a request arrives, the proxy selects a model chain using the following order:
+
+1. **`model_overrides[<model>]`** — if the request's `model` field has an entry, use it as the primary and append the scenario chain as a safety net.
+2. **`respect_requested_model`** — if enabled and `models[<model>]` is configured, use the requested model with default fallbacks.
+3. **Scenario routing** — fall back to the scenario chain (`default`, `background`, `think`, `complex`, `long_context`, `fast`).
+
+> **Trust model:** any client whose requests flow through the proxy can select from the configured `model_overrides` set without additional authentication. If you run the proxy as a shared service, treat `model_overrides` as a privileged allowlist.

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -93,6 +93,15 @@
     ]
   },
 
+  "model_overrides": {
+    "claude-sonnet-4.5": {
+      "provider": "opencode-zen",
+      "model_id": "claude-sonnet-4.5",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    }
+  },
+
   "opencode_go": {
     "base_url": "https://opencode.ai/zen/go/v1/chat/completions",
     "anthropic_base_url": "https://opencode.ai/zen/go/v1/messages",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	RespectRequestedModel          bool                     `json:"respect_requested_model"`
 	Models                         map[string]ModelConfig   `json:"models"`
 	Fallbacks                      map[string][]ModelConfig `json:"fallbacks"`
+	ModelOverrides                 map[string]ModelConfig   `json:"model_overrides"`
 	OpenCodeGo                     OpenCodeGoConfig         `json:"opencode_go"`
 	Logging                        LoggingConfig            `json:"logging"`
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -140,6 +140,12 @@ func applyDefaults(cfg *Config) {
 	if cfg.Logging.Level == "" {
 		cfg.Logging.Level = defaultLogLevel
 	}
+	if cfg.Fallbacks == nil {
+		cfg.Fallbacks = make(map[string][]ModelConfig)
+	}
+	if cfg.ModelOverrides == nil {
+		cfg.ModelOverrides = make(map[string]ModelConfig)
+	}
 }
 
 // validate checks that all required configuration fields are present.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -176,5 +176,25 @@ func validate(cfg *Config) error {
 	if cfg.APIKey == "" {
 		return fmt.Errorf("api_key is required (set via config file or OC_GO_CC_API_KEY env var)")
 	}
+
+	if err := validateModelOverrides(cfg.ModelOverrides); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateModelOverrides ensures each override entry has a non-empty model_id
+// and a recognized provider. Empty model_id would produce broken upstream URLs
+// (surfacing far from the config error); an unknown provider would silently
+// fall through to defaults at request time.
+func validateModelOverrides(overrides map[string]ModelConfig) error {
+	for key, mc := range overrides {
+		if mc.ModelID == "" {
+			return fmt.Errorf("model_overrides[%q] is missing required field model_id", key)
+		}
+		if mc.Provider != "" && mc.Provider != "opencode-go" && mc.Provider != "opencode-zen" {
+			return fmt.Errorf("model_overrides[%q] has invalid provider %q (must be \"opencode-go\" or \"opencode-zen\")", key, mc.Provider)
+		}
+	}
 	return nil
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -225,6 +225,71 @@ func TestInterpolateEnvVars(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_InitializesNilMaps(t *testing.T) {
+	cfg := &Config{APIKey: "test"}
+	applyDefaults(cfg)
+	if cfg.Fallbacks == nil {
+		t.Error("applyDefaults should initialize Fallbacks to non-nil map")
+	}
+	if cfg.ModelOverrides == nil {
+		t.Error("applyDefaults should initialize ModelOverrides to non-nil map")
+	}
+	// Both maps should be writable (read-then-write) without panicking.
+	cfg.Fallbacks["default"] = nil
+	cfg.ModelOverrides["kimi-k2.6"] = ModelConfig{}
+}
+
+func TestValidateModelOverrides_EmptyModelID(t *testing.T) {
+	cfg := &Config{
+		APIKey: "test",
+		ModelOverrides: map[string]ModelConfig{
+			"bad-entry": {Provider: "opencode-go", ModelID: ""},
+		},
+	}
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected validation error for empty model_id, got nil")
+	}
+}
+
+func TestValidateModelOverrides_InvalidProvider(t *testing.T) {
+	cfg := &Config{
+		APIKey: "test",
+		ModelOverrides: map[string]ModelConfig{
+			"bad-provider": {Provider: "unknown-provider", ModelID: "some-model"},
+		},
+	}
+	if err := validate(cfg); err == nil {
+		t.Fatal("expected validation error for unknown provider, got nil")
+	}
+}
+
+func TestValidateModelOverrides_EmptyProviderOK(t *testing.T) {
+	// Empty provider should be allowed (defaults to opencode-go at request time).
+	cfg := &Config{
+		APIKey: "test",
+		ModelOverrides: map[string]ModelConfig{
+			"good-entry": {ModelID: "kimi-k2.6"},
+		},
+	}
+	if err := validate(cfg); err != nil {
+		t.Errorf("expected no validation error for empty provider, got %v", err)
+	}
+}
+
+func TestValidateModelOverrides_AllValidProviders(t *testing.T) {
+	cfg := &Config{
+		APIKey: "test",
+		ModelOverrides: map[string]ModelConfig{
+			"a": {Provider: "opencode-go", ModelID: "m1"},
+			"b": {Provider: "opencode-zen", ModelID: "m2"},
+			"c": {ModelID: "m3"},
+		},
+	}
+	if err := validate(cfg); err != nil {
+		t.Errorf("expected no validation error, got %v", err)
+	}
+}
+
 func TestExpandHome(t *testing.T) {
 	home, _ := os.UserHomeDir()
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -64,6 +64,83 @@ func TestLoadJSON(t *testing.T) {
 	}
 }
 
+func TestLoadJSON_WithModelOverrides(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{
+		"api_key": "test-key",
+		"model_overrides": {
+			"claude-sonnet-4.5": {
+				"provider": "opencode-zen",
+				"model_id": "claude-sonnet-4.5",
+				"temperature": 0.5,
+				"max_tokens": 4096
+			}
+		}
+	}`
+
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	defer func() { _ = os.Unsetenv("OC_GO_CC_CONFIG") }()
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	entry, ok := cfg.ModelOverrides["claude-sonnet-4.5"]
+	if !ok {
+		t.Fatal("expected model_overrides[\"claude-sonnet-4.5\"] to be present after Load()")
+	}
+	if entry.Provider != "opencode-zen" {
+		t.Errorf("Provider = %q, want %q", entry.Provider, "opencode-zen")
+	}
+	if entry.ModelID != "claude-sonnet-4.5" {
+		t.Errorf("ModelID = %q, want %q", entry.ModelID, "claude-sonnet-4.5")
+	}
+	if entry.Temperature != 0.5 {
+		t.Errorf("Temperature = %f, want 0.5", entry.Temperature)
+	}
+	if entry.MaxTokens != 4096 {
+		t.Errorf("MaxTokens = %d, want 4096", entry.MaxTokens)
+	}
+}
+
+func TestLoadJSON_ModelOverrides_InvalidEntryRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{
+		"api_key": "test-key",
+		"model_overrides": {
+			"bad-entry": {
+				"provider": "opencode-go"
+			}
+		}
+	}`
+
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	defer func() { _ = os.Unsetenv("OC_GO_CC_CONFIG") }()
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	if _, err := Load(); err == nil {
+		t.Fatal("expected Load() to fail validation for empty model_id, got nil")
+	}
+}
+
 func TestLoadMissingAPIKey(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.json")

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -178,20 +178,28 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Route to appropriate model.
-	// If the request specifies a model override, use it directly.
-	// Otherwise, use scenario-based routing.
-	requestedModel := anthropicReq.Model
-
 	var routeResult router.RouteResult
-	if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
-		// Streaming: use faster models to minimize TTFT (time-to-first-token)
-		routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount, requestedModel)
-	} else {
-		var err error
-		routeResult, err = h.modelRouter.Route(routerMessages, tokenCount, requestedModel)
-		if err != nil {
-			h.sendError(w, http.StatusInternalServerError, "routing failed", err)
-			return
+	var isOverride bool
+
+	// Check model_overrides first
+	if anthropicReq.Model != "" {
+		if overrideResult, ok := h.modelRouter.RouteWithOverride(anthropicReq.Model); ok {
+			routeResult = overrideResult
+			isOverride = true
+		}
+	}
+
+	if !isOverride {
+		if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
+			// Streaming: use faster models to minimize TTFT (time-to-first-token)
+			routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount)
+		} else {
+			var err error
+			routeResult, err = h.modelRouter.Route(routerMessages, tokenCount)
+			if err != nil {
+				h.sendError(w, http.StatusInternalServerError, "routing failed", err)
+				return
+			}
 		}
 	}
 
@@ -203,6 +211,21 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 
 	// Build fallback chain.
 	modelChain := routeResult.GetModelChain()
+
+	if isOverride {
+		// Append scenario fallback chain as safety net
+		var scenarioResult router.RouteResult
+		var scenarioErr error
+		if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
+			scenarioResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount)
+		} else {
+			scenarioResult, scenarioErr = h.modelRouter.Route(routerMessages, tokenCount)
+		}
+		if scenarioErr == nil {
+			scenarioChain := scenarioResult.GetModelChain()
+			modelChain = append(modelChain, scenarioChain...)
+		}
+	}
 
 	if isStreaming {
 		// Streaming: use ProxyStream for real-time SSE transformation

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -190,12 +190,13 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 	}
 
 	if !isOverride {
+		requestedModel := anthropicReq.Model
 		if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
 			// Streaming: use faster models to minimize TTFT (time-to-first-token)
-			routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount)
+			routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount, requestedModel)
 		} else {
 			var err error
-			routeResult, err = h.modelRouter.Route(routerMessages, tokenCount)
+			routeResult, err = h.modelRouter.Route(routerMessages, tokenCount, requestedModel)
 			if err != nil {
 				h.sendError(w, http.StatusInternalServerError, "routing failed", err)
 				return
@@ -217,9 +218,9 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 		var scenarioResult router.RouteResult
 		var scenarioErr error
 		if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
-			scenarioResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount)
+			scenarioResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount, "")
 		} else {
-			scenarioResult, scenarioErr = h.modelRouter.Route(routerMessages, tokenCount)
+			scenarioResult, scenarioErr = h.modelRouter.Route(routerMessages, tokenCount, "")
 		}
 		if scenarioErr == nil {
 			scenarioChain := scenarioResult.GetModelChain()

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -177,25 +177,11 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 		tokenCount = 0
 	}
 
-	// Route to appropriate model.
-	var routeResult router.RouteResult
-	var isOverride bool
-
-	// Check model_overrides first
-	if anthropicReq.Model != "" {
-		if overrideResult, ok := h.modelRouter.RouteWithOverride(anthropicReq.Model); ok {
-			routeResult = overrideResult
-			isOverride = true
-		}
-	}
-
-	if !isOverride {
-		var err error
-		routeResult, err = h.routeOnce(routerMessages, tokenCount, anthropicReq.Model, isStreaming)
-		if err != nil {
-			h.sendError(w, http.StatusInternalServerError, "routing failed", err)
-			return
-		}
+	// Route to appropriate model and build fallback chain.
+	modelChain, routeResult, err := h.buildModelChain(anthropicReq.Model, routerMessages, tokenCount, isStreaming)
+	if err != nil {
+		h.sendError(w, http.StatusInternalServerError, "routing failed", err)
+		return
 	}
 
 	h.logger.Info("routing request",
@@ -205,17 +191,6 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 		"tokens", tokenCount,
 	)
 
-	// Build fallback chain.
-	modelChain := routeResult.GetModelChain()
-
-	if isOverride {
-		// Append scenario fallback chain as safety net (deduplicated by ModelID).
-		scenarioResult, err := h.routeOnce(routerMessages, tokenCount, "", isStreaming)
-		if err == nil {
-			modelChain = appendUniqueModels(modelChain, scenarioResult.GetModelChain())
-		}
-	}
-
 	if isStreaming {
 		// Streaming: use ProxyStream for real-time SSE transformation
 		h.handleStreaming(w, r, &anthropicReq, modelChain, rawBody)
@@ -223,6 +198,40 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 		// Non-streaming: execute with fallback and return full response
 		h.handleNonStreaming(w, r, &anthropicReq, modelChain, rawBody)
 	}
+}
+
+// buildModelChain resolves the request to a model chain (primary + fallbacks),
+// honoring model_overrides (with a deduplicated scenario safety-net) and
+// respecting the streaming-scenario-routing toggle.
+//
+// Precedence:
+//  1. If requestedModel matches an entry in model_overrides, use that as the
+//     primary and append the scenario chain as a deduplicated safety net.
+//  2. Otherwise, fall through to scenario-based routing via routeOnce.
+func (h *MessagesHandler) buildModelChain(
+	requestedModel string,
+	routerMessages []router.MessageContent,
+	tokenCount int,
+	isStreaming bool,
+) ([]config.ModelConfig, router.RouteResult, error) {
+	if requestedModel != "" {
+		if overrideResult, ok := h.modelRouter.RouteWithOverride(requestedModel); ok {
+			scenarioResult, err := h.routeOnce(routerMessages, tokenCount, "", isStreaming)
+			if err != nil {
+				// Override is valid; surface the scenario routing error rather
+				// than silently dropping the safety net.
+				return overrideResult.GetModelChain(), overrideResult, err
+			}
+			chain := appendUniqueModels(overrideResult.GetModelChain(), scenarioResult.GetModelChain())
+			return chain, overrideResult, nil
+		}
+	}
+
+	result, err := h.routeOnce(routerMessages, tokenCount, requestedModel, isStreaming)
+	if err != nil {
+		return nil, result, err
+	}
+	return result.GetModelChain(), result, nil
 }
 
 // routeOnce performs scenario-based routing, honoring the streaming-scenario-routing

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -190,17 +190,11 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 	}
 
 	if !isOverride {
-		requestedModel := anthropicReq.Model
-		if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
-			// Streaming: use faster models to minimize TTFT (time-to-first-token)
-			routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount, requestedModel)
-		} else {
-			var err error
-			routeResult, err = h.modelRouter.Route(routerMessages, tokenCount, requestedModel)
-			if err != nil {
-				h.sendError(w, http.StatusInternalServerError, "routing failed", err)
-				return
-			}
+		var err error
+		routeResult, err = h.routeOnce(routerMessages, tokenCount, anthropicReq.Model, isStreaming)
+		if err != nil {
+			h.sendError(w, http.StatusInternalServerError, "routing failed", err)
+			return
 		}
 	}
 
@@ -215,17 +209,10 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 	modelChain := routeResult.GetModelChain()
 
 	if isOverride {
-		// Append scenario fallback chain as safety net
-		var scenarioResult router.RouteResult
-		var scenarioErr error
-		if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
-			scenarioResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount, "")
-		} else {
-			scenarioResult, scenarioErr = h.modelRouter.Route(routerMessages, tokenCount, "")
-		}
-		if scenarioErr == nil {
-			scenarioChain := scenarioResult.GetModelChain()
-			modelChain = append(modelChain, scenarioChain...)
+		// Append scenario fallback chain as safety net (deduplicated by ModelID).
+		scenarioResult, err := h.routeOnce(routerMessages, tokenCount, "", isStreaming)
+		if err == nil {
+			modelChain = appendUniqueModels(modelChain, scenarioResult.GetModelChain())
 		}
 	}
 
@@ -236,6 +223,44 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 		// Non-streaming: execute with fallback and return full response
 		h.handleNonStreaming(w, r, &anthropicReq, modelChain, rawBody)
 	}
+}
+
+// routeOnce performs scenario-based routing, honoring the streaming-scenario-routing
+// toggle. Pass requestedModel="" to force scenario routing (used for the override
+// safety-net chain), or a non-empty value to let resolveRequestedModel kick in
+// (only when respect_requested_model is enabled and no override matched).
+func (h *MessagesHandler) routeOnce(
+	routerMessages []router.MessageContent,
+	tokenCount int,
+	requestedModel string,
+	isStreaming bool,
+) (router.RouteResult, error) {
+	if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
+		// Streaming: use faster models to minimize TTFT (time-to-first-token)
+		return h.modelRouter.RouteForStreaming(routerMessages, tokenCount, requestedModel), nil
+	}
+	return h.modelRouter.Route(routerMessages, tokenCount, requestedModel)
+}
+
+// appendUniqueModels appends models from extra to base, skipping any model_id
+// already present in base. The first occurrence of a ModelID is kept; later
+// duplicates are dropped. Order of the base chain is preserved.
+func appendUniqueModels(base, extra []config.ModelConfig) []config.ModelConfig {
+	if len(extra) == 0 {
+		return base
+	}
+	seen := make(map[string]struct{}, len(base))
+	for _, m := range base {
+		seen[m.ModelID] = struct{}{}
+	}
+	for _, m := range extra {
+		if _, ok := seen[m.ModelID]; ok {
+			continue
+		}
+		base = append(base, m)
+		seen[m.ModelID] = struct{}{}
+	}
+	return base
 }
 
 // handleStreaming handles a streaming request with real-time SSE proxying.

--- a/internal/handlers/messages_test.go
+++ b/internal/handlers/messages_test.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"log/slog"
 	"testing"
 
 	"oc-go-cc/internal/config"
+	"oc-go-cc/internal/router"
 )
 
 func TestAppendUniqueModels_DedupsByModelID(t *testing.T) {
@@ -92,4 +94,232 @@ func TestAppendUniqueModels_EmptyBase(t *testing.T) {
 	if len(got) != 2 {
 		t.Errorf("expected 2 models, got %d (got=%+v)", len(got), got)
 	}
+}
+
+// newTestMessagesHandler returns a MessagesHandler wired with a real ModelRouter
+// and a non-nil logger. Other dependencies (client, fallbackHandler, metrics)
+// are nil — these tests only exercise buildModelChain, which uses modelRouter.
+func newTestMessagesHandler(t *testing.T, cfg *config.Config) *MessagesHandler {
+	t.Helper()
+	return &MessagesHandler{
+		modelRouter: router.NewModelRouter(config.NewAtomicConfig(cfg, "/tmp/test-config.json")),
+		logger:      slog.Default(),
+	}
+}
+
+func chainIDs(chain []config.ModelConfig) []string {
+	out := make([]string, len(chain))
+	for i, m := range chain {
+		out[i] = m.ModelID
+	}
+	return out
+}
+
+func TestBuildModelChain_NoOverride_UsesScenarioRoute(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"default": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {
+				{Provider: "opencode-go", ModelID: "mimo-v2-pro"},
+				{Provider: "opencode-go", ModelID: "qwen3.6-plus"},
+			},
+		},
+	}
+	h := newTestMessagesHandler(t, cfg)
+
+	chain, result, err := h.buildModelChain("", nil, 100, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"kimi-k2.6", "mimo-v2-pro", "qwen3.6-plus"}
+	if got := chainIDs(chain); !equalStrings(got, want) {
+		t.Errorf("chain = %v, want %v", got, want)
+	}
+	if result.Scenario != router.ScenarioDefault {
+		t.Errorf("scenario = %s, want %s", result.Scenario, router.ScenarioDefault)
+	}
+}
+
+func TestBuildModelChain_Override_AppendsScenarioChainDeduped(t *testing.T) {
+	// The override's primary overlaps with the default scenario's primary.
+	// The dedup logic must drop the duplicate.
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"default": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {
+				{Provider: "opencode-go", ModelID: "mimo-v2-pro"},
+				{Provider: "opencode-go", ModelID: "qwen3.6-plus"},
+			},
+		},
+		ModelOverrides: map[string]config.ModelConfig{
+			"kimi-k2.6": {
+				Provider:    "opencode-zen",
+				ModelID:     "kimi-k2.6",
+				Temperature: 0.3,
+				MaxTokens:   2048,
+			},
+		},
+	}
+	h := newTestMessagesHandler(t, cfg)
+
+	chain, result, err := h.buildModelChain("kimi-k2.6", nil, 100, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Order: [override.primary=kimi-k2.6, scenario.primary=kimi-k2.6 (DROPPED), scenario.fallbacks...]
+	// Final chain: [kimi-k2.6, mimo-v2-pro, qwen3.6-plus]
+	want := []string{"kimi-k2.6", "mimo-v2-pro", "qwen3.6-plus"}
+	if got := chainIDs(chain); !equalStrings(got, want) {
+		t.Errorf("chain = %v, want %v (dedup must drop scenario.primary that overlaps override.primary)", got, want)
+	}
+
+	// Primary must come from the override (preserving the override's settings).
+	if result.Primary.Temperature != 0.3 {
+		t.Errorf("primary.Temperature = %f, want 0.3 (override settings must be preserved)", result.Primary.Temperature)
+	}
+	if result.Scenario != router.ScenarioOverride {
+		t.Errorf("scenario = %s, want %s", result.Scenario, router.ScenarioOverride)
+	}
+}
+
+func TestBuildModelChain_Override_AppendsUniqueScenarioModels(t *testing.T) {
+	// Override primary does NOT overlap with the scenario chain.
+	// Result: override primary + override fallbacks + (scenario primary, dedup check, scenario fallbacks).
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"default": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {
+				{Provider: "opencode-go", ModelID: "mimo-v2-pro"},
+			},
+		},
+		ModelOverrides: map[string]config.ModelConfig{
+			"claude-sonnet-4.5": {
+				Provider: "opencode-zen",
+				ModelID:  "claude-sonnet-4.5",
+			},
+		},
+	}
+	h := newTestMessagesHandler(t, cfg)
+
+	chain, result, err := h.buildModelChain("claude-sonnet-4.5", nil, 100, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"claude-sonnet-4.5", "kimi-k2.6", "mimo-v2-pro"}
+	if got := chainIDs(chain); !equalStrings(got, want) {
+		t.Errorf("chain = %v, want %v", got, want)
+	}
+	if result.Scenario != router.ScenarioOverride {
+		t.Errorf("scenario = %s, want %s", result.Scenario, router.ScenarioOverride)
+	}
+}
+
+func TestBuildModelChain_Override_NoMatchingFallbacksKey(t *testing.T) {
+	// Override has no entry in fallbacks[]. The chain should be the override
+	// primary alone, then the scenario chain appended.
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"default": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {
+				{Provider: "opencode-go", ModelID: "mimo-v2-pro"},
+			},
+		},
+		ModelOverrides: map[string]config.ModelConfig{
+			"claude-sonnet-4.5": {Provider: "opencode-zen", ModelID: "claude-sonnet-4.5"},
+		},
+	}
+	h := newTestMessagesHandler(t, cfg)
+
+	chain, _, err := h.buildModelChain("claude-sonnet-4.5", nil, 100, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"claude-sonnet-4.5", "kimi-k2.6", "mimo-v2-pro"}
+	if got := chainIDs(chain); !equalStrings(got, want) {
+		t.Errorf("chain = %v, want %v", got, want)
+	}
+}
+
+func TestBuildModelChain_StreamingFlag_UsesStreamingRoute(t *testing.T) {
+	// With streaming + EnableStreamingScenarioRouting=false, the safety-net
+	// append should use the streaming route (RouteForStreaming), not Route.
+	cfg := &config.Config{
+		EnableStreamingScenarioRouting: false,
+		Models: map[string]config.ModelConfig{
+			"default": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+			"fast":    {Provider: "opencode-go", ModelID: "qwen3.6-plus"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {{ModelID: "mimo-v2-pro"}},
+			"fast":    {{ModelID: "qwen3.5-plus"}},
+		},
+		ModelOverrides: map[string]config.ModelConfig{
+			"claude-sonnet-4.5": {Provider: "opencode-zen", ModelID: "claude-sonnet-4.5"},
+		},
+	}
+	h := newTestMessagesHandler(t, cfg)
+
+	// Non-streaming: scenario is default
+	_, resultNonStream, _ := h.buildModelChain("claude-sonnet-4.5", nil, 100, false)
+	if resultNonStream.Scenario != router.ScenarioOverride {
+		t.Errorf("non-streaming scenario = %s, want %s", resultNonStream.Scenario, router.ScenarioOverride)
+	}
+
+	// Streaming: override still wins, but the safety-net uses fast route.
+	chain, _, _ := h.buildModelChain("claude-sonnet-4.5", nil, 100, true)
+	want := []string{"claude-sonnet-4.5", "qwen3.6-plus", "qwen3.5-plus"}
+	if got := chainIDs(chain); !equalStrings(got, want) {
+		t.Errorf("streaming chain = %v, want %v (safety-net should use RouteForStreaming)", got, want)
+	}
+}
+
+func TestBuildModelChain_UnknownModel_FallsThroughToScenarioRoute(t *testing.T) {
+	// Requested model has no entry in model_overrides and not in models map,
+	// and respect_requested_model is false → scenario routing.
+	cfg := &config.Config{
+		RespectRequestedModel: false,
+		Models: map[string]config.ModelConfig{
+			"default": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {{ModelID: "mimo-v2-pro"}},
+		},
+		ModelOverrides: map[string]config.ModelConfig{
+			"some-other-model": {Provider: "opencode-zen", ModelID: "some-other-model"},
+		},
+	}
+	h := newTestMessagesHandler(t, cfg)
+
+	chain, result, err := h.buildModelChain("completely-unknown", nil, 100, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"kimi-k2.6", "mimo-v2-pro"}
+	if got := chainIDs(chain); !equalStrings(got, want) {
+		t.Errorf("chain = %v, want %v", got, want)
+	}
+	if result.Scenario == router.ScenarioOverride {
+		t.Errorf("scenario should not be override, got %s", result.Scenario)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/handlers/messages_test.go
+++ b/internal/handlers/messages_test.go
@@ -188,8 +188,9 @@ func TestBuildModelChain_Override_AppendsScenarioChainDeduped(t *testing.T) {
 }
 
 func TestBuildModelChain_Override_AppendsUniqueScenarioModels(t *testing.T) {
-	// Override primary does NOT overlap with the scenario chain.
-	// Result: override primary + override fallbacks + (scenario primary, dedup check, scenario fallbacks).
+	// Override primary does NOT overlap with the scenario chain. With default
+	// fallbacks, the chain is: [override primary, default fallback, scenario
+	// primary, scenario fallback(s)] with dups removed.
 	cfg := &config.Config{
 		Models: map[string]config.ModelConfig{
 			"default": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
@@ -212,7 +213,13 @@ func TestBuildModelChain_Override_AppendsUniqueScenarioModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := []string{"claude-sonnet-4.5", "kimi-k2.6", "mimo-v2-pro"}
+	// Chain construction:
+	//   1. override primary       = claude-sonnet-4.5
+	//   2. default fallbacks      = [mimo-v2-pro]            (from fallbacks["default"])
+	//   3. scenario safety-net:
+	//        scenario primary      = kimi-k2.6                 (new)
+	//        scenario fallbacks    = [mimo-v2-pro]            (dup, dropped)
+	want := []string{"claude-sonnet-4.5", "mimo-v2-pro", "kimi-k2.6"}
 	if got := chainIDs(chain); !equalStrings(got, want) {
 		t.Errorf("chain = %v, want %v", got, want)
 	}
@@ -222,8 +229,9 @@ func TestBuildModelChain_Override_AppendsUniqueScenarioModels(t *testing.T) {
 }
 
 func TestBuildModelChain_Override_NoMatchingFallbacksKey(t *testing.T) {
-	// Override has no entry in fallbacks[]. The chain should be the override
-	// primary alone, then the scenario chain appended.
+	// Override has no entry in fallbacks[]. RouteWithOverride should fall back
+	// to fallbacks["default"], then the scenario chain is appended as a
+	// deduplicated safety net.
 	cfg := &config.Config{
 		Models: map[string]config.ModelConfig{
 			"default": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
@@ -243,9 +251,13 @@ func TestBuildModelChain_Override_NoMatchingFallbacksKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := []string{"claude-sonnet-4.5", "kimi-k2.6", "mimo-v2-pro"}
+	// Expected: [override primary, default fallback (mimo-v2-pro), scenario primary (kimi-k2.6)]
+	// Note: mimo-v2-pro is in BOTH the default fallback and NOT in the scenario
+	// chain here, so dedup is exercised on the override primary not overlapping
+	// the scenario primary.
+	want := []string{"claude-sonnet-4.5", "mimo-v2-pro", "kimi-k2.6"}
 	if got := chainIDs(chain); !equalStrings(got, want) {
-		t.Errorf("chain = %v, want %v", got, want)
+		t.Errorf("chain = %v, want %v (override -> default fallback -> scenario primary)", got, want)
 	}
 }
 
@@ -275,8 +287,10 @@ func TestBuildModelChain_StreamingFlag_UsesStreamingRoute(t *testing.T) {
 	}
 
 	// Streaming: override still wins, but the safety-net uses fast route.
+	// Chain: [claude-sonnet-4.5 (override), mimo-v2-pro (default fallback),
+	//         qwen3.6-plus (fast scenario primary), qwen3.5-plus (fast scenario fallback)]
 	chain, _, _ := h.buildModelChain("claude-sonnet-4.5", nil, 100, true)
-	want := []string{"claude-sonnet-4.5", "qwen3.6-plus", "qwen3.5-plus"}
+	want := []string{"claude-sonnet-4.5", "mimo-v2-pro", "qwen3.6-plus", "qwen3.5-plus"}
 	if got := chainIDs(chain); !equalStrings(got, want) {
 		t.Errorf("streaming chain = %v, want %v (safety-net should use RouteForStreaming)", got, want)
 	}

--- a/internal/handlers/messages_test.go
+++ b/internal/handlers/messages_test.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"testing"
+
+	"oc-go-cc/internal/config"
+)
+
+func TestAppendUniqueModels_DedupsByModelID(t *testing.T) {
+	base := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		{Provider: "opencode-go", ModelID: "glm-5"},
+	}
+	extra := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "kimi-k2.6"}, // dup of base[0]
+		{Provider: "opencode-go", ModelID: "mimo-v2-pro"},
+		{Provider: "opencode-go", ModelID: "glm-5"}, // dup of base[1]
+	}
+
+	got := appendUniqueModels(base, extra)
+	wantIDs := []string{"kimi-k2.6", "glm-5", "mimo-v2-pro"}
+
+	if len(got) != len(wantIDs) {
+		t.Fatalf("got %d models, want %d (got=%+v)", len(got), len(wantIDs), got)
+	}
+	for i, m := range got {
+		if m.ModelID != wantIDs[i] {
+			t.Errorf("position %d: got %s, want %s", i, m.ModelID, wantIDs[i])
+		}
+	}
+}
+
+func TestAppendUniqueModels_PreservesBaseOrder(t *testing.T) {
+	base := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "a"},
+		{Provider: "opencode-go", ModelID: "b"},
+		{Provider: "opencode-go", ModelID: "c"},
+	}
+	// Extra starts with a model that would have come earlier in the chain
+	// (b) and adds new models. The base order must be preserved.
+	extra := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "b"}, // dup
+		{Provider: "opencode-go", ModelID: "d"},
+		{Provider: "opencode-go", ModelID: "e"},
+	}
+
+	got := appendUniqueModels(base, extra)
+	wantIDs := []string{"a", "b", "c", "d", "e"}
+
+	if len(got) != len(wantIDs) {
+		t.Fatalf("got %d models, want %d (got=%+v)", len(got), len(wantIDs), got)
+	}
+	for i, m := range got {
+		if m.ModelID != wantIDs[i] {
+			t.Errorf("position %d: got %s, want %s", i, m.ModelID, wantIDs[i])
+		}
+	}
+}
+
+func TestAppendUniqueModels_EmptyExtra(t *testing.T) {
+	base := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "a"},
+	}
+	got := appendUniqueModels(base, nil)
+	if len(got) != 1 || got[0].ModelID != "a" {
+		t.Errorf("expected unchanged base, got %+v", got)
+	}
+}
+
+func TestAppendUniqueModels_AllDuplicates(t *testing.T) {
+	base := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "a"},
+		{Provider: "opencode-go", ModelID: "b"},
+	}
+	extra := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "a"},
+		{Provider: "opencode-go", ModelID: "b"},
+	}
+
+	got := appendUniqueModels(base, extra)
+	if len(got) != 2 {
+		t.Errorf("expected 2 models, got %d (got=%+v)", len(got), got)
+	}
+}
+
+func TestAppendUniqueModels_EmptyBase(t *testing.T) {
+	extra := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "a"},
+		{Provider: "opencode-go", ModelID: "b"},
+	}
+	got := appendUniqueModels(nil, extra)
+	if len(got) != 2 {
+		t.Errorf("expected 2 models, got %d (got=%+v)", len(got), got)
+	}
+}

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -98,6 +98,25 @@ func (r *ModelRouter) IsStreamingScenarioRoutingEnabled() bool {
 	return r.atomic.Get().EnableStreamingScenarioRouting
 }
 
+// RouteWithOverride checks if the requested model matches a model_overrides entry.
+// Returns the override RouteResult and true if matched, zero value and false otherwise.
+func (r *ModelRouter) RouteWithOverride(requestedModel string) (RouteResult, bool) {
+	cfg := r.atomic.Get()
+	if cfg.ModelOverrides == nil {
+		return RouteResult{}, false
+	}
+	override, ok := cfg.ModelOverrides[requestedModel]
+	if !ok {
+		return RouteResult{}, false
+	}
+	fallbacks := cfg.Fallbacks[requestedModel]
+	return RouteResult{
+		Primary:   override,
+		Fallbacks: fallbacks,
+		Scenario:  "override",
+	}, true
+}
+
 // GetModelChain returns the full chain of models to try (primary + fallbacks).
 func (rr *RouteResult) GetModelChain() []config.ModelConfig {
 	chain := []config.ModelConfig{rr.Primary}

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -101,10 +101,10 @@ func (r *ModelRouter) IsStreamingScenarioRoutingEnabled() bool {
 // RouteWithOverride checks if the requested model matches a model_overrides entry.
 //
 // When matched, the returned RouteResult uses the override ModelConfig as the
-// primary, and fallbacks[<requestedModel>] (which may be nil/empty) as the
-// fallback chain. Unlike Route/RouteForStreaming, this method does NOT fall
-// back to fallbacks["default"] when the key is missing — the caller is expected
-// to merge a scenario-derived safety-net chain on top (see MessagesHandler).
+// primary. The fallback chain is fallbacks[<requestedModel>], falling back to
+// fallbacks["default"] when the override key has no entry (matching the
+// behavior of Route and RouteForStreaming). The caller (MessagesHandler) is
+// expected to merge a scenario-derived safety-net chain on top.
 //
 // Returns the override RouteResult and true if matched, or a zero value and
 // false if the requested model has no entry in model_overrides.
@@ -118,6 +118,9 @@ func (r *ModelRouter) RouteWithOverride(requestedModel string) (RouteResult, boo
 		return RouteResult{}, false
 	}
 	fallbacks := cfg.Fallbacks[requestedModel]
+	if len(fallbacks) == 0 {
+		fallbacks = cfg.Fallbacks["default"]
+	}
 	return RouteResult{
 		Primary:   override,
 		Fallbacks: fallbacks,

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -99,7 +99,15 @@ func (r *ModelRouter) IsStreamingScenarioRoutingEnabled() bool {
 }
 
 // RouteWithOverride checks if the requested model matches a model_overrides entry.
-// Returns the override RouteResult and true if matched, zero value and false otherwise.
+//
+// When matched, the returned RouteResult uses the override ModelConfig as the
+// primary, and fallbacks[<requestedModel>] (which may be nil/empty) as the
+// fallback chain. Unlike Route/RouteForStreaming, this method does NOT fall
+// back to fallbacks["default"] when the key is missing — the caller is expected
+// to merge a scenario-derived safety-net chain on top (see MessagesHandler).
+//
+// Returns the override RouteResult and true if matched, or a zero value and
+// false if the requested model has no entry in model_overrides.
 func (r *ModelRouter) RouteWithOverride(requestedModel string) (RouteResult, bool) {
 	cfg := r.atomic.Get()
 	if cfg.ModelOverrides == nil {
@@ -113,7 +121,7 @@ func (r *ModelRouter) RouteWithOverride(requestedModel string) (RouteResult, boo
 	return RouteResult{
 		Primary:   override,
 		Fallbacks: fallbacks,
-		Scenario:  "override",
+		Scenario:  ScenarioOverride,
 	}, true
 }
 

--- a/internal/router/model_router_test.go
+++ b/internal/router/model_router_test.go
@@ -295,13 +295,45 @@ func TestRouteWithOverride_NilMap(t *testing.T) {
 	}
 }
 
-func TestRouteWithOverride_MissingFallbacksKey(t *testing.T) {
+func TestRouteWithOverride_MissingFallbacksKey_FallsBackToDefault(t *testing.T) {
 	cfg := &config.Config{
 		ModelOverrides: map[string]config.ModelConfig{
 			"kimi-k2.6": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
 		},
-		// Note: no entry in Fallbacks for "kimi-k2.6" — should still return
-		// a single-element chain rather than panicking on the nil slice.
+		Fallbacks: map[string][]config.ModelConfig{
+			"default": {
+				{Provider: "opencode-go", ModelID: "qwen3.5-plus"},
+				{Provider: "opencode-go", ModelID: "mimo-v2-pro"},
+			},
+		},
+		// No entry in Fallbacks for "kimi-k2.6" — should fall back to
+		// fallbacks["default"], matching Route/RouteForStreaming behavior.
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	result, ok := router.RouteWithOverride("kimi-k2.6")
+	if !ok {
+		t.Fatal("expected RouteWithOverride to match")
+	}
+	if len(result.Fallbacks) != 2 {
+		t.Fatalf("expected 2 default fallbacks, got %d: %+v", len(result.Fallbacks), result.Fallbacks)
+	}
+	if result.Fallbacks[0].ModelID != "qwen3.5-plus" || result.Fallbacks[1].ModelID != "mimo-v2-pro" {
+		t.Errorf("expected default fallbacks [qwen3.5-plus, mimo-v2-pro], got %+v", result.Fallbacks)
+	}
+	chain := result.GetModelChain()
+	if len(chain) != 3 {
+		t.Errorf("expected 3-element chain (primary + 2 default fallbacks), got %d", len(chain))
+	}
+}
+
+func TestRouteWithOverride_NoFallbacksAnywhere(t *testing.T) {
+	cfg := &config.Config{
+		ModelOverrides: map[string]config.ModelConfig{
+			"kimi-k2.6": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		// Both the override key and "default" are missing.
 	}
 
 	router := NewModelRouter(newTestAtomicConfig(cfg))

--- a/internal/router/model_router_test.go
+++ b/internal/router/model_router_test.go
@@ -232,3 +232,89 @@ func TestResolveRequestedModel_UsesFallbacks(t *testing.T) {
 		t.Errorf("expected first fallback qwen3.5-plus, got %s", result.Fallbacks[0].ModelID)
 	}
 }
+
+func TestRouteWithOverride_MatchesKey(t *testing.T) {
+	cfg := &config.Config{
+		ModelOverrides: map[string]config.ModelConfig{
+			"kimi-k2.6": {
+				Provider:    "opencode-go",
+				ModelID:     "kimi-k2.6",
+				Temperature: 0.3,
+				MaxTokens:   2048,
+			},
+		},
+		Fallbacks: map[string][]config.ModelConfig{
+			"kimi-k2.6": {
+				{Provider: "opencode-go", ModelID: "qwen3.5-plus"},
+			},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	result, ok := router.RouteWithOverride("kimi-k2.6")
+	if !ok {
+		t.Fatal("expected RouteWithOverride to match")
+	}
+	if result.Primary.ModelID != "kimi-k2.6" {
+		t.Errorf("expected primary kimi-k2.6, got %s", result.Primary.ModelID)
+	}
+	if result.Primary.Temperature != 0.3 {
+		t.Errorf("expected temperature 0.3, got %f", result.Primary.Temperature)
+	}
+	if result.Scenario != ScenarioOverride {
+		t.Errorf("expected ScenarioOverride, got %s", result.Scenario)
+	}
+	if len(result.Fallbacks) != 1 || result.Fallbacks[0].ModelID != "qwen3.5-plus" {
+		t.Errorf("expected single fallback qwen3.5-plus, got %+v", result.Fallbacks)
+	}
+}
+
+func TestRouteWithOverride_NoMatch(t *testing.T) {
+	cfg := &config.Config{
+		ModelOverrides: map[string]config.ModelConfig{
+			"kimi-k2.6": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	result, ok := router.RouteWithOverride("some-other-model")
+	if ok {
+		t.Errorf("expected no match, got result %+v", result)
+	}
+}
+
+func TestRouteWithOverride_NilMap(t *testing.T) {
+	cfg := &config.Config{} // ModelOverrides is nil
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	if _, ok := router.RouteWithOverride("anything"); ok {
+		t.Error("expected no match for nil ModelOverrides map (must not panic)")
+	}
+}
+
+func TestRouteWithOverride_MissingFallbacksKey(t *testing.T) {
+	cfg := &config.Config{
+		ModelOverrides: map[string]config.ModelConfig{
+			"kimi-k2.6": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		// Note: no entry in Fallbacks for "kimi-k2.6" — should still return
+		// a single-element chain rather than panicking on the nil slice.
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+
+	result, ok := router.RouteWithOverride("kimi-k2.6")
+	if !ok {
+		t.Fatal("expected RouteWithOverride to match")
+	}
+	if len(result.Fallbacks) != 0 {
+		t.Errorf("expected empty fallbacks, got %+v", result.Fallbacks)
+	}
+	chain := result.GetModelChain()
+	if len(chain) != 1 {
+		t.Errorf("expected 1-element chain, got %d", len(chain))
+	}
+}

--- a/internal/router/scenarios.go
+++ b/internal/router/scenarios.go
@@ -17,6 +17,7 @@ const (
 	ScenarioComplex     Scenario = "complex"
 	ScenarioLongContext Scenario = "long_context"
 	ScenarioFast        Scenario = "fast"
+	ScenarioOverride    Scenario = "override"
 )
 
 // ScenarioResult contains the detected scenario and token count.

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -1079,3 +1079,4 @@ func mustJSON(t *testing.T, v any) string {
 }
 
 func strPtr(s string) *string { return &s }
+

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -1079,4 +1079,3 @@ func mustJSON(t *testing.T, v any) string {
 }
 
 func strPtr(s string) *string { return &s }
-


### PR DESCRIPTION
Adds model_overrides config section for per-request model selection. Allows users to specify a model ID in the request (e.g. via Claude Code -m flag) that bypasses scenario-based routing.

Key features:
- model_overrides map: requested model ID → override ModelConfig
- Override fallbacks chain with scenario fallbacks as safety net (deduplicated)
- ReasoningEffort config honored on first turn
- cache_control stripped for non-DeepSeek models
- ScenarioOverride constant, supportsCacheControl renamed to isDeepSeekModel

This complements the existing respect_requested_model flag with more flexible per-model override configuration.