### PR TITLE
feat: support image multimodal content in Anthropic-to-OpenAI conversion

### DIFF
--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -11,20 +11,23 @@
       "provider": "opencode-go",
       "model_id": "qwen3.5-plus",
       "temperature": 0.5,
-      "max_tokens": 2048
+      "max_tokens": 2048,
+      "vision": true
     },
     "default": {
       "provider": "opencode-go",
       "model_id": "kimi-k2.6",
       "temperature": 0.7,
-      "max_tokens": 4096
+      "max_tokens": 4096,
+      "vision": true
     },
     "long_context": {
       "provider": "opencode-go",
       "model_id": "minimax-m2.5",
       "temperature": 0.7,
       "max_tokens": 16384,
-      "context_threshold": 80000
+      "context_threshold": 80000,
+      "vision": true
     },
     "deepseek-v4-pro": {
       "provider": "opencode-go",
@@ -50,19 +53,22 @@
       "provider": "opencode-go",
       "model_id": "glm-5",
       "temperature": 0.7,
-      "max_tokens": 8192
+      "max_tokens": 8192,
+      "vision": true
     },
     "complex": {
       "provider": "opencode-go",
       "model_id": "glm-5.1",
       "temperature": 0.7,
-      "max_tokens": 4096
+      "max_tokens": 4096,
+      "vision": true
     },
     "fast": {
       "provider": "opencode-go",
       "model_id": "qwen3.6-plus",
       "temperature": 0.7,
-      "max_tokens": 4096
+      "max_tokens": 4096,
+      "vision": true
     }
   },
 
@@ -98,7 +104,8 @@
       "provider": "opencode-zen",
       "model_id": "claude-sonnet-4.5",
       "temperature": 0.7,
-      "max_tokens": 8192
+      "max_tokens": 8192,
+      "vision": true
     }
   },
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type ModelConfig struct {
 	ContextThreshold int             `json:"context_threshold"`
 	ReasoningEffort  string          `json:"reasoning_effort"`
 	Thinking         json.RawMessage `json:"thinking,omitempty"`
+	Vision           bool            `json:"vision"`
 }
 
 // OpenCodeGoConfig holds the upstream OpenCode Go API settings.

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -412,7 +412,10 @@ func (t *RequestTransformer) transformUserMessage(blocks []types.ContentBlock) (
 				})
 			}
 			parts = append(parts, imageParts...)
