### PR TITLE
feat: inject model capability declaration into system prompts

### DIFF
--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -386,6 +386,12 @@ func getDefaultConfig() string {
   "hot_reload": false,
   "enable_streaming_scenario_routing": false,
   "respect_requested_model": false,
+  "capability_injection": {
+    "enabled": true,
+    "prefix": "",
+    "suffix": "",
+    "overrides": {}
+  },
   "models": {
     "background": {
       "provider": "opencode-go",

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -6,6 +6,13 @@
   "enable_streaming_scenario_routing": false,
   "respect_requested_model": false,
 
+  "capability_injection": {
+    "enabled": true,
+    "prefix": "",
+    "suffix": "",
+    "overrides": {}
+  },
+
   "models": {
     "background": {
       "provider": "opencode-go",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,9 +14,18 @@ type Config struct {
 	Models                         map[string]ModelConfig   `json:"models"`
 	Fallbacks                      map[string][]ModelConfig `json:"fallbacks"`
 	ModelOverrides                 map[string]ModelConfig   `json:"model_overrides"`
+	CapabilityInjection            CapabilityInjectionConfig `json:"capability_injection"`
 	OpenCodeGo                     OpenCodeGoConfig         `json:"opencode_go"`
 	OpenCodeZen                    OpenCodeZenConfig        `json:"opencode_zen"`
 	Logging                        LoggingConfig            `json:"logging"`
+}
+
+// CapabilityInjectionConfig controls model capability injection into system prompts.
+type CapabilityInjectionConfig struct {
+	Enabled   bool              `json:"enabled"`
+	Prefix    string            `json:"prefix"`
+	Suffix    string            `json:"suffix"`
+	Overrides map[string]string `json:"overrides"`
 }
 
 // ModelConfig defines routing rules for a specific model.

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -72,12 +72,13 @@ func NewMessagesHandler(
 	fallbackHandler *router.FallbackHandler,
 	tokenCounter *token.Counter,
 	metrics *metrics.Metrics,
+	capInjection config.CapabilityInjectionConfig,
 ) *MessagesHandler {
 	return &MessagesHandler{
 		client:              openCodeClient,
 		modelRouter:         modelRouter,
 		fallbackHandler:     fallbackHandler,
-		requestTransformer:  transformer.NewRequestTransformer(),
+		requestTransformer:  transformer.NewRequestTransformer(capInjection),
 		responseTransformer: transformer.NewResponseTransformer(),
 		streamHandler:       transformer.NewStreamHandler(),
 		tokenCounter:        tokenCounter,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,6 +58,7 @@ func NewServer(atomic *config.AtomicConfig) (*Server, error) {
 		fallbackHandler,
 		tokenCounter,
 		metrics,
+		cfg.CapabilityInjection,
 	)
 	healthHandler := handlers.NewHealthHandler(tokenCounter, fallbackHandler, metrics)
 

--- a/internal/transformer/capability.go
+++ b/internal/transformer/capability.go
@@ -1,0 +1,410 @@
+// Package transformer handles request and response format conversion
+// between Anthropic Messages API and OpenAI Chat Completions API.
+package transformer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ModelCapability describes what a model can and cannot do.
+type ModelCapability struct {
+	Description       string `json:"description"`        // Human-readable model name
+	Multimodal        bool   `json:"multimodal"`         // Supports image/video input
+	ContextWindow     string `json:"context_window"`     // e.g. "256K", "1M"
+	Reasoning         bool   `json:"reasoning"`          // Supports thinking/reasoning
+	ReasoningNote     string `json:"reasoning_note"`     // Optional note about reasoning
+	MaxTokens         int    `json:"max_tokens"`         // Default max output tokens
+	SupportsTools     bool   `json:"supports_tools"`     // Supports tool/function calling
+}
+
+// CapabilityInjectionConfig controls how model capabilities are injected.
+type CapabilityInjectionConfig struct {
+	Enabled    bool              `json:"enabled"`
+	Prefix     string            `json:"prefix"`     // Text before the capability block
+	Suffix     string            `json:"suffix"`     // Text after the capability block
+	Overrides  map[string]string `json:"overrides"`  // Custom capability text per model ID (exact match)
+}
+
+// GetCapabilityText returns the injected capability text for a given model ID.
+// Returns empty string if no match is found or injection is disabled.
+func (cfg CapabilityInjectionConfig) GetCapabilityText(modelID string) string {
+	if !cfg.Enabled {
+		return ""
+	}
+
+	// Check for exact model ID override first
+	if text, ok := cfg.Overrides[modelID]; ok {
+		return text
+	}
+
+	cap, ok := matchModelCapability(modelID)
+	if !ok {
+		return ""
+	}
+
+	return cfg.formatCapability(modelID, cap)
+}
+
+// formatCapability builds the injection text from a matched capability.
+func (cfg CapabilityInjectionConfig) formatCapability(modelID string, cap ModelCapability) string {
+	var b strings.Builder
+
+	if cfg.Prefix != "" {
+		b.WriteString(cfg.Prefix)
+		b.WriteString("\n")
+	}
+
+	b.WriteString(fmt.Sprintf("## Current Model: %s (%s)\n", cap.Description, modelID))
+	b.WriteString(fmt.Sprintf("- Multimodal (image/video input): %s\n", boolToStr(cap.Multimodal)))
+	b.WriteString(fmt.Sprintf("- Context window: %s\n", cap.ContextWindow))
+
+	if cap.ReasoningNote != "" {
+		b.WriteString(fmt.Sprintf("- Reasoning/thinking: %s (%s)\n", boolToStr(cap.Reasoning), cap.ReasoningNote))
+	} else {
+		b.WriteString(fmt.Sprintf("- Reasoning/thinking: %s\n", boolToStr(cap.Reasoning)))
+	}
+
+	b.WriteString(fmt.Sprintf("- Tool/function calling: %s\n", boolToStr(cap.SupportsTools)))
+
+	if cfg.Suffix != "" {
+		b.WriteString(cfg.Suffix)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// InjectSystemPrompt prepends the capability text to the system prompt.
+// If systemText is empty, the capability text becomes the system prompt.
+func (cfg CapabilityInjectionConfig) InjectSystemPrompt(systemText string, modelID string) string {
+	capText := cfg.GetCapabilityText(modelID)
+	if capText == "" {
+		return systemText
+	}
+
+	if systemText == "" {
+		return capText
+	}
+
+	return capText + "\n\n---\n\n" + systemText
+}
+
+// boolToStr returns "yes" or "no" for a boolean.
+func boolToStr(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+// matchModelCapability finds the best capability match for a model ID.
+// Uses prefix matching so "deepseek-v4-pro" and "deepseek-v4-flash" both match.
+func matchModelCapability(modelID string) (ModelCapability, bool) {
+	lower := strings.ToLower(modelID)
+	for prefix, cap := range modelCapabilityMap {
+		if strings.HasPrefix(lower, prefix) {
+			return cap, true
+		}
+	}
+	return ModelCapability{}, false
+}
+
+// modelCapabilityMap defines known model capabilities keyed by model ID prefix.
+// Ordered roughly by specificity; first prefix match wins.
+var modelCapabilityMap = map[string]ModelCapability{
+	// DeepSeek V4 family
+	"deepseek-v4-pro": {
+		Description:   "DeepSeek V4 Pro",
+		Multimodal:    false,
+		ContextWindow: "1M tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports thinking mode with reasoning_effort",
+		SupportsTools: true,
+	},
+	"deepseek-v4-flash": {
+		Description:   "DeepSeek V4 Flash",
+		Multimodal:    false,
+		ContextWindow: "1M tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports thinking mode with reasoning_effort",
+		SupportsTools: true,
+	},
+	"deepseek-v4": {
+		Description:   "DeepSeek V4",
+		Multimodal:    false,
+		ContextWindow: "1M tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports thinking mode",
+		SupportsTools: true,
+	},
+
+	// DeepSeek V3 / R1 family
+	"deepseek-r1": {
+		Description:   "DeepSeek R1",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     true,
+		ReasoningNote: "built-in chain-of-thought, no separate thinking toggle",
+		SupportsTools: true,
+	},
+	"deepseek-v3": {
+		Description:   "DeepSeek V3",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"deepseek": {
+		Description:   "DeepSeek",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+
+	// Kimi K2 family
+	"kimi-k2.6": {
+		Description:   "Kimi K2.6",
+		Multimodal:    false,
+		ContextWindow: "256K tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports thinking, reasoning_effort: low/medium/high",
+		SupportsTools: true,
+	},
+	"kimi-k2.5": {
+		Description:   "Kimi K2.5",
+		Multimodal:    false,
+		ContextWindow: "256K tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports thinking",
+		SupportsTools: true,
+	},
+	"kimi-k2": {
+		Description:   "Kimi K2",
+		Multimodal:    false,
+		ContextWindow: "256K tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports thinking",
+		SupportsTools: true,
+	},
+	"kimi": {
+		Description:   "Kimi",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+
+	// GLM family
+	"glm-5.1": {
+		Description:   "GLM-5.1",
+		Multimodal:    false,
+		ContextWindow: "200K tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports deep reasoning, no image/video input",
+		SupportsTools: true,
+	},
+	"glm-5": {
+		Description:   "GLM-5",
+		Multimodal:    false,
+		ContextWindow: "200K tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports reasoning",
+		SupportsTools: true,
+	},
+	"glm-4": {
+		Description:   "GLM-4",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"glm": {
+		Description:   "GLM",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+
+	// Qwen family
+	"qwen3.6-plus": {
+		Description:   "Qwen3.6 Plus",
+		Multimodal:    false,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"qwen3.6": {
+		Description:   "Qwen3.6",
+		Multimodal:    false,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"qwen3.5-plus": {
+		Description:   "Qwen3.5 Plus",
+		Multimodal:    false,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"qwen3.5": {
+		Description:   "Qwen3.5",
+		Multimodal:    false,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"qwen3": {
+		Description:   "Qwen3",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"qwen": {
+		Description:   "Qwen",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+
+	// MiniMax family
+	"minimax-m2.7": {
+		Description:   "MiniMax M2.7",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		ReasoningNote: "supports image input via Anthropic-native endpoint",
+		SupportsTools: true,
+	},
+	"minimax-m2.5": {
+		Description:   "MiniMax M2.5",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		ReasoningNote: "supports image input via Anthropic-native endpoint",
+		SupportsTools: true,
+	},
+	"minimax-m2": {
+		Description:   "MiniMax M2",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		ReasoningNote: "supports image input via Anthropic-native endpoint",
+		SupportsTools: true,
+	},
+	"minimax-m1": {
+		Description:   "MiniMax M1",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"minimax": {
+		Description:   "MiniMax",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+
+	// MiMo family
+	"mimo-v2-pro": {
+		Description:   "MiMo V2 Pro",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"mimo-v2": {
+		Description:   "MiMo V2",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"mimo": {
+		Description:   "MiMo",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+
+	// Claude (via Zen)
+	"claude-opus-4": {
+		Description:   "Claude Opus 4",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports extended thinking with budget_tokens",
+		SupportsTools: true,
+	},
+	"claude-sonnet-4": {
+		Description:   "Claude Sonnet 4",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports extended thinking with budget_tokens",
+		SupportsTools: true,
+	},
+	"claude-haiku-4": {
+		Description:   "Claude Haiku 4",
+		Multimodal:    false,
+		ContextWindow: "200K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"claude": {
+		Description:   "Claude (generic)",
+		Multimodal:    true,
+		ContextWindow: "200K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+
+	// GPT / Codex (via Zen)
+	"gpt-5": {
+		Description:   "GPT-5 / Codex",
+		Multimodal:    true,
+		ContextWindow: "128K tokens",
+		Reasoning:     true,
+		ReasoningNote: "supports reasoning_effort",
+		SupportsTools: true,
+	},
+	"codex": {
+		Description:   "Codex",
+		Multimodal:    false,
+		ContextWindow: "128K tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+
+	// Gemini (via Zen)
+	"gemini-2.5": {
+		Description:   "Gemini 2.5",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     true,
+		ReasoningNote: "native multimodal support, supports thinking",
+		SupportsTools: true,
+	},
+	"gemini-2": {
+		Description:   "Gemini 2",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+	"gemini": {
+		Description:   "Gemini",
+		Multimodal:    true,
+		ContextWindow: "1M tokens",
+		Reasoning:     false,
+		SupportsTools: true,
+	},
+}

--- a/internal/transformer/capability_test.go
+++ b/internal/transformer/capability_test.go
@@ -1,0 +1,234 @@
+package transformer
+
+import (
+	"testing"
+
+	"oc-go-cc/internal/config"
+)
+
+func TestMatchModelCapability(t *testing.T) {
+	tests := []struct {
+		modelID     string
+		wantMatch   bool
+		wantDesc    string
+		wantMulti   bool
+		wantContext string
+		wantReason  bool
+		wantTools   bool
+	}{
+		// DeepSeek family
+		{"deepseek-v4-pro", true, "DeepSeek V4 Pro", false, "1M tokens", true, true},
+		{"deepseek-v4-flash", true, "DeepSeek V4 Flash", false, "1M tokens", true, true},
+		{"deepseek-v4", true, "DeepSeek V4", false, "1M tokens", true, true},
+		{"deepseek-r1", true, "DeepSeek R1", false, "128K tokens", true, true},
+		{"deepseek-v3", true, "DeepSeek V3", false, "128K tokens", false, true},
+		// GLM family
+		{"glm-5.1", true, "GLM-5.1", false, "200K tokens", true, true},
+		{"glm-5", true, "GLM-5", false, "200K tokens", true, true},
+		{"glm-4", true, "GLM-4", false, "128K tokens", false, true},
+		// Kimi family
+		{"kimi-k2.6", true, "Kimi K2.6", false, "256K tokens", true, true},
+		{"kimi-k2.5", true, "Kimi K2.5", false, "256K tokens", true, true},
+		{"kimi-k2", true, "Kimi K2", false, "256K tokens", true, true},
+		// Qwen family
+		{"qwen3.6-plus", true, "Qwen3.6 Plus", false, "1M tokens", false, true},
+		{"qwen3.5-plus", true, "Qwen3.5 Plus", false, "1M tokens", false, true},
+		// MiniMax family (multimodal)
+		{"minimax-m2.7", true, "MiniMax M2.7", true, "1M tokens", false, true},
+		{"minimax-m2.5", true, "MiniMax M2.5", true, "1M tokens", false, true},
+		{"minimax-m1", true, "MiniMax M1", true, "1M tokens", false, true},
+		// MiMo family
+		{"mimo-v2-pro", true, "MiMo V2 Pro", false, "128K tokens", false, true},
+		// Claude family (via Zen)
+		{"claude-sonnet-4.5", true, "Claude Sonnet 4", true, "1M tokens", true, true},
+		{"claude-opus-4", true, "Claude Opus 4", true, "1M tokens", true, true},
+		{"claude-haiku-4.5", true, "Claude Haiku 4", false, "200K tokens", false, true},
+		// Unknown model
+		{"unknown-model", false, "", false, "", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			cap, ok := matchModelCapability(tt.modelID)
+			if ok != tt.wantMatch {
+				t.Errorf("matchModelCapability(%q) ok = %v, want %v", tt.modelID, ok, tt.wantMatch)
+				return
+			}
+			if !tt.wantMatch {
+				return
+			}
+			if cap.Description != tt.wantDesc {
+				t.Errorf("Description = %q, want %q", cap.Description, tt.wantDesc)
+			}
+			if cap.Multimodal != tt.wantMulti {
+				t.Errorf("Multimodal = %v, want %v", cap.Multimodal, tt.wantMulti)
+			}
+			if cap.ContextWindow != tt.wantContext {
+				t.Errorf("ContextWindow = %q, want %q", cap.ContextWindow, tt.wantContext)
+			}
+			if cap.Reasoning != tt.wantReason {
+				t.Errorf("Reasoning = %v, want %v", cap.Reasoning, tt.wantReason)
+			}
+			if cap.SupportsTools != tt.wantTools {
+				t.Errorf("SupportsTools = %v, want %v", cap.SupportsTools, tt.wantTools)
+			}
+		})
+	}
+}
+
+func TestMatchModelCapabilityPrefixPriority(t *testing.T) {
+	// More specific prefixes should match before less specific ones.
+	// "deepseek-v4-pro" should match "deepseek-v4-pro" not "deepseek-v4"
+	cap, ok := matchModelCapability("deepseek-v4-pro")
+	if !ok {
+		t.Fatal("expected match for deepseek-v4-pro")
+	}
+	if cap.Description != "DeepSeek V4 Pro" {
+		t.Errorf("got %q, want DeepSeek V4 Pro", cap.Description)
+	}
+
+	// "deepseek-v4" (bare) should match the generic prefix
+	cap, ok = matchModelCapability("deepseek-v4")
+	if !ok {
+		t.Fatal("expected match for deepseek-v4")
+	}
+	if cap.Description != "DeepSeek V4" {
+		t.Errorf("got %q, want DeepSeek V4", cap.Description)
+	}
+}
+
+func TestCapabilityInjectionDisabled(t *testing.T) {
+	cfg := config.CapabilityInjectionConfig{
+		Enabled: false,
+	}
+
+	text := cfg.GetCapabilityText("glm-5.1")
+	if text != "" {
+		t.Errorf("expected empty text when disabled, got %q", text)
+	}
+
+	result := cfg.InjectSystemPrompt("original prompt", "glm-5.1")
+	if result != "original prompt" {
+		t.Errorf("expected unchanged prompt when disabled, got %q", result)
+	}
+}
+
+func TestCapabilityInjectionEnabled(t *testing.T) {
+	cfg := config.CapabilityInjectionConfig{
+		Enabled: true,
+	}
+
+	text := cfg.GetCapabilityText("glm-5.1")
+	if text == "" {
+		t.Fatal("expected non-empty capability text for glm-5.1")
+	}
+
+	// Verify it contains the key information
+	checks := []string{
+		"GLM-5.1",
+		"glm-5.1",
+		"Multimodal",
+		"Context window",
+		"200K tokens",
+		"Reasoning/thinking",
+		"Tool/function calling",
+		"no", // multimodal = false -> "no"
+	}
+	for _, check := range checks {
+		if !contains(text, check) {
+			t.Errorf("capability text missing %q:\n%s", check, text)
+		}
+	}
+}
+
+func TestInjectSystemPrompt(t *testing.T) {
+	cfg := config.CapabilityInjectionConfig{
+		Enabled: true,
+	}
+
+	// With existing system prompt
+	result := cfg.InjectSystemPrompt("Be helpful.", "kimi-k2.6")
+	if !contains(result, "Be helpful.") {
+		t.Error("original system prompt should be preserved")
+	}
+	if !contains(result, "Kimi K2.6") {
+		t.Error("capability info should be prepended")
+	}
+	// Capability should come before the original prompt
+	capIdx := indexOf(result, "Kimi K2.6")
+	promptIdx := indexOf(result, "Be helpful.")
+	if capIdx >= promptIdx {
+		t.Error("capability should appear before the original system prompt")
+	}
+
+	// With empty system prompt
+	result = cfg.InjectSystemPrompt("", "qwen3.6-plus")
+	if result == "" {
+		t.Error("should still inject capability even with empty system prompt")
+	}
+	if contains(result, "---") {
+		t.Error("should not add separator when there is no original system prompt")
+	}
+}
+
+func TestCapabilityInjectionWithPrefixSuffix(t *testing.T) {
+	cfg := config.CapabilityInjectionConfig{
+		Enabled: true,
+		Prefix:  "[MODEL CAPABILITIES]",
+		Suffix:  "[END CAPABILITIES]",
+	}
+
+	text := cfg.GetCapabilityText("deepseek-v4-pro")
+	if !contains(text, "[MODEL CAPABILITIES]") {
+		t.Error("should contain prefix")
+	}
+	if !contains(text, "[END CAPABILITIES]") {
+		t.Error("should contain suffix")
+	}
+}
+
+func TestCapabilityInjectionOverride(t *testing.T) {
+	customText := "This model can do everything. Trust it."
+	cfg := config.CapabilityInjectionConfig{
+		Enabled: true,
+		Overrides: map[string]string{
+			"my-custom-model": customText,
+		},
+	}
+
+	// Exact model ID match should use override
+	text := cfg.GetCapabilityText("my-custom-model")
+	if text != customText {
+		t.Errorf("override text = %q, want %q", text, customText)
+	}
+
+	// Non-matching model should fall back to prefix matching
+	text = cfg.GetCapabilityText("glm-5.1")
+	if text == "" {
+		t.Error("non-override model should still get capability text via prefix matching")
+	}
+}
+
+func TestUnknownModelNoInjection(t *testing.T) {
+	cfg := config.CapabilityInjectionConfig{
+		Enabled: true,
+	}
+
+	text := cfg.GetCapabilityText("completely-unknown-model-xyz")
+	if text != "" {
+		t.Errorf("expected empty text for unknown model, got %q", text)
+	}
+}
+
+func contains(s, substr string) bool {
+	return indexOf(s, substr) >= 0
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -12,11 +12,13 @@ import (
 )
 
 // RequestTransformer converts Anthropic requests to OpenAI format.
-type RequestTransformer struct{}
+type RequestTransformer struct {
+	capInjection config.CapabilityInjectionConfig
+}
 
 // NewRequestTransformer creates a new request transformer.
-func NewRequestTransformer() *RequestTransformer {
-	return &RequestTransformer{}
+func NewRequestTransformer(capInjection config.CapabilityInjectionConfig) *RequestTransformer {
+	return &RequestTransformer{capInjection: capInjection}
 }
 
 // isThinkingDisabled checks if the thinking JSON config explicitly sets type to "disabled".
@@ -302,6 +304,10 @@ func (t *RequestTransformer) transformMessages(anthropicReq *types.MessageReques
 
 	// Add system message if present, preserving cache_control if available
 	systemText := anthropicReq.SystemText()
+
+	// Inject model capability declaration into system prompt when configured.
+	systemText = t.capInjection.InjectSystemPrompt(systemText, modelID)
+
 	if systemText != "" {
 		systemMsg := types.ChatMessage{
 			Role:    "system",
@@ -515,6 +521,10 @@ func (t *RequestTransformer) TransformToResponses(
 
 	// Add system message if present
 	systemText := anthropicReq.SystemText()
+
+	// Inject model capability declaration into system prompt when configured.
+	systemText = t.capInjection.InjectSystemPrompt(systemText, model.ModelID)
+
 	if systemText != "" {
 		content, _ := json.Marshal(systemText)
 		input = append(input, types.ResponsesInput{
@@ -608,6 +618,10 @@ func (t *RequestTransformer) TransformToGemini(
 	// Add system instruction via generation config (Gemini handles system separately)
 	// For now, prepend system as a user message if present
 	systemText := anthropicReq.SystemText()
+
+	// Inject model capability declaration into system prompt when configured.
+	systemText = t.capInjection.InjectSystemPrompt(systemText, model.ModelID)
+
 	if systemText != "" {
 		contents = append(contents, types.GeminiContent{
 			Role: "user",

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -69,7 +69,7 @@ func TestTransformRequestRoundTripReasoning(t *testing.T) {
 	}
 
 	// Step 4: Transform back to OpenAI request.
-	qt := NewRequestTransformer()
+	qt := NewRequestTransformer(config.CapabilityInjectionConfig{})
 	openaiReq, err := qt.TransformRequest(anthropicReq, config.ModelConfig{ModelID: "deepseek-v4-flash"})
 	if err != nil {
 		t.Fatalf("TransformRequest error: %v", err)
@@ -106,7 +106,7 @@ func TestTransformRequestRoundTripReasoning(t *testing.T) {
 }
 
 func TestTransformRequestPreservesThinkingAsReasoningContent(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 	stream := true
 
 	req := &types.MessageRequest{
@@ -158,7 +158,7 @@ func TestTransformRequestPreservesThinkingAsReasoningContent(t *testing.T) {
 }
 
 func TestTransformRequestIncludesStreamUsageOptions(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 	stream := true
 
 	req := &types.MessageRequest{
@@ -184,7 +184,7 @@ func TestTransformRequestIncludesStreamUsageOptions(t *testing.T) {
 }
 
 func TestTransformRequestOmitsStreamUsageOptionsWhenStreamingDisabled(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 	stream := false
 
 	req := &types.MessageRequest{
@@ -207,7 +207,7 @@ func TestTransformRequestOmitsStreamUsageOptionsWhenStreamingDisabled(t *testing
 }
 
 func TestTransformRequestIncludesEmptyReasoningContentForToolCalls(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -237,7 +237,7 @@ func TestTransformRequestIncludesEmptyReasoningContentForToolCalls(t *testing.T)
 }
 
 func TestTransformRequestSerializesAssistantToolCallContent(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -277,7 +277,7 @@ func TestTransformRequestSerializesAssistantToolCallContent(t *testing.T) {
 }
 
 func TestTransformRequestAppliesReasoningEffortAndThinking(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	// When the conversation history already contains thinking blocks,
 	// reasoning_effort and thinking should be applied.
@@ -317,7 +317,7 @@ func TestTransformRequestAppliesReasoningEffortAndThinking(t *testing.T) {
 }
 
 func TestTransformRequestDeepSeekHistoryGuardOverridesExplicitThinking(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	// DeepSeek rejects thinking mode when historical assistant messages lack
 	// reasoning_content, so the safety guard must win over explicit config.
@@ -348,7 +348,7 @@ func TestTransformRequestDeepSeekHistoryGuardOverridesExplicitThinking(t *testin
 }
 
 func TestTransformRequestFirstTurnEnablesThinkingWithReasoningEffort(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	// First turn (no assistant messages in history), only reasoning_effort
 	// set in config → thinking should be enabled so DeepSeek can produce
@@ -381,7 +381,7 @@ func TestTransformRequestFirstTurnEnablesThinkingWithReasoningEffort(t *testing.
 }
 
 func TestTransformRequestRequestDisabledThinkingSkipsReasoningEffort(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -409,7 +409,7 @@ func TestTransformRequestRequestDisabledThinkingSkipsReasoningEffort(t *testing.
 }
 
 func TestTransformRequestThinkingDecisionMatrix(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	userOnly := []types.Message{
 		{Role: "user", Content: json.RawMessage(`"solve this carefully"`)},
@@ -541,7 +541,7 @@ func TestTransformRequestThinkingDecisionMatrix(t *testing.T) {
 }
 
 func TestTransformRequestFirstTurnReasoningEffortDefaultsToHigh(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	// First turn with thinking in history (from previous response round-trip).
 	// No explicit ReasoningEffort → defaults to "high".
@@ -581,7 +581,7 @@ func TestTransformRequestFirstTurnReasoningEffortDefaultsToHigh(t *testing.T) {
 }
 
 func TestTransformRequestSafetyGuardWithReasoningEffortOnly(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	// Only ReasoningEffort set (no explicit Thinking). History has an
 	// assistant message without thinking blocks + it's a DeepSeek model
@@ -614,7 +614,7 @@ func TestTransformRequestSafetyGuardWithReasoningEffortOnly(t *testing.T) {
 }
 
 func TestTransformRequestNoThinkingConfigNoHistory(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	// No Thinking, no ReasoningEffort, no thinking history → nothing set.
 	req := &types.MessageRequest{
@@ -641,7 +641,7 @@ func TestTransformRequestNoThinkingConfigNoHistory(t *testing.T) {
 }
 
 func TestTransformRequestPreservesSystemCacheControl(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -679,7 +679,7 @@ func TestTransformRequestPreservesSystemCacheControl(t *testing.T) {
 }
 
 func TestTransformRequestSkipsCacheControlForKimiSystem(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -714,7 +714,7 @@ func TestTransformRequestSkipsCacheControlForKimiSystem(t *testing.T) {
 }
 
 func TestTransformRequestStripsCacheControlForNonKimiNonDeepSeek(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -748,7 +748,7 @@ func TestTransformRequestStripsCacheControlForNonKimiNonDeepSeek(t *testing.T) {
 }
 
 func TestTransformRequestStripsCacheControlForNonDeepSeek(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -773,7 +773,7 @@ func TestTransformRequestStripsCacheControlForNonDeepSeek(t *testing.T) {
 }
 
 func TestTransformRequestOmitsCacheControlWhenAbsent(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -803,7 +803,7 @@ func TestTransformRequestOmitsCacheControlWhenAbsent(t *testing.T) {
 }
 
 func TestTransformRequestPlacesToolResultsBeforeUserText(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -853,7 +853,7 @@ func TestTransformRequestPlacesToolResultsBeforeUserText(t *testing.T) {
 }
 
 func TestTransformRequestSkipsReasoningEffortWhenThinkingDisabled(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	// When thinking is explicitly disabled in model config, reasoning_effort
 	// must NOT be set — DeepSeek returns 400 if both are present.
@@ -890,7 +890,7 @@ func TestTransformRequestSkipsReasoningEffortWhenThinkingDisabled(t *testing.T) 
 }
 
 func TestTransformRequestOmitsPlaceholderForDeepSeek(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -919,7 +919,7 @@ func TestTransformRequestOmitsPlaceholderForDeepSeek(t *testing.T) {
 }
 
 func TestTransformRequestDeepSeekPlaceholderWithThinkingHistory(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	// When thinking history exists, DeepSeek assistant messages with tool_calls
 	// but no thinking block MUST get a placeholder reasoning_content, because
@@ -986,7 +986,7 @@ func TestTransformRequestDeepSeekPlaceholderWithThinkingHistory(t *testing.T) {
 // reasoning_content on EVERY assistant message, not just tool_use ones, so
 // the proxy must add the placeholder for text-only turns too.
 func TestTransformRequestDeepSeekPlaceholderForTextOnlyAssistant(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -1075,7 +1075,7 @@ func TestTransformRequestDeepSeekPlaceholderForTextOnlyAssistant(t *testing.T) {
 // explicitly send `thinking: disabled` so upstream switches off thinking
 // mode and stops demanding reasoning_content.
 func TestTransformRequestForceDisablesThinkingForDeepSeekWithoutHistory(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -1121,7 +1121,7 @@ func TestTransformRequestForceDisablesThinkingForDeepSeekWithoutHistory(t *testi
 //     after the first reasoning response from the upstream-default mode)
 //     returns 400 on the next request.
 func TestTransformRequestExtractsThinkingFromToolUseBlock(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 
 	req := &types.MessageRequest{
 		Model:     "claude-test",
@@ -1193,7 +1193,7 @@ func mustJSONBytes(t *testing.T, v any) json.RawMessage {
 }
 
 func TestTransformRequestStandardModelIgnoresThinkingAndEffort(t *testing.T) {
-	transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer(config.CapabilityInjectionConfig{})
 	stream := true
 
 	req := &types.MessageRequest{


### PR DESCRIPTION
## Summary

Automatically prepend a **model capability declaration** to the system prompt during Anthropic→OpenAI request transformation. This solves the common problem where upstream models routed through a proxy layer don't know their own capabilities (multimodal support, context window size, reasoning support, etc.).

## Problem

When using OpenCode Go's routing (GLM-5.1, DeepSeek V4, Kimi K2.6, etc.), the selected model receives no information about its actual capabilities. This causes:
- Models that don't support images returning 400 errors when images are in the conversation history
- Models being unaware of their context window limits
- Confusion about reasoning/thinking mode support

## Solution

Injects capability info at the top of the system prompt, e.g.:

```
## Current Model: GLM-5.1 (glm-5.1)
- Multimodal (image/video input): no
- Context window: 200K tokens
- Reasoning/thinking: yes (supports deep reasoning, no image/video input)
- Tool/function calling: yes

---

(original system prompt)
```

## Changes

- **`internal/transformer/capability.go`** (new) — model capability map with prefix matching, covering all major OpenCode Go models + Zen models
- **`internal/transformer/request.go`** — inject capability text in all three transform paths (OpenAI Chat, Responses, Gemini)
- **`internal/config/config.go`** — `CapabilityInjectionConfig` struct with `enabled`, `prefix`, `suffix`, `overrides` fields
- **`cmd/oc-go-cc/main.go`** — default config template
- **`configs/config.example.json`** — example config

## Configuration

```json
"capability_injection": {
  "enabled": true,
  "prefix": "",
  "suffix": "",
  "overrides": {}
}
```

Set `enabled: false` to disable. Use `overrides` for custom capability text per exact model ID.

## Models covered

DeepSeek V4 (Pro/Flash/R1/V3), GLM (5.1/5/4), Kimi K2 (2.6/2.5/2), Qwen3 (3.6/3.5), MiniMax (M2.7/M2.5/M2/M1), MiMo V2, Claude (Opus 4/Sonnet 4/Haiku 4), GPT-5/Codex, Gemini 2.5/2