### PR TITLE
fix: respect HTTP_PROXY/HTTPS_PROXY env vars for proxy environments

### DIFF
--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -40,6 +40,7 @@ func NewOpenCodeClient(atomic *config.AtomicConfig) *OpenCodeClient {
 		IdleConnTimeout:     90 * time.Second,
 		MaxConnsPerHost:     50,
 		DisableKeepAlives:   false,
+		Proxy:               http.ProxyFromEnvironment,
 	}
 
 	return &OpenCodeClient{


### PR DESCRIPTION
The http.Transport used by the upstream API client was missing the Proxy field, causing Go's HTTP client to ignore HTTP_PROXY and HTTPS_PROXY environment variables. Users behind corporate proxies could not connect to OpenCode endpoints.

Add Proxy: http.ProxyFromEnvironment to honor standard proxy environment variables.