### PR TITLE
fix: strip cache_control for Kimi models

### DIFF
--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -172,7 +172,8 @@ func (t *RequestTransformer) transformMessages(anthropicReq *types.MessageReques
 			Content: systemText,
 		}
 		// Try to extract cache_control from system array blocks
-		if len(anthropicReq.System) > 0 {
+		// Kimi models reject cache_control, skip for those.
+		if !strings.HasPrefix(modelID, "kimi-") && len(anthropicReq.System) > 0 {
 			var blocks []types.SystemContentBlock
 			if err := json.Unmarshal(anthropicReq.System, &blocks); err == nil {
 				for _, b := range blocks {

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -678,6 +678,75 @@ func TestTransformRequestPreservesSystemCacheControl(t *testing.T) {
 	}
 }
 
+func TestTransformRequestSkipsCacheControlForKimiSystem(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		System: json.RawMessage(`[
+			{"type":"text","text":"system prompt","cache_control":{"type":"ephemeral"}}
+		]`),
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "kimi-k2.6"})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if got, want := len(openaiReq.Messages), 2; got != want {
+		t.Fatalf("len(Messages) = %d, want %d", got, want)
+	}
+
+	systemMsg := openaiReq.Messages[0]
+	if got, want := systemMsg.Role, "system"; got != want {
+		t.Fatalf("Messages[0].Role = %q, want %q", got, want)
+	}
+	if got, want := systemMsg.Content, "system prompt"; got != want {
+		t.Fatalf("Messages[0].Content = %q, want %q", got, want)
+	}
+	if systemMsg.CacheControl != nil {
+		t.Fatalf("Kimi system message CacheControl = %v, want nil (guard should prevent assignment)", systemMsg.CacheControl)
+	}
+}
+
+func TestTransformRequestStripsCacheControlForNonKimiNonDeepSeek(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		System: json.RawMessage(`[
+			{"type":"text","text":"system prompt","cache_control":{"type":"ephemeral"}}
+		]`),
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	// Use a non-Kimi, non-DeepSeek model (e.g. GLM) — cache_control should be
+	// set by transformMessages then stripped by stripCacheControl().
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "glm-5"})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if got, want := len(openaiReq.Messages), 2; got != want {
+		t.Fatalf("len(Messages) = %d, want %d", got, want)
+	}
+
+	systemMsg := openaiReq.Messages[0]
+	if got, want := systemMsg.Role, "system"; got != want {
+		t.Fatalf("Messages[0].Role = %q, want %q", got, want)
+	}
+	if systemMsg.CacheControl != nil {
+		t.Fatalf("Non-Kimi/non-DeepSeek system message CacheControl = %v, want nil", systemMsg.CacheControl)
+	}
+}
+
 func TestTransformRequestStripsCacheControlForNonDeepSeek(t *testing.T) {
 	transformer := NewRequestTransformer()
 

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -388,6 +388,31 @@ func TestTransformRequestPreservesSystemCacheControl(t *testing.T) {
 	}
 }
 
+func TestTransformRequestStripsCacheControlForKimi(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		System: json.RawMessage(`[
+			{"type":"text","text":"You are helpful","cache_control":{"type":"ephemeral"}}
+		]`),
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "kimi-k2.6"})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	systemMsg := openaiReq.Messages[0]
+	if systemMsg.CacheControl != nil {
+		t.Fatal("Messages[0].CacheControl should be nil for Kimi models")
+	}
+}
+
 func TestTransformRequestOmitsCacheControlWhenAbsent(t *testing.T) {
 	transformer := NewRequestTransformer()
 

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -166,63 +166,11 @@ func TestTransformRequestIncludesStreamUsageOptions(t *testing.T) {
 		MaxTokens: 256,
 		Stream:    &stream,
 		Messages: []types.Message{
-			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		{Role: "user", Content: json.RawMessage(`"hello"`)},
 		},
 	}
 
 	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
-	if err != nil {
-		t.Fatalf("TransformRequest() error = %v", err)
-	}
-
-	if openaiReq.StreamOptions == nil {
-		t.Fatal("StreamOptions = nil, want include_usage enabled")
-	}
-	if !openaiReq.StreamOptions.IncludeUsage {
-		t.Fatal("StreamOptions.IncludeUsage = false, want true")
-	}
-}
-
-func TestTransformRequestOmitsStreamUsageOptionsWhenStreamingDisabled(t *testing.T) {
-	transformer := NewRequestTransformer()
-	stream := false
-
-	req := &types.MessageRequest{
-		Model:     "claude-test",
-		MaxTokens: 256,
-		Stream:    &stream,
-		Messages: []types.Message{
-			{Role: "user", Content: json.RawMessage(`"hello"`)},
-		},
-	}
-
-	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
-	if err != nil {
-		t.Fatalf("TransformRequest() error = %v", err)
-	}
-
-	if openaiReq.StreamOptions != nil {
-		t.Fatalf("StreamOptions = %v, want nil when streaming is disabled", openaiReq.StreamOptions)
-	}
-}
-
-func TestTransformRequestIncludesEmptyReasoningContentForToolCalls(t *testing.T) {
-	transformer := NewRequestTransformer()
-
-	req := &types.MessageRequest{
-		Model:     "claude-test",
-		MaxTokens: 256,
-		Messages: []types.Message{
-			{
-				Role: "assistant",
-				Content: json.RawMessage(`[
-					{"type":"tool_use","id":"toolu_456","name":"search_docs","input":{"query":"figma api"}}
-				]`),
-			},
-		},
-	}
-
-	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "kimi-k2.6"})
 	if err != nil {
 		t.Fatalf("TransformRequest() error = %v", err)
 	}

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -166,11 +166,63 @@ func TestTransformRequestIncludesStreamUsageOptions(t *testing.T) {
 		MaxTokens: 256,
 		Stream:    &stream,
 		Messages: []types.Message{
-		{Role: "user", Content: json.RawMessage(`"hello"`)},
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
 		},
 	}
 
 	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.StreamOptions == nil {
+		t.Fatal("StreamOptions = nil, want include_usage enabled")
+	}
+	if !openaiReq.StreamOptions.IncludeUsage {
+		t.Fatal("StreamOptions.IncludeUsage = false, want true")
+	}
+}
+
+func TestTransformRequestOmitsStreamUsageOptionsWhenStreamingDisabled(t *testing.T) {
+	transformer := NewRequestTransformer()
+	stream := false
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Stream:    &stream,
+		Messages: []types.Message{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if openaiReq.StreamOptions != nil {
+		t.Fatalf("StreamOptions = %v, want nil when streaming is disabled", openaiReq.StreamOptions)
+	}
+}
+
+func TestTransformRequestIncludesEmptyReasoningContentForToolCalls(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{
+				Role: "assistant",
+				Content: json.RawMessage(`[
+					{"type":"tool_use","id":"toolu_456","name":"search_docs","input":{"query":"figma api"}}
+				]`),
+			},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "kimi-k2.6"})
 	if err != nil {
 		t.Fatalf("TransformRequest() error = %v", err)
 	}
@@ -312,7 +364,7 @@ func TestTransformRequestPreservesSystemCacheControl(t *testing.T) {
 		},
 	}
 
-	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "kimi-k2.6"})
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{ModelID: "deepseek-v4-pro"})
 	if err != nil {
 		t.Fatalf("TransformRequest() error = %v", err)
 	}


### PR DESCRIPTION
Kimi provider rejects cache_control field in messages. Strip it for kimi- prefixed models.