### PR TITLE
feat: add qwen3.7-max to Anthropic endpoint routing

### DIFF
--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -49,7 +49,7 @@ func NewOpenCodeClient(atomic *config.AtomicConfig) *OpenCodeClient {
 // IsAnthropicModel returns true if the model requires the Anthropic endpoint.
 func IsAnthropicModel(modelID string) bool {
 	switch modelID {
-	case "minimax-m2.5", "minimax-m2.7":
+	case "minimax-m2.5", "minimax-m2.7", "qwen3.7-max":
 		return true
 	default:
 		return false

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -98,7 +98,12 @@ func (c *OpenCodeClient) ChatCompletion(
 
 	// Set headers
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
+	// Anthropic endpoint uses x-api-key; OpenAI endpoint uses Bearer
+	if IsAnthropicModel(modelID) {
+		httpReq.Header.Set("x-api-key", endpoint.APIKey)
+	} else {
+		httpReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
+	}
 
 	// Add streaming header if requested
 	if req.Stream != nil && *req.Stream {
@@ -186,8 +191,6 @@ func (c *OpenCodeClient) SendAnthropicRequest(
 
 	// Set headers
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	// Incase OpenCode Go expects x-api-key instead
 	httpReq.Header.Set("x-api-key", apiKey)
 
 	// Add streaming header if requested


### PR DESCRIPTION
qwen3.7-max is listed in OpenCode Go's model list but returns `Model qwen3.7-max is not supported for format oa-compat` when accessed through the OpenAI-compatible endpoint (`/v1/chat/completions`).

However, it works correctly through the Anthropic-native endpoint (`/v1/messages`).

This PR adds `qwen3.7-max` to `IsAnthropicModel()` so oc-go-cc automatically routes it through `anthropic_base_url`, matching the existing pattern used for minimax-m2.5 and minimax-m2.7.

Fixes: qwen3.7-max requests falling back to qwen3.6-plus due to endpoint format incompatibility.