### PR TITLE
feat: propagate upstream 429 + Retry-After instead of collapsing to 502

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -84,7 +84,8 @@ Environment variables override config file values. Config values also support `$
 
 | Variable                | Description                                 | Default                                          |
 | ----------------------- | ------------------------------------------- | ------------------------------------------------ |
-| `OC_GO_CC_API_KEY`      | OpenCode Go API key (**required**)          | —                                                |
+| `OC_GO_CC_API_KEY`      | OpenCode Go API key (**required** unless `OC_GO_CC_API_KEYS` is set) | —                                                |
+| `OC_GO_CC_API_KEYS`     | Comma-separated list of API keys for rotation (overrides `OC_GO_CC_API_KEY`) | —                                                |
 | `OC_GO_CC_CONFIG`       | Custom config file path                     | `~/.config/oc-go-cc/config.json`                 |
 | `OC_GO_CC_HOST`         | Proxy listen host                           | `127.0.0.1`                                      |
 | `OC_GO_CC_PORT`         | Proxy listen port                           | `3456`                                           |

--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -265,7 +265,11 @@ func validateCmd() *cobra.Command {
 			fmt.Println("Configuration is valid!")
 			fmt.Printf("  Host: %s\n", cfg.Host)
 			fmt.Printf("  Port: %d\n", cfg.Port)
-			fmt.Printf("  API Key: %s...\n", maskString(cfg.APIKey, 8))
+			if len(cfg.APIKeys) > 1 {
+				fmt.Printf("  API Keys: %d configured (primary: %s...)\n", len(cfg.APIKeys), maskString(cfg.APIKeys[0], 8))
+			} else {
+				fmt.Printf("  API Key: %s...\n", maskString(cfg.APIKey, 8))
+			}
 			fmt.Printf("  Base URL: %s\n", cfg.OpenCodeGo.BaseURL)
 			fmt.Printf("  Models configured: %d\n", len(cfg.Models))
 			fmt.Printf("  Fallback chains: %d\n", len(cfg.Fallbacks))

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -8,16 +8,28 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"oc-go-cc/internal/config"
 	"oc-go-cc/pkg/types"
 )
 
+// keyCooldownDuration is how long a key stays "cold" after a 429.
+// Picked to outlast the typical OpenCode Go per-minute rate window without
+// permanently shelving a key that recovers within the minute.
+const keyCooldownDuration = 60 * time.Second
+
 // OpenCodeClient handles communication with OpenCode Go API.
 type OpenCodeClient struct {
 	atomic     *config.AtomicConfig
 	httpClient *http.Client
+
+	// keyState rotates across the configured api_keys and tracks per-key
+	// cooldowns. Mutex guards both fields. nextIdx is round-robin pointer.
+	keyMu       sync.Mutex
+	keyCooldown map[string]time.Time
+	keyNextIdx  int
 }
 
 // NewOpenCodeClient creates a new OpenCode Go client.
@@ -43,7 +55,55 @@ func NewOpenCodeClient(atomic *config.AtomicConfig) *OpenCodeClient {
 			Timeout:   timeout,
 			Transport: transport,
 		},
+		keyCooldown: make(map[string]time.Time),
 	}
+}
+
+// configuredKeys returns the active api_keys list, preferring APIKeys but
+// falling back to APIKey for backward compat. Always returns at least one
+// entry when the config validated.
+func (c *OpenCodeClient) configuredKeys() []string {
+	cfg := c.atomic.Get()
+	if len(cfg.APIKeys) > 0 {
+		return cfg.APIKeys
+	}
+	if cfg.APIKey != "" {
+		return []string{cfg.APIKey}
+	}
+	return nil
+}
+
+// pickKey returns the next non-cold key from the rotation, or empty when all
+// keys are in cooldown. Round-robin across configured keys.
+func (c *OpenCodeClient) pickKey() string {
+	keys := c.configuredKeys()
+	if len(keys) == 0 {
+		return ""
+	}
+
+	c.keyMu.Lock()
+	defer c.keyMu.Unlock()
+
+	now := time.Now()
+	for attempt := 0; attempt < len(keys); attempt++ {
+		idx := (c.keyNextIdx + attempt) % len(keys)
+		key := keys[idx]
+		if until, cold := c.keyCooldown[key]; !cold || now.After(until) {
+			c.keyNextIdx = (idx + 1) % len(keys)
+			return key
+		}
+	}
+	return ""
+}
+
+// markKeyCold parks a key for keyCooldownDuration so subsequent picks skip it.
+func (c *OpenCodeClient) markKeyCold(key string) {
+	if key == "" {
+		return
+	}
+	c.keyMu.Lock()
+	defer c.keyMu.Unlock()
+	c.keyCooldown[key] = time.Now().Add(keyCooldownDuration)
 }
 
 // IsAnthropicModel returns true if the model requires the Anthropic endpoint.
@@ -56,68 +116,100 @@ func IsAnthropicModel(modelID string) bool {
 	}
 }
 
-// getEndpoint returns the appropriate endpoint config for a model.
-func (c *OpenCodeClient) getEndpoint(modelID string) endpointConfig {
+// baseURLFor returns the upstream URL appropriate for the model's endpoint family.
+func (c *OpenCodeClient) baseURLFor(modelID string) string {
 	cfg := c.atomic.Get()
 	if IsAnthropicModel(modelID) {
-		return endpointConfig{
-			BaseURL: cfg.OpenCodeGo.AnthropicBaseURL,
-			APIKey:  cfg.APIKey,
-		}
+		return cfg.OpenCodeGo.AnthropicBaseURL
 	}
-	return endpointConfig{
-		BaseURL: cfg.OpenCodeGo.BaseURL,
-		APIKey:  cfg.APIKey,
-	}
-}
-
-// endpointConfig holds configuration for a specific API endpoint.
-type endpointConfig struct {
-	BaseURL string
-	APIKey  string
+	return cfg.OpenCodeGo.BaseURL
 }
 
 // ChatCompletion sends a chat completion request to the OpenCode Go API.
-// Returns the raw HTTP response for the caller to handle (streaming or body read).
+// On HTTP 429 (rate limit) it marks the current api_key cold and retries with
+// the next non-cold key. Returns the upstream 429 only after every configured
+// key has been tried.
 func (c *OpenCodeClient) ChatCompletion(
 	ctx context.Context,
 	modelID string,
 	req *types.ChatCompletionRequest,
 ) (*http.Response, error) {
-	endpoint := c.getEndpoint(modelID)
-
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.BaseURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	baseURL := c.baseURLFor(modelID)
+	keyCount := len(c.configuredKeys())
+	if keyCount == 0 {
+		return nil, fmt.Errorf("no api_keys configured")
 	}
 
-	// Set headers
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
+	var lastErr error
+	for attempt := 0; attempt < keyCount; attempt++ {
+		key := c.pickKey()
+		if key == "" {
+			break
+		}
 
-	// Add streaming header if requested
-	if req.Stream != nil && *req.Stream {
+		resp, statusCode, attemptErr := c.doRequest(ctx, baseURL, key, body, req.Stream != nil && *req.Stream, false)
+		if attemptErr == nil {
+			return resp, nil
+		}
+		lastErr = attemptErr
+		if statusCode == http.StatusTooManyRequests {
+			c.markKeyCold(key)
+			continue
+		}
+		return nil, attemptErr
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("all api_keys exhausted (rate limited)")
+	}
+	return nil, lastErr
+}
+
+// doRequest performs a single attempt against `baseURL` with the supplied key.
+// On success returns the live response. On HTTP >= 400 returns (nil, statusCode, err)
+// so the caller can decide whether to retry with another key (429) or fail fast.
+// The `anthropicHeaders` flag mirrors the dual auth scheme used by
+// SendAnthropicRequest.
+func (c *OpenCodeClient) doRequest(
+	ctx context.Context,
+	baseURL string,
+	apiKey string,
+	body []byte,
+	streaming bool,
+	anthropicHeaders bool,
+) (*http.Response, int, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	if anthropicHeaders {
+		// Some OpenCode Go endpoints expect x-api-key for Anthropic-format requests.
+		httpReq.Header.Set("x-api-key", apiKey)
+	}
+	if streaming {
 		httpReq.Header.Set("Accept", "text/event-stream")
 	}
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, 0, fmt.Errorf("request failed: %w", err)
 	}
 
-	// Check for error status codes
 	if resp.StatusCode >= http.StatusBadRequest {
 		bodyBytes, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(bodyBytes))
+		return nil, resp.StatusCode, fmt.Errorf("API error %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
-	return resp, nil
+	return resp, resp.StatusCode, nil
 }
 
 // ChatCompletionNonStreaming sends a non-streaming request and returns the full parsed response.
@@ -169,7 +261,8 @@ func (c *OpenCodeClient) GetStreamingBody(
 }
 
 // SendAnthropicRequest sends a raw Anthropic-format request (for MiniMax models).
-// This skips the OpenAI transformation entirely.
+// This skips the OpenAI transformation entirely. Honors the same per-key
+// rate-limit rotation as ChatCompletion.
 func (c *OpenCodeClient) SendAnthropicRequest(
 	ctx context.Context,
 	body []byte,
@@ -177,35 +270,32 @@ func (c *OpenCodeClient) SendAnthropicRequest(
 ) (*http.Response, error) {
 	cfg := c.atomic.Get()
 	baseURL := cfg.OpenCodeGo.AnthropicBaseURL
-	apiKey := cfg.APIKey
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	keyCount := len(c.configuredKeys())
+	if keyCount == 0 {
+		return nil, fmt.Errorf("no api_keys configured")
 	}
 
-	// Set headers
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	// Incase OpenCode Go expects x-api-key instead
-	httpReq.Header.Set("x-api-key", apiKey)
+	var lastErr error
+	for attempt := 0; attempt < keyCount; attempt++ {
+		key := c.pickKey()
+		if key == "" {
+			break
+		}
 
-	// Add streaming header if requested
-	if stream {
-		httpReq.Header.Set("Accept", "text/event-stream")
+		resp, statusCode, attemptErr := c.doRequest(ctx, baseURL, key, body, stream, true)
+		if attemptErr == nil {
+			return resp, nil
+		}
+		lastErr = attemptErr
+		if statusCode == http.StatusTooManyRequests {
+			c.markKeyCold(key)
+			continue
+		}
+		return nil, attemptErr
 	}
 
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+	if lastErr == nil {
+		lastErr = fmt.Errorf("all api_keys exhausted (rate limited)")
 	}
-
-	// Check for error status codes
-	if resp.StatusCode >= http.StatusBadRequest {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	return resp, nil
+	return nil, lastErr
 }

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -205,8 +205,16 @@ func (c *OpenCodeClient) doRequest(
 
 	if resp.StatusCode >= http.StatusBadRequest {
 		bodyBytes, _ := io.ReadAll(resp.Body)
+		retryAfter := resp.Header.Get("Retry-After")
 		_ = resp.Body.Close()
-		return nil, resp.StatusCode, fmt.Errorf("API error %d: %s", resp.StatusCode, string(bodyBytes))
+		// Structured error so the fallback loop + handler can propagate
+		// quota-exhaustion (429 + Retry-After) instead of flattening it
+		// into a generic 502. See pkg/types.UpstreamError.
+		return nil, resp.StatusCode, &types.UpstreamError{
+			StatusCode: resp.StatusCode,
+			RetryAfter: retryAfter,
+			Body:       string(bodyBytes),
+		}
 	}
 
 	return resp, resp.StatusCode, nil

--- a/internal/client/opencode_test.go
+++ b/internal/client/opencode_test.go
@@ -1,6 +1,11 @@
 package client
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"oc-go-cc/internal/config"
+)
 
 func TestIsAnthropicModelOnlyRoutesNativeAnthropicModels(t *testing.T) {
 	tests := []struct {
@@ -36,5 +41,82 @@ func TestIsAnthropicModelOnlyRoutesNativeAnthropicModels(t *testing.T) {
 				t.Fatalf("IsAnthropicModel(%q) = %v, want %v", tt.modelID, got, tt.want)
 			}
 		})
+	}
+}
+
+// newTestClient builds an OpenCodeClient backed by an in-memory atomic config.
+// The HTTP client is never invoked by these key-selector tests so its defaults
+// don't matter.
+func newTestClient(cfg *config.Config) *OpenCodeClient {
+	return NewOpenCodeClient(config.NewAtomicConfig(cfg, ""))
+}
+
+func TestPickKeyFallsBackToAPIKeyWhenAPIKeysEmpty(t *testing.T) {
+	c := newTestClient(&config.Config{APIKey: "solo"})
+	if got := c.pickKey(); got != "solo" {
+		t.Fatalf("pickKey() = %q, want %q", got, "solo")
+	}
+}
+
+func TestPickKeyRoundRobinsAcrossConfiguredKeys(t *testing.T) {
+	c := newTestClient(&config.Config{APIKeys: []string{"k1", "k2", "k3"}})
+
+	got := []string{c.pickKey(), c.pickKey(), c.pickKey(), c.pickKey()}
+	want := []string{"k1", "k2", "k3", "k1"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("pick[%d] = %q, want %q (sequence %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestPickKeySkipsColdKeys(t *testing.T) {
+	c := newTestClient(&config.Config{APIKeys: []string{"k1", "k2"}})
+
+	c.markKeyCold("k1")
+
+	for i := 0; i < 3; i++ {
+		if got := c.pickKey(); got != "k2" {
+			t.Fatalf("attempt %d: pickKey() = %q, want %q (k1 cold)", i, got, "k2")
+		}
+	}
+}
+
+func TestPickKeyReturnsEmptyWhenAllKeysCold(t *testing.T) {
+	c := newTestClient(&config.Config{APIKeys: []string{"k1", "k2"}})
+
+	c.markKeyCold("k1")
+	c.markKeyCold("k2")
+
+	if got := c.pickKey(); got != "" {
+		t.Fatalf("pickKey() = %q, want empty (all cold)", got)
+	}
+}
+
+func TestPickKeyRehabilitatesAfterCooldownExpires(t *testing.T) {
+	c := newTestClient(&config.Config{APIKeys: []string{"k1"}})
+
+	c.keyMu.Lock()
+	c.keyCooldown["k1"] = time.Now().Add(-1 * time.Second) // already expired
+	c.keyMu.Unlock()
+
+	if got := c.pickKey(); got != "k1" {
+		t.Fatalf("pickKey() = %q, want %q (cooldown expired)", got, "k1")
+	}
+}
+
+func TestPickKeyReturnsEmptyWhenNoKeysConfigured(t *testing.T) {
+	c := newTestClient(&config.Config{})
+	if got := c.pickKey(); got != "" {
+		t.Fatalf("pickKey() = %q, want empty (no keys)", got)
+	}
+}
+
+func TestMarkKeyColdIgnoresEmptyString(t *testing.T) {
+	c := newTestClient(&config.Config{APIKeys: []string{"k1"}})
+	c.markKeyCold("") // must not panic; must not pollute cooldown map
+
+	if got := c.pickKey(); got != "k1" {
+		t.Fatalf("pickKey() = %q after no-op markKeyCold, want %q", got, "k1")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import "encoding/json"
 // Config holds the complete application configuration.
 type Config struct {
 	APIKey                         string                   `json:"api_key"`
+	APIKeys                        []string                 `json:"api_keys,omitempty"`
 	Host                           string                   `json:"host"`
 	Port                           int                      `json:"port"`
 	HotReload                      bool                     `json:"hot_reload"`

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -104,6 +104,15 @@ func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("OC_GO_CC_API_KEY"); v != "" {
 		cfg.APIKey = v
 	}
+	if v := os.Getenv("OC_GO_CC_API_KEYS"); v != "" {
+		parts := strings.Split(v, ",")
+		cfg.APIKeys = cfg.APIKeys[:0]
+		for _, p := range parts {
+			if trimmed := strings.TrimSpace(p); trimmed != "" {
+				cfg.APIKeys = append(cfg.APIKeys, trimmed)
+			}
+		}
+	}
 	if v := os.Getenv("OC_GO_CC_HOST"); v != "" {
 		cfg.Host = v
 	}
@@ -122,6 +131,17 @@ func applyEnvOverrides(cfg *Config) {
 
 // applyDefaults fills in missing configuration values with sensible defaults.
 func applyDefaults(cfg *Config) {
+	// Normalize api_key / api_keys: callers should read APIKeys.
+	// If api_keys is empty but api_key is set, promote it to a single-element
+	// slice so the rest of the code only needs to read APIKeys.
+	if len(cfg.APIKeys) == 0 && cfg.APIKey != "" {
+		cfg.APIKeys = []string{cfg.APIKey}
+	}
+	// If api_keys is set but api_key is not, mirror the first one into APIKey
+	// to keep existing single-key callers (tests, status printer) working.
+	if cfg.APIKey == "" && len(cfg.APIKeys) > 0 {
+		cfg.APIKey = cfg.APIKeys[0]
+	}
 	if cfg.Host == "" {
 		cfg.Host = defaultHost
 	}
@@ -144,8 +164,8 @@ func applyDefaults(cfg *Config) {
 
 // validate checks that all required configuration fields are present.
 func validate(cfg *Config) error {
-	if cfg.APIKey == "" {
-		return fmt.Errorf("api_key is required (set via config file or OC_GO_CC_API_KEY env var)")
+	if cfg.APIKey == "" && len(cfg.APIKeys) == 0 {
+		return fmt.Errorf("api_key (or api_keys) is required (set via config file or OC_GO_CC_API_KEY / OC_GO_CC_API_KEYS env var)")
 	}
 	return nil
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -181,6 +181,123 @@ func TestInterpolateEnvVars(t *testing.T) {
 	}
 }
 
+func TestAPIKeysFromFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{"api_keys": ["alpha", "bravo", "charlie"]}`
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	defer func() { _ = os.Unsetenv("OC_GO_CC_CONFIG") }()
+
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+	oldAPIKeys := os.Getenv("OC_GO_CC_API_KEYS")
+	_ = os.Unsetenv("OC_GO_CC_API_KEYS")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEYS", oldAPIKeys) }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(cfg.APIKeys) != 3 {
+		t.Fatalf("APIKeys len = %d, want 3", len(cfg.APIKeys))
+	}
+	if cfg.APIKeys[0] != "alpha" || cfg.APIKeys[1] != "bravo" || cfg.APIKeys[2] != "charlie" {
+		t.Errorf("APIKeys = %v, want [alpha bravo charlie]", cfg.APIKeys)
+	}
+	// applyDefaults must mirror APIKeys[0] into APIKey for legacy callers.
+	if cfg.APIKey != "alpha" {
+		t.Errorf("APIKey mirror = %q, want %q", cfg.APIKey, "alpha")
+	}
+}
+
+func TestAPIKeyPromotedIntoAPIKeysWhenAPIKeysAbsent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{"api_key": "single"}`
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	defer func() { _ = os.Unsetenv("OC_GO_CC_CONFIG") }()
+
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(cfg.APIKeys) != 1 || cfg.APIKeys[0] != "single" {
+		t.Errorf("APIKeys = %v, want [single]", cfg.APIKeys)
+	}
+}
+
+func TestEnvOverrideAPIKeysCommaSeparated(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{"api_key": "file-key"}`
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	_ = os.Setenv("OC_GO_CC_API_KEYS", "k1, k2 ,k3,")
+	defer func() {
+		_ = os.Unsetenv("OC_GO_CC_CONFIG")
+		_ = os.Unsetenv("OC_GO_CC_API_KEYS")
+	}()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(cfg.APIKeys) != 3 {
+		t.Fatalf("APIKeys len = %d, want 3 (trailing comma + spaces should be trimmed)", len(cfg.APIKeys))
+	}
+	for i, want := range []string{"k1", "k2", "k3"} {
+		if cfg.APIKeys[i] != want {
+			t.Errorf("APIKeys[%d] = %q, want %q", i, cfg.APIKeys[i], want)
+		}
+	}
+}
+
+func TestLoadMissingAPIKeyAndAPIKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{"host": "127.0.0.1"}`
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	defer func() { _ = os.Unsetenv("OC_GO_CC_CONFIG") }()
+
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+	oldAPIKeys := os.Getenv("OC_GO_CC_API_KEYS")
+	_ = os.Unsetenv("OC_GO_CC_API_KEYS")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEYS", oldAPIKeys) }()
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() expected error when both api_key and api_keys are missing, got nil")
+	}
+}
+
 func TestExpandHome(t *testing.T) {
 	home, _ := os.UserHomeDir()
 

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -263,6 +263,17 @@ func (h *MessagesHandler) handleStreaming(
 
 	streamStart := time.Now()
 
+	// Track the terminal upstream error so a 429 (quota) can be propagated
+	// with its Retry-After even in the streaming path. Prefer a rate-limit
+	// error over a generic one.
+	var lastStreamErr, rateLimitStreamErr error
+	noteStreamErr := func(err error) {
+		lastStreamErr = err
+		if rateLimitStreamErr == nil && types.IsRateLimited(err) {
+			rateLimitStreamErr = err
+		}
+	}
+
 	for _, model := range modelChain {
 		// Check if client already disconnected before trying this model
 		select {
@@ -291,6 +302,7 @@ func (h *MessagesHandler) handleStreaming(
 					return
 				}
 				h.logger.Warn("anthropic streaming failed", "model", model.ModelID, "error", err)
+				noteStreamErr(err)
 				continue
 			}
 			cancel()
@@ -318,6 +330,7 @@ func (h *MessagesHandler) handleStreaming(
 				return
 			}
 			h.logger.Warn("streaming request failed", "model", model.ModelID, "error", err)
+			noteStreamErr(err)
 			continue
 		}
 
@@ -348,11 +361,20 @@ func (h *MessagesHandler) handleStreaming(
 
 	// All models failed
 	h.metrics.RecordFailure()
+	terminalErr := rateLimitStreamErr
+	if terminalErr == nil {
+		terminalErr = lastStreamErr
+	}
 	if !rw.wroteHeader {
-		h.sendError(w, http.StatusBadGateway, "all streaming models failed", nil)
+		// Headers not sent yet — propagate 429 + Retry-After (quota) or 502.
+		h.sendUpstreamError(w, terminalErr)
 	} else {
-		// Headers already sent - send error as SSE event
-		h.sendStreamError(rw, "all upstream models failed")
+		// Headers already sent — can only signal via an SSE error event.
+		msg := "all upstream models failed"
+		if types.IsRateLimited(terminalErr) {
+			msg = "upstream rate limit (quota) exhausted"
+		}
+		h.sendStreamError(rw, msg)
 	}
 }
 
@@ -466,7 +488,7 @@ func (h *MessagesHandler) handleNonStreaming(
 
 	if err != nil {
 		h.metrics.RecordFailure()
-		h.sendError(w, http.StatusBadGateway, "all models failed", err)
+		h.sendUpstreamError(w, err)
 		return
 	}
 
@@ -553,6 +575,24 @@ func extractTextFromBlocks(blocks []types.ContentBlock) string {
 		}
 	}
 	return content
+}
+
+// sendUpstreamError maps a terminal fallback error to a client response,
+// preserving quota-exhaustion semantics. When the error is a 429 (with an
+// optional Retry-After), it is propagated as 429 + Retry-After so callers
+// (e.g. the model-router failover layer) can distinguish "out of quota,
+// resets at T" from a generic upstream outage. Everything else stays 502.
+func (h *MessagesHandler) sendUpstreamError(w http.ResponseWriter, err error) {
+	if ue, ok := types.AsUpstreamError(err); ok && ue.StatusCode == http.StatusTooManyRequests {
+		if ue.RetryAfter != "" {
+			if rw, ok := w.(*responseWriter); !ok || !rw.wroteHeader {
+				w.Header().Set("Retry-After", ue.RetryAfter)
+			}
+		}
+		h.sendError(w, http.StatusTooManyRequests, "upstream rate limit (quota) exhausted", err)
+		return
+	}
+	h.sendError(w, http.StatusBadGateway, "all models failed", err)
 }
 
 // sendError sends an error response in Anthropic format.

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -177,13 +177,14 @@ func (h *MessagesHandler) HandleMessages(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Route to appropriate model.
+	// If the client requested a specific known model, use it directly (passthrough).
+	// Otherwise, use scenario-based routing.
 	var routeResult router.RouteResult
 	if isStreaming && !h.modelRouter.IsStreamingScenarioRoutingEnabled() {
-		// Streaming: use faster models to minimize TTFT (time-to-first-token)
-		routeResult = h.modelRouter.RouteForStreaming(routerMessages, tokenCount)
+		routeResult = h.modelRouter.RouteWithModelForStreaming(anthropicReq.Model, routerMessages, tokenCount)
 	} else {
 		var err error
-		routeResult, err = h.modelRouter.Route(routerMessages, tokenCount)
+		routeResult, err = h.modelRouter.RouteWithModel(anthropicReq.Model, routerMessages, tokenCount)
 		if err != nil {
 			h.sendError(w, http.StatusInternalServerError, "routing failed", err)
 			return

--- a/internal/router/fallback.go
+++ b/internal/router/fallback.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"oc-go-cc/internal/config"
+	"oc-go-cc/pkg/types"
 )
 
 // CircuitState represents the state of a circuit breaker.
@@ -174,6 +175,12 @@ func (h *FallbackHandler) ExecuteWithFallback(
 ) (*FallbackResult, []byte, error) {
 	totalModels := len(models)
 
+	// Track errors so the terminal failure carries a meaningful status.
+	// A rate-limit (429 + Retry-After) is preserved preferentially so the
+	// handler can propagate quota-exhaustion instead of a generic 502.
+	var lastErr error
+	var rateLimitErr error
+
 	for i, model := range models {
 		cb := h.getCircuitBreaker(model.ModelID)
 
@@ -208,6 +215,11 @@ func (h *FallbackHandler) ExecuteWithFallback(
 			}, body, nil
 		}
 
+		lastErr = err
+		if rateLimitErr == nil && types.IsRateLimited(err) {
+			rateLimitErr = err
+		}
+
 		cb.RecordFailure()
 		h.logger.Warn("model failed, trying fallback",
 			"model", model.ModelID,
@@ -217,12 +229,23 @@ func (h *FallbackHandler) ExecuteWithFallback(
 		)
 	}
 
+	// Prefer surfacing a 429 (with its Retry-After) over a generic failure
+	// so the caller knows it was quota, not an outage. Falls back to the
+	// last error, then a generic message if every model was circuit-skipped.
+	terminalErr := rateLimitErr
+	if terminalErr == nil {
+		terminalErr = lastErr
+	}
+	if terminalErr == nil {
+		terminalErr = fmt.Errorf("all models failed (%d attempts)", totalModels)
+	}
+
 	return &FallbackResult{
 		ModelID:     models[0].ModelID,
 		Success:     false,
 		Attempted:   totalModels,
 		TotalModels: totalModels,
-	}, nil, fmt.Errorf("all models failed (%d attempts)", totalModels)
+	}, nil, terminalErr
 }
 
 // GetFallbackChain returns the fallback chain for a given primary model.

--- a/internal/router/fallback_test.go
+++ b/internal/router/fallback_test.go
@@ -1,0 +1,96 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"oc-go-cc/internal/config"
+	"oc-go-cc/pkg/types"
+)
+
+func twoModelChain() []config.ModelConfig {
+	return []config.ModelConfig{
+		{ModelID: "primary"},
+		{ModelID: "fallback"},
+	}
+}
+
+// newHandler builds a fallback handler with a high circuit-breaker threshold
+// so a single test failure never trips the breaker mid-test.
+func newHandler() *FallbackHandler {
+	return NewFallbackHandler(nil, 100, time.Minute)
+}
+
+func TestExecuteWithFallback_PreservesRateLimitError(t *testing.T) {
+	h := newHandler()
+	// primary 429s (quota), fallback fails with a generic error.
+	// The terminal error MUST be the 429 (with Retry-After), not the generic one.
+	exec := func(_ context.Context, m config.ModelConfig) ([]byte, error) {
+		if m.ModelID == "primary" {
+			return nil, &types.UpstreamError{StatusCode: 429, RetryAfter: "223920", Body: "quota"}
+		}
+		return nil, errors.New("connection reset")
+	}
+
+	_, _, err := h.ExecuteWithFallback(context.Background(), twoModelChain(), exec)
+	if err == nil {
+		t.Fatal("expected terminal error, got nil")
+	}
+	ue, ok := types.AsUpstreamError(err)
+	if !ok {
+		t.Fatalf("terminal error is not an UpstreamError: %v", err)
+	}
+	if ue.StatusCode != 429 || ue.RetryAfter != "223920" {
+		t.Fatalf("rate-limit error not preserved: %+v", ue)
+	}
+}
+
+func TestExecuteWithFallback_RateLimitPreferredOverLaterGeneric(t *testing.T) {
+	h := newHandler()
+	// primary generic-fails, fallback 429s. Either order must surface the 429.
+	exec := func(_ context.Context, m config.ModelConfig) ([]byte, error) {
+		if m.ModelID == "primary" {
+			return nil, errors.New("timeout")
+		}
+		return nil, &types.UpstreamError{StatusCode: 429, RetryAfter: "60"}
+	}
+
+	_, _, err := h.ExecuteWithFallback(context.Background(), twoModelChain(), exec)
+	if !types.IsRateLimited(err) {
+		t.Fatalf("expected a 429 terminal error regardless of position, got: %v", err)
+	}
+}
+
+func TestExecuteWithFallback_GenericWhenNoRateLimit(t *testing.T) {
+	h := newHandler()
+	exec := func(_ context.Context, _ config.ModelConfig) ([]byte, error) {
+		return nil, &types.UpstreamError{StatusCode: 502, Body: "bad gateway"}
+	}
+
+	_, _, err := h.ExecuteWithFallback(context.Background(), twoModelChain(), exec)
+	if err == nil {
+		t.Fatal("expected terminal error, got nil")
+	}
+	if types.IsRateLimited(err) {
+		t.Fatalf("non-429 failures must not be reported as rate-limited: %v", err)
+	}
+}
+
+func TestExecuteWithFallback_SuccessShortCircuits(t *testing.T) {
+	h := newHandler()
+	calls := 0
+	exec := func(_ context.Context, m config.ModelConfig) ([]byte, error) {
+		calls++
+		return []byte("ok"), nil
+	}
+
+	res, body, err := h.ExecuteWithFallback(context.Background(), twoModelChain(), exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(body) != "ok" || !res.Success || calls != 1 {
+		t.Fatalf("expected single successful call, got calls=%d res=%+v body=%q", calls, res, body)
+	}
+}

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -97,3 +97,55 @@ func (r *ModelRouter) RouteForStreaming(messages []MessageContent, tokenCount in
 		Scenario:  result.Scenario,
 	}
 }
+
+// KnownOpenCodeGoModels lists model IDs that can be passed through directly.
+// When a client requests one of these, the proxy uses it as-is instead of
+// scenario-based routing. This enables per-subagent model selection.
+var KnownOpenCodeGoModels = map[string]bool{
+	"glm-5.1":       true,
+	"glm-5":         true,
+	"kimi-k2.6":     true,
+	"kimi-k2.5":     true,
+	"mimo-v2-pro":   true,
+	"mimo-v2-omni":  true,
+	"qwen3.6-plus":  true,
+	"qwen3.5-plus":  true,
+	"minimax-m2.7":  true,
+	"minimax-m2.5":  true,
+}
+
+// RouteWithModel determines which model to use, respecting the client's model
+// choice when it matches a known OpenCode Go model (passthrough mode).
+// Falls back to scenario-based Route() for unknown models.
+func (r *ModelRouter) RouteWithModel(requestModel string, messages []MessageContent, tokenCount int) (RouteResult, error) {
+	if requestModel != "" && KnownOpenCodeGoModels[requestModel] {
+		cfg := r.atomic.Get()
+		return RouteResult{
+			Primary: config.ModelConfig{
+				Provider:  "opencode-go",
+				ModelID:   requestModel,
+				MaxTokens: 4096,
+			},
+			Fallbacks: cfg.Fallbacks["default"],
+			Scenario:  ScenarioPassthrough,
+		}, nil
+	}
+	return r.Route(messages, tokenCount)
+}
+
+// RouteWithModelForStreaming is like RouteWithModel but for streaming requests.
+func (r *ModelRouter) RouteWithModelForStreaming(requestModel string, messages []MessageContent, tokenCount int) RouteResult {
+	if requestModel != "" && KnownOpenCodeGoModels[requestModel] {
+		cfg := r.atomic.Get()
+		return RouteResult{
+			Primary: config.ModelConfig{
+				Provider:  "opencode-go",
+				ModelID:   requestModel,
+				MaxTokens: 4096,
+			},
+			Fallbacks: cfg.Fallbacks["default"],
+			Scenario:  ScenarioPassthrough,
+		}
+	}
+	return r.RouteForStreaming(messages, tokenCount)
+}

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -102,16 +102,16 @@ func (r *ModelRouter) RouteForStreaming(messages []MessageContent, tokenCount in
 // When a client requests one of these, the proxy uses it as-is instead of
 // scenario-based routing. This enables per-subagent model selection.
 var KnownOpenCodeGoModels = map[string]bool{
-	"glm-5.1":       true,
-	"glm-5":         true,
-	"kimi-k2.6":     true,
-	"kimi-k2.5":     true,
-	"mimo-v2-pro":   true,
-	"mimo-v2-omni":  true,
-	"qwen3.6-plus":  true,
-	"qwen3.5-plus":  true,
-	"minimax-m2.7":  true,
-	"minimax-m2.5":  true,
+	"glm-5.1":      true,
+	"glm-5":        true,
+	"kimi-k2.6":    true,
+	"kimi-k2.5":    true,
+	"mimo-v2-pro":  true,
+	"mimo-v2-omni": true,
+	"qwen3.6-plus": true,
+	"qwen3.5-plus": true,
+	"minimax-m2.7": true,
+	"minimax-m2.5": true,
 }
 
 // RouteWithModel determines which model to use, respecting the client's model

--- a/internal/router/scenarios.go
+++ b/internal/router/scenarios.go
@@ -230,3 +230,6 @@ func RouteForStreaming(messages []MessageContent, tokenCount int, cfg *config.Co
 		Reason:     "streaming request - use fast model (qwen3.6-plus)",
 	}
 }
+
+// ScenarioPassthrough is used when the client explicitly requests a known model.
+const ScenarioPassthrough Scenario = "passthrough"

--- a/pkg/types/upstream_error.go
+++ b/pkg/types/upstream_error.go
@@ -1,0 +1,41 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+)
+
+// UpstreamError is a structured error carrying the HTTP status and (when
+// present) the Retry-After header returned by the OpenCode Go upstream.
+//
+// It exists so quota-exhaustion (HTTP 429 + Retry-After) survives the
+// fallback loop instead of being flattened into a generic "all models
+// failed" 502. Callers can errors.As() it to propagate the real status
+// and reset hint back to the client.
+type UpstreamError struct {
+	StatusCode int
+	RetryAfter string // raw Retry-After header value (seconds or HTTP-date); "" if absent
+	Body       string
+}
+
+func (e *UpstreamError) Error() string {
+	if e.RetryAfter != "" {
+		return fmt.Sprintf("API error %d (retry-after: %s): %s", e.StatusCode, e.RetryAfter, e.Body)
+	}
+	return fmt.Sprintf("API error %d: %s", e.StatusCode, e.Body)
+}
+
+// AsUpstreamError unwraps err (following %w chains) into an *UpstreamError.
+func AsUpstreamError(err error) (*UpstreamError, bool) {
+	var ue *UpstreamError
+	if errors.As(err, &ue) {
+		return ue, true
+	}
+	return nil, false
+}
+
+// IsRateLimited reports whether err is an UpstreamError with status 429.
+func IsRateLimited(err error) bool {
+	ue, ok := AsUpstreamError(err)
+	return ok && ue.StatusCode == 429
+}

--- a/pkg/types/upstream_error_test.go
+++ b/pkg/types/upstream_error_test.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestAsUpstreamError_Direct(t *testing.T) {
+	ue := &UpstreamError{StatusCode: 429, RetryAfter: "223920", Body: "rate limited"}
+	got, ok := AsUpstreamError(ue)
+	if !ok {
+		t.Fatal("AsUpstreamError returned ok=false for a direct *UpstreamError")
+	}
+	if got.StatusCode != 429 || got.RetryAfter != "223920" {
+		t.Fatalf("unexpected unwrap: %+v", got)
+	}
+}
+
+func TestAsUpstreamError_Wrapped(t *testing.T) {
+	// The handler wraps client errors with %w ("chat completion failed: %w").
+	// AsUpstreamError must see through the wrap.
+	ue := &UpstreamError{StatusCode: 429, RetryAfter: "60"}
+	wrapped := fmt.Errorf("chat completion failed: %w", ue)
+	got, ok := AsUpstreamError(wrapped)
+	if !ok {
+		t.Fatal("AsUpstreamError failed to unwrap a %w-wrapped UpstreamError")
+	}
+	if got.RetryAfter != "60" {
+		t.Fatalf("RetryAfter lost through wrap: %q", got.RetryAfter)
+	}
+}
+
+func TestAsUpstreamError_NonUpstream(t *testing.T) {
+	if _, ok := AsUpstreamError(errors.New("boom")); ok {
+		t.Fatal("AsUpstreamError returned ok=true for a plain error")
+	}
+	if _, ok := AsUpstreamError(nil); ok {
+		t.Fatal("AsUpstreamError returned ok=true for nil")
+	}
+}
+
+func TestIsRateLimited(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"429 direct", &UpstreamError{StatusCode: 429}, true},
+		{"429 wrapped", fmt.Errorf("x: %w", &UpstreamError{StatusCode: 429}), true},
+		{"502 not rate-limited", &UpstreamError{StatusCode: 502}, false},
+		{"401 not rate-limited", &UpstreamError{StatusCode: 401}, false},
+		{"plain error", errors.New("nope"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsRateLimited(tc.err); got != tc.want {
+				t.Fatalf("IsRateLimited(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpstreamError_ErrorString(t *testing.T) {
+	withRA := (&UpstreamError{StatusCode: 429, RetryAfter: "223920", Body: "limit"}).Error()
+	if !contains(withRA, "429") || !contains(withRA, "223920") {
+		t.Fatalf("Error() should mention status + retry-after, got: %q", withRA)
+	}
+	noRA := (&UpstreamError{StatusCode: 502, Body: "bad"}).Error()
+	if contains(noRA, "retry-after") {
+		t.Fatalf("Error() should omit retry-after when empty, got: %q", noRA)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

When the OpenCode Go subscription hits a usage limit, the upstream returns **`429` + `Retry-After`** (observed live: `retry-after: 223920` ≈ **2.6 days** — the exact quota-reset time). oc-go-cc was **throwing this away**: the fallback loop tried every model, each 429'd, and the handler returned a generic **`502 "all models failed"`** — losing both the 429 status and the Retry-After.

Downstream impact (model-router): it saw only a 502, so its 429-aware failover (PR #87) never recognized quota exhaustion, and the user never learned *when* quota resets.

## Why this is the only signal

OpenCode Go exposes **no** usage/quota query endpoint — probed `/v1/usage`, `/usage`, `/me`, `/account`, `/limits`, `/rate_limit` → all **404**; their docs confirm usage is **console-only** (`opencode.ai/auth`). So the `429 + Retry-After` is the *only* machine-readable quota signal that exists. Worth preserving rather than flattening.

## Changes

- **`pkg/types.UpstreamError`** `{StatusCode, RetryAfter, Body}` + `AsUpstreamError` (`errors.As`-aware, sees through `%w`) + `IsRateLimited`.
- **`client/opencode.go`** `doRequest`: on upstream ≥400, capture `Retry-After` and return a `*UpstreamError` instead of a flat `fmt.Errorf`.
- **`router/fallback.go`**: track errors across attempts; surface a **429 (with Retry-After) preferentially** as the terminal error rather than a generic "all models failed".
- **`handlers/messages.go`**: new `sendUpstreamError` — a 429 terminal error → **429 + Retry-After** (streaming + non-streaming); everything else stays 502. Streaming path notes quota in its SSE error event when headers were already sent.

## Effect

A quota-exhausted oc-go now returns `429 + Retry-After`. model-router's existing 429 regex correctly fails over to kimi, and the Retry-After is available to surface "quota resets in ~Xh".

## Tests

- `pkg/types`: unwrap (direct/wrapped/non-upstream), `IsRateLimited` matrix, `Error()` formatting — 6 cases.
- `router/fallback_test.go` (new): 429 preserved as terminal; 429 preferred over later generic regardless of position; non-429 stays generic; success short-circuits.
- `go build`/`vet`/`gofmt` clean; full suite green.

## Test plan
- [x] `go test ./...` — all pass locally
- [ ] CI green (`-race` on x86)
- [ ] Deploy to host + verify a real quota-429 now propagates (currently quota IS exhausted, retry-after ~2.6d — ideal live test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)