-			contentJSON, _ := json.Marshal(parts)
+			contentJSON, err := json.Marshal(parts)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal multimodal content: %w", err)
+				}
 			result = append(result, types.ChatMessage{Role: "user", Content: contentJSON})
 		} else {
 			// Text-only message

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -66,7 +66,7 @@ func (t *RequestTransformer) TransformRequest(
 	model config.ModelConfig,
 ) (*types.ChatCompletionRequest, error) {
 	// Transform messages
-	messages, err := t.transformMessages(anthropicReq, model.ModelID)
+	messages, err := t.transformMessages(anthropicReq, model.ModelID, model.Vision)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform messages: %w", err)
 	}
@@ -301,7 +301,7 @@ func hasAssistantMessages(messages []types.Message) bool {
 }
 
 // transformMessages converts Anthropic messages to OpenAI format.
-func (t *RequestTransformer) transformMessages(anthropicReq *types.MessageRequest, modelID string) ([]types.ChatMessage, error) {
+func (t *RequestTransformer) transformMessages(anthropicReq *types.MessageRequest, modelID string, vision bool) ([]types.ChatMessage, error) {
 	hasThinking := HasThinkingBlocks(anthropicReq.Messages)
 
 	var result []types.ChatMessage
@@ -331,7 +331,7 @@ func (t *RequestTransformer) transformMessages(anthropicReq *types.MessageReques
 
 	// Transform each message
 	for _, msg := range anthropicReq.Messages {
-		openaiMsgs, err := t.transformMessage(msg, modelID, hasThinking)
+		openaiMsgs, err := t.transformMessage(msg, modelID, hasThinking, vision)
 		if err != nil {
 			return nil, err
 		}
@@ -343,12 +343,12 @@ func (t *RequestTransformer) transformMessages(anthropicReq *types.MessageReques
 
 // transformMessage converts a single Anthropic message to one or more OpenAI messages.
 // Tool_use and tool_result require special handling to map to OpenAI's function calling format.
-func (t *RequestTransformer) transformMessage(msg types.Message, modelID string, hasThinkingInHistory bool) ([]types.ChatMessage, error) {
+func (t *RequestTransformer) transformMessage(msg types.Message, modelID string, hasThinkingInHistory bool, vision bool) ([]types.ChatMessage, error) {
 	blocks := msg.ContentBlocks()
 
 	switch msg.Role {
 	case "user":
-		return t.transformUserMessage(blocks)
+		return t.transformUserMessage(blocks, vision)
 	case "assistant":
 		return t.transformAssistantMessage(blocks, modelID, hasThinkingInHistory)
 	default:
@@ -365,12 +365,14 @@ func (t *RequestTransformer) transformMessage(msg types.Message, modelID string,
 
 // transformUserMessage converts a user message with potential tool_result and image blocks.
 // Image blocks are converted to OpenAI's multimodal content format (content array
-// with image_url parts) so that vision-capable models (Kimi K2.6, etc.) receive
-// the actual image data instead of a text placeholder.
-func (t *RequestTransformer) transformUserMessage(blocks []types.ContentBlock) ([]types.ChatMessage, error) {
+// with image_url parts) so that vision-capable models receive the actual image data.
+// For models without vision support, image blocks are replaced with a "[Image]" text
+// placeholder to prevent upstream 400 errors from unsupported image_url parts.
+func (t *RequestTransformer) transformUserMessage(blocks []types.ContentBlock, vision bool) ([]types.ChatMessage, error) {
 	var result []types.ChatMessage
 	var textParts []string
 	var imageParts []types.ChatContentPart
+	hasImage := false
 
 	for _, block := range blocks {
 		switch block.Type {
@@ -386,12 +388,16 @@ func (t *RequestTransformer) transformUserMessage(blocks []types.ContentBlock) (
 			})
 		case "image":
 			if block.Source != nil {
-				imageParts = append(imageParts, types.ChatContentPart{
-					Type: "image_url",
-					ImageURL: &types.ImageURL{
-						URL: fmt.Sprintf("data:%s;base64,%s", block.Source.MediaType, block.Source.Data),
-					},
-				})
+				if vision {
+					imageParts = append(imageParts, types.ChatContentPart{
+						Type: "image_url",
+						ImageURL: &types.ImageURL{
+							URL: fmt.Sprintf("data:%s;base64,%s", block.Source.MediaType, block.Source.Data),
+						},
+					})
+				} else {
+					hasImage = true
+				}
 			}
 		}
 	}
@@ -401,7 +407,7 @@ func (t *RequestTransformer) transformUserMessage(blocks []types.ContentBlock) (
 	// immediately after the assistant message that emitted tool_calls.
 	// If the Anthropic user turn also includes free-form text and/or images,
 	// emit it as a subsequent user message after all tool results.
-	if len(textParts) > 0 || len(imageParts) > 0 {
+	if len(textParts) > 0 || len(imageParts) > 0 || hasImage {
 		if len(imageParts) > 0 {
 			// Multimodal message: build content array with text + image_url parts
 			var parts []types.ChatContentPart
@@ -413,15 +419,23 @@ func (t *RequestTransformer) transformUserMessage(blocks []types.ContentBlock) (
 			}
 			parts = append(parts, imageParts...)
 			contentJSON, err := json.Marshal(parts)
-				if err != nil {
-					return nil, fmt.Errorf("failed to marshal multimodal content: %w", err)
-				}
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal multimodal content: %w", err)
+			}
 			result = append(result, types.ChatMessage{Role: "user", Content: contentJSON})
 		} else {
-			// Text-only message
+			// Text-only message (possibly with image placeholder for non-vision models)
+			text := strings.Join(textParts, "")
+			if hasImage {
+				if text != "" {
+					text += "\n\n[Image]"
+				} else {
+					text = "[Image]"
+				}
+			}
 			result = append(result, types.ChatMessage{
 				Role:    "user",
-				Content: contentText(strings.Join(textParts, "")),
+				Content: contentText(text),
 			})
 		}
 	}

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -578,6 +578,8 @@ func (t *RequestTransformer) TransformToResponses(
 			switch block.Type {
 			case "text":
 				textParts = append(textParts, block.Text)
+			case "image":
+				textParts = append(textParts, "[Image]")
 			case "tool_result":
 				// For Responses API, tool results are separate items
 				toolContent := block.TextContent()
@@ -678,6 +680,8 @@ func (t *RequestTransformer) TransformToGemini(
 			switch block.Type {
 			case "text":
 				textParts = append(textParts, block.Text)
+			case "image":
+				textParts = append(textParts, "[Image]")
 			case "tool_result":
 				toolContent := block.TextContent()
 				contents = append(contents, types.GeminiContent{

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -11,6 +11,12 @@ import (
 	"oc-go-cc/pkg/types"
 )
 
+// contentText is a convenience wrapper around types.TextContent for brevity
+// at call sites that construct ChatMessage values.
+func contentText(s string) json.RawMessage {
+	return types.TextContent(s)
+}
+
 // RequestTransformer converts Anthropic requests to OpenAI format.
 type RequestTransformer struct{}
 
@@ -305,7 +311,7 @@ func (t *RequestTransformer) transformMessages(anthropicReq *types.MessageReques
 	if systemText != "" {
 		systemMsg := types.ChatMessage{
 			Role:    "system",
-			Content: systemText,
+			Content: contentText(systemText),
 		}
 		// Try to extract cache_control from system array blocks
 		// Kimi models reject cache_control, skip for those.
@@ -353,14 +359,18 @@ func (t *RequestTransformer) transformMessage(msg types.Message, modelID string,
 				text += b.Text
 			}
 		}
-		return []types.ChatMessage{{Role: msg.Role, Content: text}}, nil
+		return []types.ChatMessage{{Role: msg.Role, Content: contentText(text)}}, nil
 	}
 }
 
-// transformUserMessage converts a user message with potential tool_result blocks.
+// transformUserMessage converts a user message with potential tool_result and image blocks.
+// Image blocks are converted to OpenAI's multimodal content format (content array
+// with image_url parts) so that vision-capable models (Kimi K2.6, etc.) receive
+// the actual image data instead of a text placeholder.
 func (t *RequestTransformer) transformUserMessage(blocks []types.ContentBlock) ([]types.ChatMessage, error) {
 	var result []types.ChatMessage
 	var textParts []string
+	var imageParts []types.ChatContentPart
 
 	for _, block := range blocks {
 		switch block.Type {
@@ -371,27 +381,46 @@ func (t *RequestTransformer) transformUserMessage(blocks []types.ContentBlock) (
 			toolContent := block.TextContent()
 			result = append(result, types.ChatMessage{
 				Role:       "tool",
-				Content:    toolContent,
+				Content:    contentText(toolContent),
 				ToolCallID: block.GetToolID(),
 			})
 		case "image":
-			// Images not supported in text-only models, skip
-			textParts = append(textParts, "[Image]")
+			if block.Source != nil {
+				imageParts = append(imageParts, types.ChatContentPart{
+					Type: "image_url",
+					ImageURL: &types.ImageURL{
+						URL: fmt.Sprintf("data:%s;base64,%s", block.Source.MediaType, block.Source.Data),
+					},
+				})
+			}
 		}
 	}
 
-	// If there's text content, add it as a user message
-	if len(textParts) > 0 {
-		text := ""
-		for _, p := range textParts {
-			text += p
+	// If there's text or image content, add it as a user message.
+	// OpenAI-compatible tool calling requires tool responses to appear
+	// immediately after the assistant message that emitted tool_calls.
+	// If the Anthropic user turn also includes free-form text and/or images,
+	// emit it as a subsequent user message after all tool results.
+	if len(textParts) > 0 || len(imageParts) > 0 {
+		if len(imageParts) > 0 {
+			// Multimodal message: build content array with text + image_url parts
+			var parts []types.ChatContentPart
+			if len(textParts) > 0 {
+				parts = append(parts, types.ChatContentPart{
+					Type: "text",
+					Text: strings.Join(textParts, ""),
+				})
+			}
+			parts = append(parts, imageParts...)
+			contentJSON, _ := json.Marshal(parts)
+			result = append(result, types.ChatMessage{Role: "user", Content: contentJSON})
+		} else {
+			// Text-only message
+			result = append(result, types.ChatMessage{
+				Role:    "user",
+				Content: contentText(strings.Join(textParts, "")),
+			})
 		}
-		// OpenAI-compatible tool calling requires tool responses to appear
-		// immediately after the assistant message that emitted tool_calls.
-		// If the Anthropic user turn also includes free-form text, emit it as
-		// a subsequent user message after all tool results.
-		userMsg := types.ChatMessage{Role: "user", Content: text}
-		result = append(result, userMsg)
 	}
 
 	return result, nil
@@ -474,7 +503,7 @@ func (t *RequestTransformer) transformAssistantMessage(blocks []types.ContentBlo
 
 	msg := types.ChatMessage{
 		Role:             "assistant",
-		Content:          content,
+		Content:          contentText(content),
 		ReasoningContent: reasoningContentPtr,
 		ToolCalls:        toolCalls,
 	}

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -24,7 +24,7 @@ func TestTransformRequestRoundTripReasoning(t *testing.T) {
 			Index: 0,
 			Message: types.ChatMessage{
 				Role:             "assistant",
-				Content:          "The answer is 42",
+				Content:          contentText("The answer is 42"),
 				ReasoningContent: &deepSeekReasoning,
 			},
 			FinishReason: "stop",
@@ -667,7 +667,7 @@ func TestTransformRequestPreservesSystemCacheControl(t *testing.T) {
 	if got, want := systemMsg.Role, "system"; got != want {
 		t.Fatalf("Messages[0].Role = %q, want %q", got, want)
 	}
-	if got, want := systemMsg.Content, "You are helpful"; got != want {
+	if got, want := systemMsg.ContentText(), "You are helpful"; got != want {
 		t.Fatalf("Messages[0].Content = %q, want %q", got, want)
 	}
 	if systemMsg.CacheControl == nil {
@@ -705,7 +705,7 @@ func TestTransformRequestSkipsCacheControlForKimiSystem(t *testing.T) {
 	if got, want := systemMsg.Role, "system"; got != want {
 		t.Fatalf("Messages[0].Role = %q, want %q", got, want)
 	}
-	if got, want := systemMsg.Content, "system prompt"; got != want {
+	if got, want := systemMsg.ContentText(), "system prompt"; got != want {
 		t.Fatalf("Messages[0].Content = %q, want %q", got, want)
 	}
 	if systemMsg.CacheControl != nil {
@@ -847,7 +847,7 @@ func TestTransformRequestPlacesToolResultsBeforeUserText(t *testing.T) {
 	if got, want := openaiReq.Messages[2].Role, "user"; got != want {
 		t.Fatalf("Messages[2].Role = %q, want %q", got, want)
 	}
-	if got, want := openaiReq.Messages[2].Content, "now continue"; got != want {
+	if got, want := openaiReq.Messages[2].ContentText(), "now continue"; got != want {
 		t.Fatalf("Messages[2].Content = %q, want %q", got, want)
 	}
 }

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -1320,7 +1320,7 @@ func TestTransformRequestNonVisionModelImageOnly(t *testing.T) {
 	}
 }
 
-	func TestTransformRequestStandardModelIgnoresThinkingAndEffort(t *testing.T) {
+func TestTransformRequestStandardModelIgnoresThinkingAndEffort(t *testing.T) {
 	transformer := NewRequestTransformer()
 	stream := true
 

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -3,6 +3,7 @@ package transformer
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"oc-go-cc/internal/config"
@@ -1192,7 +1193,134 @@ func mustJSONBytes(t *testing.T, v any) json.RawMessage {
 	return json.RawMessage(b)
 }
 
-func TestTransformRequestStandardModelIgnoresThinkingAndEffort(t *testing.T) {
+func TestTransformRequestVisionModelPassesImageContent(t *testing.T) {
+		transformer := NewRequestTransformer()
+
+		// User message with both text and an image
+		req := &types.MessageRequest{
+			Model:     "claude-test",
+			MaxTokens: 256,
+			Messages: []types.Message{
+				{
+					Role: "user",
+					Content: json.RawMessage(`[
+						{"type":"text","text":"What's in this image?"},
+						{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
+					]`),
+				},
+			},
+		}
+
+		// Vision-capable model: images should be passed as image_url content parts
+		openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+			ModelID: "kimi-k2.6",
+			Vision:  true,
+		})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+
+		if got, want := len(openaiReq.Messages), 1; got != want {
+			t.Fatalf("len(Messages) = %d, want %d", got, want)
+		}
+
+		body, err := json.Marshal(openaiReq.Messages[0].Content)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+		if !bytes.Contains(body, []byte(`"type":"image_url"`)) {
+			t.Fatalf("vision model content missing image_url: %s", body)
+		}
+		if !bytes.Contains(body, []byte(`"data:image/png;base64,iVBORw0KGgo="`)) {
+			t.Fatalf("vision model content missing image data URL: %s", body)
+		}
+		if !bytes.Contains(body, []byte(`"What's in this image?"`)) {
+			t.Fatalf("vision model content missing text: %s", body)
+		}
+	}
+
+	func TestTransformRequestNonVisionModelStripsImages(t *testing.T) {
+		transformer := NewRequestTransformer()
+
+		// User message with both text and an image
+		req := &types.MessageRequest{
+			Model:     "claude-test",
+			MaxTokens: 256,
+			Messages: []types.Message{
+				{
+					Role: "user",
+					Content: json.RawMessage(`[
+						{"type":"text","text":"What's in this image?"},
+						{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
+					]`),
+				},
+			},
+		}
+
+		// Non-vision model: images should be replaced with [Image] placeholder
+		openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+			ModelID: "deepseek-v4-pro",
+		})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+
+		if got, want := len(openaiReq.Messages), 1; got != want {
+			t.Fatalf("len(Messages) = %d, want %d", got, want)
+		}
+
+		content := openaiReq.Messages[0].ContentText()
+		if !strings.Contains(content, "[Image]") {
+			t.Fatalf("non-vision model content missing [Image] placeholder: %q", content)
+		}
+		if !strings.Contains(content, "What's in this image?") {
+			t.Fatalf("non-vision model content missing original text: %q", content)
+		}
+		// Verify no image_url was sent
+		body, err := json.Marshal(openaiReq.Messages[0].Content)
+		if err != nil {
+			t.Fatalf("json.Marshal() error = %v", err)
+		}
+		if bytes.Contains(body, []byte(`"type":"image_url"`)) {
+			t.Fatalf("non-vision model should not contain image_url: %s", body)
+		}
+	}
+
+	func TestTransformRequestNonVisionModelImageOnly(t *testing.T) {
+		transformer := NewRequestTransformer()
+
+		// User message with only an image, no text
+		req := &types.MessageRequest{
+			Model:     "claude-test",
+			MaxTokens: 256,
+			Messages: []types.Message{
+				{
+					Role: "user",
+					Content: json.RawMessage(`[
+						{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
+					]`),
+				},
+			},
+		}
+
+		openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+			ModelID: "deepseek-v4-flash",
+		})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+
+		if got, want := len(openaiReq.Messages), 1; got != want {
+			t.Fatalf("len(Messages) = %d, want %d", got, want)
+		}
+
+		content := openaiReq.Messages[0].ContentText()
+		if got, want := content, "[Image]"; got != want {
+			t.Fatalf("ContentText() = %q, want %q", got, want)
+		}
+	}
+
+	func TestTransformRequestStandardModelIgnoresThinkingAndEffort(t *testing.T) {
 	transformer := NewRequestTransformer()
 	stream := true
 

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -1194,131 +1194,131 @@ func mustJSONBytes(t *testing.T, v any) json.RawMessage {
 }
 
 func TestTransformRequestVisionModelPassesImageContent(t *testing.T) {
-		transformer := NewRequestTransformer()
+	transformer := NewRequestTransformer()
 
-		// User message with both text and an image
-		req := &types.MessageRequest{
-			Model:     "claude-test",
-			MaxTokens: 256,
-			Messages: []types.Message{
-				{
-					Role: "user",
-					Content: json.RawMessage(`[
-						{"type":"text","text":"What's in this image?"},
-						{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
-					]`),
-				},
+	// User message with both text and an image
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{
+				Role: "user",
+				Content: json.RawMessage(`[
+					{"type":"text","text":"What's in this image?"},
+					{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
+				]`),
 			},
-		}
-
-		// Vision-capable model: images should be passed as image_url content parts
-		openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
-			ModelID: "kimi-k2.6",
-			Vision:  true,
-		})
-		if err != nil {
-			t.Fatalf("TransformRequest() error = %v", err)
-		}
-
-		if got, want := len(openaiReq.Messages), 1; got != want {
-			t.Fatalf("len(Messages) = %d, want %d", got, want)
-		}
-
-		body, err := json.Marshal(openaiReq.Messages[0].Content)
-		if err != nil {
-			t.Fatalf("json.Marshal() error = %v", err)
-		}
-		if !bytes.Contains(body, []byte(`"type":"image_url"`)) {
-			t.Fatalf("vision model content missing image_url: %s", body)
-		}
-		if !bytes.Contains(body, []byte(`"data:image/png;base64,iVBORw0KGgo="`)) {
-			t.Fatalf("vision model content missing image data URL: %s", body)
-		}
-		if !bytes.Contains(body, []byte(`"What's in this image?"`)) {
-			t.Fatalf("vision model content missing text: %s", body)
-		}
+		},
 	}
 
-	func TestTransformRequestNonVisionModelStripsImages(t *testing.T) {
-		transformer := NewRequestTransformer()
-
-		// User message with both text and an image
-		req := &types.MessageRequest{
-			Model:     "claude-test",
-			MaxTokens: 256,
-			Messages: []types.Message{
-				{
-					Role: "user",
-					Content: json.RawMessage(`[
-						{"type":"text","text":"What's in this image?"},
-						{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
-					]`),
-				},
-			},
-		}
-
-		// Non-vision model: images should be replaced with [Image] placeholder
-		openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
-			ModelID: "deepseek-v4-pro",
-		})
-		if err != nil {
-			t.Fatalf("TransformRequest() error = %v", err)
-		}
-
-		if got, want := len(openaiReq.Messages), 1; got != want {
-			t.Fatalf("len(Messages) = %d, want %d", got, want)
-		}
-
-		content := openaiReq.Messages[0].ContentText()
-		if !strings.Contains(content, "[Image]") {
-			t.Fatalf("non-vision model content missing [Image] placeholder: %q", content)
-		}
-		if !strings.Contains(content, "What's in this image?") {
-			t.Fatalf("non-vision model content missing original text: %q", content)
-		}
-		// Verify no image_url was sent
-		body, err := json.Marshal(openaiReq.Messages[0].Content)
-		if err != nil {
-			t.Fatalf("json.Marshal() error = %v", err)
-		}
-		if bytes.Contains(body, []byte(`"type":"image_url"`)) {
-			t.Fatalf("non-vision model should not contain image_url: %s", body)
-		}
+	// Vision-capable model: images should be passed as image_url content parts
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID: "kimi-k2.6",
+		Vision:  true,
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
 	}
 
-	func TestTransformRequestNonVisionModelImageOnly(t *testing.T) {
-		transformer := NewRequestTransformer()
-
-		// User message with only an image, no text
-		req := &types.MessageRequest{
-			Model:     "claude-test",
-			MaxTokens: 256,
-			Messages: []types.Message{
-				{
-					Role: "user",
-					Content: json.RawMessage(`[
-						{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
-					]`),
-				},
-			},
-		}
-
-		openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
-			ModelID: "deepseek-v4-flash",
-		})
-		if err != nil {
-			t.Fatalf("TransformRequest() error = %v", err)
-		}
-
-		if got, want := len(openaiReq.Messages), 1; got != want {
-			t.Fatalf("len(Messages) = %d, want %d", got, want)
-		}
-
-		content := openaiReq.Messages[0].ContentText()
-		if got, want := content, "[Image]"; got != want {
-			t.Fatalf("ContentText() = %q, want %q", got, want)
-		}
+	if got, want := len(openaiReq.Messages), 1; got != want {
+		t.Fatalf("len(Messages) = %d, want %d", got, want)
 	}
+
+	body, err := json.Marshal(openaiReq.Messages[0].Content)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if !bytes.Contains(body, []byte(`"type":"image_url"`)) {
+		t.Fatalf("vision model content missing image_url: %s", body)
+	}
+	if !bytes.Contains(body, []byte(`"data:image/png;base64,iVBORw0KGgo="`)) {
+		t.Fatalf("vision model content missing image data URL: %s", body)
+	}
+	if !bytes.Contains(body, []byte(`"What's in this image?"`)) {
+		t.Fatalf("vision model content missing text: %s", body)
+	}
+}
+
+func TestTransformRequestNonVisionModelStripsImages(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	// User message with both text and an image
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{
+				Role: "user",
+				Content: json.RawMessage(`[
+					{"type":"text","text":"What's in this image?"},
+					{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
+				]`),
+			},
+		},
+	}
+
+	// Non-vision model: images should be replaced with [Image] placeholder
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID: "deepseek-v4-pro",
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if got, want := len(openaiReq.Messages), 1; got != want {
+		t.Fatalf("len(Messages) = %d, want %d", got, want)
+	}
+
+	content := openaiReq.Messages[0].ContentText()
+	if !strings.Contains(content, "[Image]") {
+		t.Fatalf("non-vision model content missing [Image] placeholder: %q", content)
+	}
+	if !strings.Contains(content, "What's in this image?") {
+		t.Fatalf("non-vision model content missing original text: %q", content)
+	}
+	// Verify no image_url was sent
+	body, err := json.Marshal(openaiReq.Messages[0].Content)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if bytes.Contains(body, []byte(`"type":"image_url"`)) {
+		t.Fatalf("non-vision model should not contain image_url: %s", body)
+	}
+}
+
+func TestTransformRequestNonVisionModelImageOnly(t *testing.T) {
+	transformer := NewRequestTransformer()
+
+	// User message with only an image, no text
+	req := &types.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 256,
+		Messages: []types.Message{
+			{
+				Role: "user",
+				Content: json.RawMessage(`[
+					{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGgo="}}
+				]`),
+			},
+		},
+	}
+
+	openaiReq, err := transformer.TransformRequest(req, config.ModelConfig{
+		ModelID: "deepseek-v4-flash",
+	})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if got, want := len(openaiReq.Messages), 1; got != want {
+		t.Fatalf("len(Messages) = %d, want %d", got, want)
+	}
+
+	content := openaiReq.Messages[0].ContentText()
+	if got, want := content, "[Image]"; got != want {
+		t.Fatalf("ContentText() = %q, want %q", got, want)
+	}
+}
 
 	func TestTransformRequestStandardModelIgnoresThinkingAndEffort(t *testing.T) {
 	transformer := NewRequestTransformer()

--- a/internal/transformer/response.go
+++ b/internal/transformer/response.go
@@ -105,10 +105,10 @@ func (t *ResponseTransformer) transformContent(msg types.ChatMessage) ([]types.C
 	}
 
 	// Handle text content.
-	if msg.Content != "" {
+	if text := msg.ContentText(); text != "" {
 		blocks = append(blocks, types.ContentBlock{
 			Type: "text",
-			Text: msg.Content,
+			Text: text,
 		})
 	}
 

--- a/internal/transformer/response_test.go
+++ b/internal/transformer/response_test.go
@@ -20,7 +20,7 @@ func TestTransformResponsePreservesReasoningContent(t *testing.T) {
 				Index: 0,
 				Message: types.ChatMessage{
 					Role:             "assistant",
-					Content:          "The answer is 42.",
+					Content:          contentText("The answer is 42."),
 					ReasoningContent: &reasoning,
 				},
 				FinishReason: "stop",
@@ -71,7 +71,7 @@ func TestTransformResponsePreservesReasoningContentWithToolCalls(t *testing.T) {
 				Index: 0,
 				Message: types.ChatMessage{
 					Role:             "assistant",
-					Content:          "",
+					Content:          contentText(""),
 					ReasoningContent: &reasoning,
 					ToolCalls: []types.ToolCall{
 						{
@@ -136,7 +136,7 @@ func TestTransformResponseOmitsEmptyReasoningContent(t *testing.T) {
 				Index: 0,
 				Message: types.ChatMessage{
 					Role:             "assistant",
-					Content:          "Hello there.",
+					Content:          contentText("Hello there."),
 					ReasoningContent: &emptyReasoning,
 				},
 				FinishReason: "stop",
@@ -176,7 +176,7 @@ func TestTransformResponseNoReasoningContent(t *testing.T) {
 				Index: 0,
 				Message: types.ChatMessage{
 					Role:    "assistant",
-					Content: "Just a plain response.",
+					Content: contentText("Just a plain response."),
 				},
 				FinishReason: "stop",
 			},
@@ -214,7 +214,7 @@ func TestTransformResponseWithCacheTokens(t *testing.T) {
 				Index: 0,
 				Message: types.ChatMessage{
 					Role:    "assistant",
-					Content: "Hello, world!",
+					Content: contentText("Hello, world!"),
 				},
 				FinishReason: "stop",
 			},
@@ -266,7 +266,7 @@ func TestTransformResponseWithPartialCacheTokens(t *testing.T) {
 				Index: 0,
 				Message: types.ChatMessage{
 					Role:    "assistant",
-					Content: "ok",
+					Content: contentText("ok"),
 				},
 				FinishReason: "stop",
 			},
@@ -312,7 +312,7 @@ func TestTransformResponseCacheExceedsPromptTokens(t *testing.T) {
 				Index: 0,
 				Message: types.ChatMessage{
 					Role:    "assistant",
-					Content: "ok",
+					Content: contentText("ok"),
 				},
 				FinishReason: "stop",
 			},
@@ -355,7 +355,7 @@ func TestTransformResponseWithoutCacheTokens(t *testing.T) {
 				Index: 0,
 				Message: types.ChatMessage{
 					Role:    "assistant",
-					Content: "No cache here",
+					Content: contentText("No cache here"),
 				},
 				FinishReason: "stop",
 			},

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -366,7 +366,7 @@ func (h *StreamHandler) processSSELine(
 	}
 
 	// Handle text content deltas
-	if choice.Delta.Content != "" {
+	if textContent := choice.Delta.ContentText(); textContent != "" {
 		if !*contentStarted {
 			// If reasoning was already started, close it first
 			if *reasoningStarted {
@@ -393,7 +393,7 @@ func (h *StreamHandler) processSSELine(
 
 		delta := types.Delta{
 			Type: "text_delta",
-			Text: choice.Delta.Content,
+			Text: textContent,
 		}
 		event := types.MessageEvent{
 			Type:  "content_block_delta",

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -414,7 +414,7 @@ func TestProxyStream_ReasoningAndContentInSameChunk(t *testing.T) {
 	body := sseLines(
 		fmt.Sprintf(`{"choices":[{"delta":%s}]}`, mustJSON(t, types.ChatMessage{
 			ReasoningContent: strPtr("Thinking..."),
-			Content:          "Hello",
+			Content:          contentText("Hello"),
 		})),
 		`{"choices":[{"delta":{"content":" world"}}]}`,
 		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,

--- a/pkg/types/openai.go
+++ b/pkg/types/openai.go
@@ -20,6 +20,7 @@ type ImageURL struct {
 
 // TextContent is a helper to create a json.RawMessage for a plain-text content value.
 func TextContent(s string) json.RawMessage {
+	// json.Marshal(string) never fails for a valid Go string.
 	b, _ := json.Marshal(s)
 	return b
 }
@@ -60,7 +61,9 @@ type ChatMessage struct {
 
 // ContentText extracts the text content from the message, handling both
 // plain text strings and multimodal content arrays (where it concatenates
-// all text-type parts). Returns empty string if content is absent.
+// all text-type parts). Returns empty string if content is absent or unparseable. This is intentional
+// — ContentText is a best-effort text extractor for routing and display purposes, not a
+// strict parser. Failures are never fatal; callers should handle empty returns gracefully.
 func (m ChatMessage) ContentText() string {
 	if len(m.Content) == 0 {
 		return ""

--- a/pkg/types/openai.go
+++ b/pkg/types/openai.go
@@ -6,6 +6,24 @@ import "encoding/json"
 // OpenAI API types for the Chat Completions API.
 // Reference: https://platform.openai.com/docs/api-reference/chat
 
+// ChatContentPart represents a single part in a multimodal message content array.
+type ChatContentPart struct {
+	Type     string    `json:"type"`
+	Text     string    `json:"text,omitempty"`
+	ImageURL *ImageURL `json:"image_url,omitempty"`
+}
+
+// ImageURL represents the URL source for an image in a multimodal message.
+type ImageURL struct {
+	URL string `json:"url"`
+}
+
+// TextContent is a helper to create a json.RawMessage for a plain-text content value.
+func TextContent(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}
+
 // ChatCompletionRequest represents a request to the OpenAI Chat Completions API.
 type ChatCompletionRequest struct {
 	Model           string          `json:"model"`
@@ -28,14 +46,40 @@ type StreamOptions struct {
 }
 
 // ChatMessage represents a single message in the conversation.
+// Content can be either a plain text string or an array of ChatContentPart
+// for multimodal messages containing images.
 type ChatMessage struct {
 	Role             string        `json:"role"`
-	Content          string        `json:"content"`
+	Content          json.RawMessage `json:"content"`
 	ReasoningContent *string       `json:"reasoning_content,omitempty"`
 	ToolCalls        []ToolCall    `json:"tool_calls,omitempty"`
 	Name             string        `json:"name,omitempty"`
 	ToolCallID       string        `json:"tool_call_id,omitempty"`
 	CacheControl     *CacheControl `json:"cache_control,omitempty"`
+}
+
+// ContentText extracts the text content from the message, handling both
+// plain text strings and multimodal content arrays (where it concatenates
+// all text-type parts). Returns empty string if content is absent.
+func (m ChatMessage) ContentText() string {
+	if len(m.Content) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(m.Content, &s); err == nil {
+		return s
+	}
+	var parts []ChatContentPart
+	if err := json.Unmarshal(m.Content, &parts); err == nil {
+		var text string
+		for _, p := range parts {
+			if p.Type == "text" {
+				text += p.Text
+			}
+		}
+		return text
+	}
+	return ""
 }
 
 // ToolCall represents a function call made by the model.

--- a/pkg/types/openai.go
+++ b/pkg/types/openai.go
@@ -50,13 +50,13 @@ type StreamOptions struct {
 // Content can be either a plain text string or an array of ChatContentPart
 // for multimodal messages containing images.
 type ChatMessage struct {
-	Role             string        `json:"role"`
+	Role             string          `json:"role"`
 	Content          json.RawMessage `json:"content"`
-	ReasoningContent *string       `json:"reasoning_content,omitempty"`
-	ToolCalls        []ToolCall    `json:"tool_calls,omitempty"`
-	Name             string        `json:"name,omitempty"`
-	ToolCallID       string        `json:"tool_call_id,omitempty"`
-	CacheControl     *CacheControl `json:"cache_control,omitempty"`
+	ReasoningContent *string         `json:"reasoning_content,omitempty"`
+	ToolCalls        []ToolCall      `json:"tool_calls,omitempty"`
+	Name             string          `json:"name,omitempty"`
+	ToolCallID       string          `json:"tool_call_id,omitempty"`
+	CacheControl     *CacheControl   `json:"cache_control,omitempty"`
 }
 
 // ContentText extracts the text content from the message, handling both


### PR DESCRIPTION
## Summary
- Fix image content blocks being silently discarded during Anthropic→OpenAI request transformation
- Images are now converted to OpenAI's multimodal `image_url` format with base64 data URLs, enabling vision-capable models (Kimi K2.6, etc.) to receive actual image data instead of `[Image]` text placeholder
- Add `ChatContentPart`, `ImageURL` types for multimodal content arrays
- Change `ChatMessage.Content` from `string` to `json.RawMessage` for dual-format serialization (string or array)
- Update response/stream transformers and all tests to match new Content type
- Add `vision` config field to `ModelConfig` — non-vision models (e.g. deepseek-v4-pro) now strip image content to `[Image]` text placeholder instead of sending unsupported `image_url` parts (fixes 400 errors and prevents unwanted model fallback)

## ⚠️ Breaking config change
Vision-capable models must now be explicitly marked with `"vision": true` in `config.json`. Without this flag, images will be replaced with a `[Image]` text placeholder.

Add `"vision": true` to any model that supports multimodal input (e.g. Kimi K2.6, GLM-5/5.1, Qwen-VL, MiniMax, MiMo). Example:
```json
{
  "provider": "opencode-go",
  "model_id": "kimi-k2.6",
  "temperature": 0.7,
  "max_tokens": 4096,
  "vision": true
}
```

Models without `"vision"` (default `false`) will have image blocks silently replaced with `[Image]` text, allowing the request to succeed without error or fallback.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (except pre-existing token cache path test)
- [x] Manual test: send image from Claude Code through oc-go-cc to Kimi K2.6 and verify image is received
- [x] New tests verify vision model passes image_url, non-vision model strips to [Image], image-only message produces bare [Image]

## Related
Fixes #33 (qwen3.6-plus vision model cannot receive image data when used through oc-go-cc)