### PR TITLE
Add Claude Code env conflict check

### DIFF
--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -40,6 +41,7 @@ Configuration is stored at ~/.config/oc-go-cc/config.json`,
 	rootCmd.AddCommand(statusCmd())
 	rootCmd.AddCommand(initCmd())
 	rootCmd.AddCommand(validateCmd())
+	rootCmd.AddCommand(checkCmd())
 	rootCmd.AddCommand(modelsCmd())
 	rootCmd.AddCommand(autostartCmd())
 
@@ -269,6 +271,81 @@ func validateCmd() *cobra.Command {
 			fmt.Printf("  Base URL: %s\n", cfg.OpenCodeGo.BaseURL)
 			fmt.Printf("  Models configured: %d\n", len(cfg.Models))
 			fmt.Printf("  Fallback chains: %d\n", len(cfg.Fallbacks))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to config file")
+	return cmd
+}
+
+// checkCmd returns the command to check Claude Code environment conflicts.
+func checkCmd() *cobra.Command {
+	var configPath string
+
+	cmd := &cobra.Command{
+		Use:          "check",
+		Short:        "Check Claude Code env conflicts",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if configPath != "" {
+				_ = os.Setenv("OC_GO_CC_CONFIG", configPath)
+			}
+
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("invalid config: %w", err)
+			}
+
+			expectedURL := fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port)
+			conflicts := 0
+			checkEnv := func(source string, env map[string]string) {
+				if value, ok := env["ANTHROPIC_BASE_URL"]; ok && value != expectedURL {
+					fmt.Printf("%s: ANTHROPIC_BASE_URL is %q, expected %q\n", source, value, expectedURL)
+					conflicts++
+				}
+				if _, ok := env["ANTHROPIC_API_KEY"]; ok {
+					fmt.Printf("%s: ANTHROPIC_API_KEY is set\n", source)
+					conflicts++
+				}
+			}
+
+			env := map[string]string{}
+			if value, ok := os.LookupEnv("ANTHROPIC_BASE_URL"); ok {
+				env["ANTHROPIC_BASE_URL"] = value
+			}
+			if _, ok := os.LookupEnv("ANTHROPIC_API_KEY"); ok {
+				env["ANTHROPIC_API_KEY"] = ""
+			}
+			checkEnv("environment", env)
+
+			home, _ := os.UserHomeDir()
+			for _, path := range []string{
+				filepath.Join(home, ".claude", "settings.json"),
+				filepath.Join(home, ".claude.json"),
+			} {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					if !os.IsNotExist(err) {
+						fmt.Printf("%s: %v\n", path, err)
+					}
+					continue
+				}
+
+				var settings struct {
+					Env map[string]string `json:"env"`
+				}
+				if err := json.Unmarshal(data, &settings); err != nil {
+					fmt.Printf("%s: %v\n", path, err)
+					continue
+				}
+				checkEnv(path, settings.Env)
+			}
+
+			if conflicts > 0 {
+				return fmt.Errorf("found %d Claude Code env conflict(s)", conflicts)
+			}
+			fmt.Println("No Claude Code env conflicts found.")
 			return nil
 		},
 	}

--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"oc-go-cc/internal/config"
@@ -294,52 +295,46 @@ func checkCmd() *cobra.Command {
 
 			cfg, err := config.Load()
 			if err != nil {
-				return fmt.Errorf("invalid config: %w", err)
+				cfg = &config.Config{Host: "127.0.0.1", Port: 3456}
+				fmt.Printf("Warning: could not load config (%v), using defaults for check\n", err)
 			}
 
-			expectedURL := fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port)
+			expectedURL := strings.TrimRight(fmt.Sprintf("http://%s:%d", cfg.Host, cfg.Port), "/")
 			conflicts := 0
-			checkEnv := func(source string, env map[string]string) {
-				if value, ok := env["ANTHROPIC_BASE_URL"]; ok && value != expectedURL {
-					fmt.Printf("%s: ANTHROPIC_BASE_URL is %q, expected %q\n", source, value, expectedURL)
-					conflicts++
-				}
-				if _, ok := env["ANTHROPIC_API_KEY"]; ok {
-					fmt.Printf("%s: ANTHROPIC_API_KEY is set\n", source)
-					conflicts++
-				}
-			}
 
 			env := map[string]string{}
-			if value, ok := os.LookupEnv("ANTHROPIC_BASE_URL"); ok {
-				env["ANTHROPIC_BASE_URL"] = value
+			for _, key := range []string{"ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} {
+				if value, ok := os.LookupEnv(key); ok {
+					env[key] = value
+				}
 			}
-			if _, ok := os.LookupEnv("ANTHROPIC_API_KEY"); ok {
-				env["ANTHROPIC_API_KEY"] = ""
-			}
-			checkEnv("environment", env)
+			conflicts += checkClaudeEnv("environment", env, expectedURL)
 
-			home, _ := os.UserHomeDir()
-			for _, path := range []string{
-				filepath.Join(home, ".claude", "settings.json"),
-				filepath.Join(home, ".claude.json"),
-			} {
-				data, err := os.ReadFile(path)
-				if err != nil {
-					if !os.IsNotExist(err) {
-						fmt.Printf("%s: %v\n", path, err)
+			home, err := os.UserHomeDir()
+			if err != nil {
+				fmt.Printf("Warning: cannot determine home directory: %v\n", err)
+			} else {
+				for _, path := range []string{
+					filepath.Join(home, ".claude", "settings.json"),
+					filepath.Join(home, ".claude.json"),
+				} {
+					data, err := os.ReadFile(path)
+					if err != nil {
+						if !os.IsNotExist(err) {
+							fmt.Printf("%s: %v\n", path, err)
+						}
+						continue
 					}
-					continue
-				}
 
-				var settings struct {
-					Env map[string]string `json:"env"`
+					var settings struct {
+						Env map[string]string `json:"env"`
+					}
+					if err := json.Unmarshal(data, &settings); err != nil {
+						fmt.Printf("%s: %v\n", path, err)
+						continue
+					}
+					conflicts += checkClaudeEnv(path, settings.Env, expectedURL)
 				}
-				if err := json.Unmarshal(data, &settings); err != nil {
-					fmt.Printf("%s: %v\n", path, err)
-					continue
-				}
-				checkEnv(path, settings.Env)
 			}
 
 			if conflicts > 0 {
@@ -352,6 +347,32 @@ func checkCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to config file")
 	return cmd
+}
+
+// checkClaudeEnv checks a single environment map for conflicting Claude Code settings.
+// Returns the number of conflicts found.
+func checkClaudeEnv(source string, env map[string]string, expectedURL string) int {
+	conflicts := 0
+	if value, ok := env["ANTHROPIC_BASE_URL"]; ok {
+		normalized := strings.TrimRight(value, "/")
+		if normalized != expectedURL {
+			fmt.Printf("%s: ANTHROPIC_BASE_URL is %q, expected %q\n", source, value, expectedURL)
+			conflicts++
+		}
+	}
+	if _, ok := env["ANTHROPIC_API_KEY"]; ok {
+		fmt.Printf("%s: ANTHROPIC_API_KEY is set\n", source)
+		conflicts++
+	}
+	if value, ok := env["ANTHROPIC_AUTH_TOKEN"]; ok {
+		if value != "unused" {
+			fmt.Printf("%s: ANTHROPIC_AUTH_TOKEN is %q, expected \"unused\"\n", source, value)
+			conflicts++
+		}
+	} else {
+		fmt.Printf("%s: ANTHROPIC_AUTH_TOKEN is not set (recommended: \"unused\")\n", source)
+	}
+	return conflicts
 }
 
 // modelsCmd returns the command to list available models.


### PR DESCRIPTION
# Add Claude Code env conflict check

## Summary

`oc-go-cc validate` checks the proxy configuration itself, but Claude Code can still read persistent `ANTHROPIC_*` settings from `~/.claude/settings.json` or `~/.claude.json`.

If those settings point to an old `ANTHROPIC_BASE_URL` or include a leftover `ANTHROPIC_API_KEY`, Claude Code may fail even when `oc-go-cc` is configured correctly.

This adds a small read-only `oc-go-cc check` command that reports:

- `ANTHROPIC_BASE_URL` mismatches against the configured `http://<host>:<port>`
- whether `ANTHROPIC_API_KEY` is set

The command does not modify Claude Code config files and does not print API key values.

## Usage

```bash
oc-go-cc check
```

Example output:

```text
environment: ANTHROPIC_BASE_URL is "http://127.0.0.1:8045", expected "http://127.0.0.1:3456"
environment: ANTHROPIC_API_KEY is set
Error: found 2 Claude Code env conflict(s)
```