### PR TITLE
feat: add API key rotation with round-robin across multiple keys

### DIFF
--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -265,7 +265,11 @@ func validateCmd() *cobra.Command {
 			fmt.Println("Configuration is valid!")
 			fmt.Printf("  Host: %s\n", cfg.Host)
 			fmt.Printf("  Port: %d\n", cfg.Port)
-			fmt.Printf("  API Key: %s...\n", maskString(cfg.APIKey, 8))
+			if keys := cfg.EffectiveAPIKeys(); len(keys) > 1 {
+				fmt.Printf("  API Keys: %d keys (round-robin)\n", len(keys))
+			} else {
+				fmt.Printf("  API Key: %s...\n", maskString(cfg.APIKey, 8))
+			}
 			fmt.Printf("  Base URL: %s\n", cfg.OpenCodeGo.BaseURL)
 			fmt.Printf("  Models configured: %d\n", len(cfg.Models))
 			fmt.Printf("  Fallback chains: %d\n", len(cfg.Fallbacks))

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -1,5 +1,6 @@
 {
   "api_key": "${OC_GO_CC_API_KEY}",
+  "api_keys": ["${OC_GO_CC_API_KEY_1}", "${OC_GO_CC_API_KEY_2}"],
   "host": "127.0.0.1",
   "port": 3456,
   "hot_reload": false,

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"oc-go-cc/internal/config"
@@ -24,6 +25,18 @@ const (
 type OpenCodeClient struct {
 	atomic     *config.AtomicConfig
 	httpClient *http.Client
+	keyCounter atomic.Uint64
+}
+
+// nextAPIKey returns the next API key in round-robin order from the configured key pool.
+func (c *OpenCodeClient) nextAPIKey() string {
+	cfg := c.atomic.Get()
+	keys := cfg.EffectiveAPIKeys()
+	if len(keys) == 0 {
+		return ""
+	}
+	idx := c.keyCounter.Add(1) - 1
+	return keys[idx%uint64(len(keys))]
 }
 
 // NewOpenCodeClient creates a new OpenCode client.
@@ -133,26 +146,27 @@ func isResponsesModel(modelID string) bool {
 // getEndpoint returns the appropriate endpoint config for a model.
 func (c *OpenCodeClient) getEndpoint(modelID string, modelConfig config.ModelConfig) endpointConfig {
 	cfg := c.atomic.Get()
+	apiKey := c.nextAPIKey()
 
 	if IsZen(modelConfig) {
 		zen := cfg.OpenCodeZen
 		switch ClassifyEndpoint(modelID) {
 		case EndpointAnthropic:
-			return endpointConfig{BaseURL: zen.AnthropicBaseURL, APIKey: cfg.APIKey}
+			return endpointConfig{BaseURL: zen.AnthropicBaseURL, APIKey: apiKey}
 		case EndpointResponses:
-			return endpointConfig{BaseURL: zen.ResponsesBaseURL, APIKey: cfg.APIKey}
+			return endpointConfig{BaseURL: zen.ResponsesBaseURL, APIKey: apiKey}
 		case EndpointGemini:
-			return endpointConfig{BaseURL: zen.GeminiBaseURL + "/" + modelID, APIKey: cfg.APIKey}
+			return endpointConfig{BaseURL: zen.GeminiBaseURL + "/" + modelID, APIKey: apiKey}
 		default:
-			return endpointConfig{BaseURL: zen.BaseURL, APIKey: cfg.APIKey}
+			return endpointConfig{BaseURL: zen.BaseURL, APIKey: apiKey}
 		}
 	}
 
 	// Default: OpenCode Go
 	if IsAnthropicModel(modelID) {
-		return endpointConfig{BaseURL: cfg.OpenCodeGo.AnthropicBaseURL, APIKey: cfg.APIKey}
+		return endpointConfig{BaseURL: cfg.OpenCodeGo.AnthropicBaseURL, APIKey: apiKey}
 	}
-	return endpointConfig{BaseURL: cfg.OpenCodeGo.BaseURL, APIKey: cfg.APIKey}
+	return endpointConfig{BaseURL: cfg.OpenCodeGo.BaseURL, APIKey: apiKey}
 }
 
 // endpointConfig holds configuration for a specific API endpoint.
@@ -268,7 +282,7 @@ func (c *OpenCodeClient) SendAnthropicRequest(
 	} else {
 		baseURL = cfg.OpenCodeGo.AnthropicBaseURL
 	}
-	apiKey := cfg.APIKey
+	apiKey := c.nextAPIKey()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewReader(body))
 	if err != nil {

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -29,14 +29,20 @@ type OpenCodeClient struct {
 }
 
 // nextAPIKey returns the next API key in round-robin order from the configured key pool.
+// The counter is kept in [0, n) via CAS so it never overflows.
 func (c *OpenCodeClient) nextAPIKey() string {
 	cfg := c.atomic.Get()
 	keys := cfg.EffectiveAPIKeys()
 	if len(keys) == 0 {
 		return ""
 	}
-	idx := c.keyCounter.Add(1) - 1
-	return keys[idx%uint64(len(keys))]
+	n := uint64(len(keys))
+	for {
+		old := c.keyCounter.Load()
+		if c.keyCounter.CompareAndSwap(old, (old+1)%n) {
+			return keys[old%n]
+		}
+	}
 }
 
 // NewOpenCodeClient creates a new OpenCode client.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import "encoding/json"
 // Config holds the complete application configuration.
 type Config struct {
 	APIKey                         string                   `json:"api_key"`
+	APIKeys                        []string                 `json:"api_keys"`
 	Host                           string                   `json:"host"`
 	Port                           int                      `json:"port"`
 	HotReload                      bool                     `json:"hot_reload"`
@@ -50,4 +51,16 @@ type OpenCodeZenConfig struct {
 type LoggingConfig struct {
 	Level    string `json:"level"`
 	Requests bool   `json:"requests"`
+}
+
+// EffectiveAPIKeys returns the pool of API keys for rotation.
+// APIKeys takes precedence; falls back to the single APIKey field.
+func (c *Config) EffectiveAPIKeys() []string {
+	if len(c.APIKeys) > 0 {
+		return c.APIKeys
+	}
+	if c.APIKey != "" {
+		return []string{c.APIKey}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `api_keys` array to config for distributing requests across N OpenCode API keys using strict round-robin (one key per request)
- Falls back to single `api_key` field for full backward compatibility — no config migration needed
- Hot-reload aware: key pool updates are picked up immediately when `hot_reload: true`

## Usage

```json
{
  "api_keys": ["sk-key1", "sk-key2", "sk-key3"]
}
```

Drop `api_key` when using `api_keys`. Works with any number of keys.

## Implementation

- `Config.APIKeys []string` + `EffectiveAPIKeys()` in `internal/config/config.go`
- `keyCounter atomic.Uint64` on `OpenCodeClient` with `nextAPIKey()` round-robin method
- All four endpoint paths (`getEndpoint` + `SendAnthropicRequest`) use `nextAPIKey()` — one increment per request

## Test plan

- [ ] Single `api_key` config still works as before
- [ ] Two keys in `api_keys` alternate on successive requests
- [ ] Three+ keys cycle correctly
- [ ] `oc-go-cc validate` reports key count when multiple keys configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)