### PR TITLE
feat: add API key rotation with round-robin across multiple keys

### DIFF
--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -267,8 +267,8 @@ func validateCmd() *cobra.Command {
 			fmt.Printf("  Port: %d\n", cfg.Port)
 			if keys := cfg.EffectiveAPIKeys(); len(keys) > 1 {
 				fmt.Printf("  API Keys: %d keys (round-robin)\n", len(keys))
-			} else {
-				fmt.Printf("  API Key: %s...\n", maskString(cfg.APIKey, 8))
+			} else if len(keys) == 1 {
+				fmt.Printf("  API Key: %s...\n", maskString(keys[0], 8))
 			}
 			fmt.Printf("  Base URL: %s\n", cfg.OpenCodeGo.BaseURL)
 			fmt.Printf("  Models configured: %d\n", len(cfg.Models))

--- a/cmd/oc-go-cc/main.go
+++ b/cmd/oc-go-cc/main.go
@@ -265,7 +265,11 @@ func validateCmd() *cobra.Command {
 			fmt.Println("Configuration is valid!")
 			fmt.Printf("  Host: %s\n", cfg.Host)
 			fmt.Printf("  Port: %d\n", cfg.Port)
-			fmt.Printf("  API Key: %s...\n", maskString(cfg.APIKey, 8))
+			if keys := cfg.EffectiveAPIKeys(); len(keys) > 1 {
+				fmt.Printf("  API Keys: %d keys (round-robin)\n", len(keys))
+			} else {
+				fmt.Printf("  API Key: %s...\n", maskString(cfg.APIKey, 8))
+			}
 			fmt.Printf("  Base URL: %s\n", cfg.OpenCodeGo.BaseURL)
 			fmt.Printf("  Models configured: %d\n", len(cfg.Models))
 			fmt.Printf("  Fallback chains: %d\n", len(cfg.Fallbacks))

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -1,6 +1,5 @@
 {
   "api_key": "${OC_GO_CC_API_KEY}",
-  "api_keys": ["${OC_GO_CC_API_KEY_1}", "${OC_GO_CC_API_KEY_2}"],
   "host": "127.0.0.1",
   "port": 3456,
   "hot_reload": false,

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -1,5 +1,6 @@
 {
   "api_key": "${OC_GO_CC_API_KEY}",
+  "api_keys": ["${OC_GO_CC_API_KEY_1}", "${OC_GO_CC_API_KEY_2}"],
   "host": "127.0.0.1",
   "port": 3456,
   "hot_reload": false,

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -28,10 +28,10 @@ type OpenCodeClient struct {
 	keyCounter atomic.Uint64
 }
 
-// nextAPIKey returns the next API key in round-robin order from the configured key pool.
-func (c *OpenCodeClient) nextAPIKey() string {
-	cfg := c.atomic.Get()
-	keys := cfg.EffectiveAPIKeys()
+// nextAPIKey returns the next API key in round-robin order from the given key pool.
+// The caller provides keys from a single config read so baseURL and apiKey
+// always come from the same snapshot.
+func (c *OpenCodeClient) nextAPIKey(keys []string) string {
 	if len(keys) == 0 {
 		return ""
 	}
@@ -148,7 +148,7 @@ func isResponsesModel(modelID string) bool {
 // getEndpoint returns the appropriate endpoint config for a model.
 func (c *OpenCodeClient) getEndpoint(modelID string, modelConfig config.ModelConfig) endpointConfig {
 	cfg := c.atomic.Get()
-	apiKey := c.nextAPIKey()
+	apiKey := c.nextAPIKey(cfg.EffectiveAPIKeys())
 
 	if IsZen(modelConfig) {
 		zen := cfg.OpenCodeZen
@@ -277,14 +277,14 @@ func (c *OpenCodeClient) SendAnthropicRequest(
 	modelConfig config.ModelConfig,
 ) (*http.Response, error) {
 	cfg := c.atomic.Get()
-	var baseURL string
+	apiKey := c.nextAPIKey(cfg.EffectiveAPIKeys())
 
+	var baseURL string
 	if IsZen(modelConfig) {
 		baseURL = cfg.OpenCodeZen.AnthropicBaseURL
 	} else {
 		baseURL = cfg.OpenCodeGo.AnthropicBaseURL
 	}
-	apiKey := c.nextAPIKey()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewReader(body))
 	if err != nil {

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"oc-go-cc/internal/config"
@@ -24,6 +25,18 @@ const (
 type OpenCodeClient struct {
 	atomic     *config.AtomicConfig
 	httpClient *http.Client
+	keyCounter atomic.Uint64
+}
+
+// nextAPIKey returns the next API key in round-robin order from the configured key pool.
+func (c *OpenCodeClient) nextAPIKey() string {
+	cfg := c.atomic.Get()
+	keys := cfg.EffectiveAPIKeys()
+	if len(keys) == 0 {
+		return ""
+	}
+	idx := c.keyCounter.Add(1) - 1
+	return keys[idx%uint64(len(keys))]
 }
 
 // NewOpenCodeClient creates a new OpenCode client.
@@ -133,26 +146,27 @@ func isResponsesModel(modelID string) bool {
 // getEndpoint returns the appropriate endpoint config for a model.
 func (c *OpenCodeClient) getEndpoint(modelID string, modelConfig config.ModelConfig) endpointConfig {
 	cfg := c.atomic.Get()
+	apiKey := c.nextAPIKey()
 
 	if IsZen(modelConfig) {
 		zen := cfg.OpenCodeZen
 		switch ClassifyEndpoint(modelID) {
 		case EndpointAnthropic:
-			return endpointConfig{BaseURL: zen.AnthropicBaseURL, APIKey: cfg.APIKey}
+			return endpointConfig{BaseURL: zen.AnthropicBaseURL, APIKey: apiKey}
 		case EndpointResponses:
-			return endpointConfig{BaseURL: zen.ResponsesBaseURL, APIKey: cfg.APIKey}
+			return endpointConfig{BaseURL: zen.ResponsesBaseURL, APIKey: apiKey}
 		case EndpointGemini:
-			return endpointConfig{BaseURL: zen.GeminiBaseURL + "/" + modelID, APIKey: cfg.APIKey}
+			return endpointConfig{BaseURL: zen.GeminiBaseURL + "/" + modelID, APIKey: apiKey}
 		default:
-			return endpointConfig{BaseURL: zen.BaseURL, APIKey: cfg.APIKey}
+			return endpointConfig{BaseURL: zen.BaseURL, APIKey: apiKey}
 		}
 	}
 
 	// Default: OpenCode Go
 	if IsAnthropicModel(modelID) {
-		return endpointConfig{BaseURL: cfg.OpenCodeGo.AnthropicBaseURL, APIKey: cfg.APIKey}
+		return endpointConfig{BaseURL: cfg.OpenCodeGo.AnthropicBaseURL, APIKey: apiKey}
 	}
-	return endpointConfig{BaseURL: cfg.OpenCodeGo.BaseURL, APIKey: cfg.APIKey}
+	return endpointConfig{BaseURL: cfg.OpenCodeGo.BaseURL, APIKey: apiKey}
 }
 
 // endpointConfig holds configuration for a specific API endpoint.
@@ -268,7 +282,7 @@ func (c *OpenCodeClient) SendAnthropicRequest(
 	} else {
 		baseURL = cfg.OpenCodeGo.AnthropicBaseURL
 	}
-	apiKey := cfg.APIKey
+	apiKey := c.nextAPIKey()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewReader(body))
 	if err != nil {

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -29,14 +29,20 @@ type OpenCodeClient struct {
 }
 
 // nextAPIKey returns the next API key in round-robin order from the configured key pool.
+// The counter is kept in [0, n) via CAS so it never overflows.
 func (c *OpenCodeClient) nextAPIKey() string {
 	cfg := c.atomic.Get()
 	keys := cfg.EffectiveAPIKeys()
 	if len(keys) == 0 {
 		return ""
 	}
-	idx := c.keyCounter.Add(1) - 1
-	return keys[idx%uint64(len(keys))]
+	n := uint64(len(keys))
+	for {
+		old := c.keyCounter.Load()
+		if c.keyCounter.CompareAndSwap(old, (old+1)%n) {
+			return keys[old%n]
+		}
+	}
 }
 
 // NewOpenCodeClient creates a new OpenCode client.

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -29,7 +29,6 @@ type OpenCodeClient struct {
 }
 
 // nextAPIKey returns the next API key in round-robin order from the configured key pool.
-// The counter is kept in [0, n) via CAS so it never overflows.
 func (c *OpenCodeClient) nextAPIKey() string {
 	cfg := c.atomic.Get()
 	keys := cfg.EffectiveAPIKeys()
@@ -37,12 +36,8 @@ func (c *OpenCodeClient) nextAPIKey() string {
 		return ""
 	}
 	n := uint64(len(keys))
-	for {
-		old := c.keyCounter.Load()
-		if c.keyCounter.CompareAndSwap(old, (old+1)%n) {
-			return keys[old%n]
-		}
-	}
+	old := c.keyCounter.Add(1)
+	return keys[(old-1)%n]
 }
 
 // NewOpenCodeClient creates a new OpenCode client.

--- a/internal/client/opencode_test.go
+++ b/internal/client/opencode_test.go
@@ -256,3 +256,78 @@ func TestIsResponsesModel(t *testing.T) {
 		})
 	}
 }
+
+func TestNextAPIKey_RoundRobin(t *testing.T) {
+	cfg := &config.Config{
+		APIKeys: []string{"key-a", "key-b", "key-c"},
+	}
+	atomicCfg := config.NewAtomicConfig(cfg, "")
+	c := &OpenCodeClient{
+		atomic: atomicCfg,
+	}
+
+	// With 3 keys, iteration 0..5 should cycle key-a, key-b, key-c, key-a, key-b, key-c
+	expected := []string{"key-a", "key-b", "key-c", "key-a", "key-b", "key-c"}
+	for i, want := range expected {
+		if got := c.nextAPIKey(); got != want {
+			t.Errorf("iteration %d: nextAPIKey() = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestNextAPIKey_SingleKey(t *testing.T) {
+	cfg := &config.Config{APIKey: "single"}
+	atomicCfg := config.NewAtomicConfig(cfg, "")
+	c := &OpenCodeClient{atomic: atomicCfg}
+
+	for i := 0; i < 5; i++ {
+		if got := c.nextAPIKey(); got != "single" {
+			t.Errorf("iteration %d: nextAPIKey() = %q, want %q", i, got, "single")
+		}
+	}
+}
+
+func TestNextAPIKey_EmptyKeys(t *testing.T) {
+	cfg := &config.Config{APIKey: ""}
+	atomicCfg := config.NewAtomicConfig(cfg, "")
+	c := &OpenCodeClient{atomic: atomicCfg}
+
+	if got := c.nextAPIKey(); got != "" {
+		t.Errorf("nextAPIKey() = %q, want empty string", got)
+	}
+}
+
+func TestNextAPIKey_ConcurrentSafety(t *testing.T) {
+	cfg := &config.Config{
+		APIKeys: []string{"k1", "k2", "k3"},
+	}
+	atomicCfg := config.NewAtomicConfig(cfg, "")
+	c := &OpenCodeClient{atomic: atomicCfg}
+
+	const goroutines = 3
+	const callsPerGoroutine = 100
+	results := make(chan string, goroutines*callsPerGoroutine)
+
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			for i := 0; i < callsPerGoroutine; i++ {
+				results <- c.nextAPIKey()
+			}
+		}()
+	}
+
+	seen := make(map[string]int)
+	for i := 0; i < goroutines*callsPerGoroutine; i++ {
+		key := <-results
+		seen[key]++
+	}
+
+	// Each key should be seen exactly (goroutines*callsPerGoroutine)/3 times
+	total := goroutines * callsPerGoroutine
+	expectedPerKey := total / len(cfg.APIKeys)
+	for _, key := range cfg.APIKeys {
+		if seen[key] != expectedPerKey {
+			t.Errorf("key %q seen %d times, want %d", key, seen[key], expectedPerKey)
+		}
+	}
+}

--- a/internal/client/opencode_test.go
+++ b/internal/client/opencode_test.go
@@ -269,7 +269,7 @@ func TestNextAPIKey_RoundRobin(t *testing.T) {
 	// With 3 keys, iteration 0..5 should cycle key-a, key-b, key-c, key-a, key-b, key-c
 	expected := []string{"key-a", "key-b", "key-c", "key-a", "key-b", "key-c"}
 	for i, want := range expected {
-		if got := c.nextAPIKey(); got != want {
+		if got := c.nextAPIKey(cfg.EffectiveAPIKeys()); got != want {
 			t.Errorf("iteration %d: nextAPIKey() = %q, want %q", i, got, want)
 		}
 	}
@@ -281,7 +281,7 @@ func TestNextAPIKey_SingleKey(t *testing.T) {
 	c := &OpenCodeClient{atomic: atomicCfg}
 
 	for i := 0; i < 5; i++ {
-		if got := c.nextAPIKey(); got != "single" {
+		if got := c.nextAPIKey(cfg.EffectiveAPIKeys()); got != "single" {
 			t.Errorf("iteration %d: nextAPIKey() = %q, want %q", i, got, "single")
 		}
 	}
@@ -292,7 +292,7 @@ func TestNextAPIKey_EmptyKeys(t *testing.T) {
 	atomicCfg := config.NewAtomicConfig(cfg, "")
 	c := &OpenCodeClient{atomic: atomicCfg}
 
-	if got := c.nextAPIKey(); got != "" {
+	if got := c.nextAPIKey(cfg.EffectiveAPIKeys()); got != "" {
 		t.Errorf("nextAPIKey() = %q, want empty string", got)
 	}
 }
@@ -311,7 +311,7 @@ func TestNextAPIKey_ConcurrentSafety(t *testing.T) {
 	for g := 0; g < goroutines; g++ {
 		go func() {
 			for i := 0; i < callsPerGoroutine; i++ {
-				results <- c.nextAPIKey()
+				results <- c.nextAPIKey(cfg.EffectiveAPIKeys())
 			}
 		}()
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import "encoding/json"
 // Config holds the complete application configuration.
 type Config struct {
 	APIKey                         string                   `json:"api_key"`
+	APIKeys                        []string                 `json:"api_keys"`
 	Host                           string                   `json:"host"`
 	Port                           int                      `json:"port"`
 	HotReload                      bool                     `json:"hot_reload"`
@@ -50,4 +51,16 @@ type OpenCodeZenConfig struct {
 type LoggingConfig struct {
 	Level    string `json:"level"`
 	Requests bool   `json:"requests"`
+}
+
+// EffectiveAPIKeys returns the pool of API keys for rotation.
+// APIKeys takes precedence; falls back to the single APIKey field.
+func (c *Config) EffectiveAPIKeys() []string {
+	if len(c.APIKeys) > 0 {
+		return c.APIKeys
+	}
+	if c.APIKey != "" {
+		return []string{c.APIKey}
+	}
+	return nil
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -193,6 +193,9 @@ func validate(cfg *Config) error {
 // and the literal placeholder string would be sent as a bearer token.
 func validateAPIKeys(keys []string) error {
 	for i, key := range keys {
+		if key == "" {
+			return fmt.Errorf("api_keys[%d] is empty — each key must be a non-empty string", i)
+		}
 		if envVarPattern.MatchString(key) {
 			return fmt.Errorf("api_keys[%d] contains unresolved env var %q — set the corresponding environment variable or remove this entry", i, key)
 		}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -107,7 +107,11 @@ func interpolateEnvVars(s string) string {
 // applyEnvOverrides applies environment variable overrides to the config.
 func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("OC_GO_CC_API_KEY"); v != "" {
-		cfg.APIKey = v
+		if len(cfg.APIKeys) > 0 {
+			cfg.APIKeys = append(cfg.APIKeys, v)
+		} else {
+			cfg.APIKey = v
+		}
 	}
 	if v := os.Getenv("OC_GO_CC_HOST"); v != "" {
 		cfg.Host = v
@@ -173,8 +177,8 @@ func applyDefaults(cfg *Config) {
 
 // validate checks that all required configuration fields are present.
 func validate(cfg *Config) error {
-	if cfg.APIKey == "" {
-		return fmt.Errorf("api_key is required (set via config file or OC_GO_CC_API_KEY env var)")
+	if cfg.APIKey == "" && len(cfg.APIKeys) == 0 {
+		return fmt.Errorf("api_key or api_keys is required (set via config file or OC_GO_CC_API_KEY env var)")
 	}
 
 	if err := validateModelOverrides(cfg.ModelOverrides); err != nil {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -107,11 +107,8 @@ func interpolateEnvVars(s string) string {
 // applyEnvOverrides applies environment variable overrides to the config.
 func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("OC_GO_CC_API_KEY"); v != "" {
-		if len(cfg.APIKeys) > 0 {
-			cfg.APIKeys = append(cfg.APIKeys, v)
-		} else {
-			cfg.APIKey = v
-		}
+		cfg.APIKey = v
+		cfg.APIKeys = nil // env var overrides both api_key and api_keys
 	}
 	if v := os.Getenv("OC_GO_CC_HOST"); v != "" {
 		cfg.Host = v

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -181,8 +181,24 @@ func validate(cfg *Config) error {
 		return fmt.Errorf("api_key or api_keys is required (set via config file or OC_GO_CC_API_KEY env var)")
 	}
 
+	if err := validateAPIKeys(cfg.APIKeys); err != nil {
+		return err
+	}
+
 	if err := validateModelOverrides(cfg.ModelOverrides); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateAPIKeys ensures no api_keys entries contain unresolved ${VAR} placeholders.
+// Unresolved placeholders indicate the user did not set the corresponding env vars,
+// and the literal placeholder string would be sent as a bearer token.
+func validateAPIKeys(keys []string) error {
+	for i, key := range keys {
+		if envVarPattern.MatchString(key) {
+			return fmt.Errorf("api_keys[%d] contains unresolved env var %q — set the corresponding environment variable or remove this entry", i, key)
+		}
 	}
 	return nil
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -196,6 +196,10 @@ func TestEnvOverrides(t *testing.T) {
 	if cfg.APIKey != "env-key" {
 		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "env-key")
 	}
+	// Env var must be the effective key (not appended to api_keys).
+	if keys := cfg.EffectiveAPIKeys(); len(keys) != 1 || keys[0] != "env-key" {
+		t.Errorf("EffectiveAPIKeys() = %v, want [env-key]", keys)
+	}
 	if cfg.Host != "env-host" {
 		t.Errorf("Host = %q, want %q", cfg.Host, "env-host")
 	}
@@ -207,6 +211,35 @@ func TestEnvOverrides(t *testing.T) {
 	}
 	if cfg.Logging.Level != "warn" {
 		t.Errorf("LogLevel = %q, want %q", cfg.Logging.Level, "warn")
+	}
+}
+
+func TestEnvOverrides_OC_GO_CC_API_KEY_OverridesAPIKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfJSON := `{
+		"api_keys": ["file-key-1", "file-key-2"]
+	}`
+	if err := os.WriteFile(cfgPath, []byte(cfJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	_ = os.Setenv("OC_GO_CC_API_KEY", "env-key")
+	defer func() {
+		_ = os.Unsetenv("OC_GO_CC_CONFIG")
+		_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	}()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Env var must fully replace the key pool, not append to it.
+	if keys := cfg.EffectiveAPIKeys(); len(keys) != 1 || keys[0] != "env-key" {
+		t.Errorf("EffectiveAPIKeys() = %v, want [env-key]", keys)
 	}
 }
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -386,3 +386,87 @@ func TestExpandHome(t *testing.T) {
 		}
 	}
 }
+
+func TestEffectiveAPIKeys_APICKeysTakesPrecedence(t *testing.T) {
+	cfg := &Config{
+		APIKey:  "single-key",
+		APIKeys: []string{"key-a", "key-b"},
+	}
+	keys := cfg.EffectiveAPIKeys()
+	if len(keys) != 2 {
+		t.Fatalf("len(keys) = %d, want 2", len(keys))
+	}
+	if keys[0] != "key-a" || keys[1] != "key-b" {
+		t.Errorf("keys = %v, want [key-a key-b]", keys)
+	}
+}
+
+func TestEffectiveAPIKeys_FallsBackToAPIKey(t *testing.T) {
+	cfg := &Config{APIKey: "single-key"}
+	keys := cfg.EffectiveAPIKeys()
+	if len(keys) != 1 {
+		t.Fatalf("len(keys) = %d, want 1", len(keys))
+	}
+	if keys[0] != "single-key" {
+		t.Errorf("keys[0] = %q, want %q", keys[0], "single-key")
+	}
+}
+
+func TestEffectiveAPIKeys_EmptyReturnsNil(t *testing.T) {
+	cfg := &Config{}
+	keys := cfg.EffectiveAPIKeys()
+	if keys != nil {
+		t.Errorf("EffectiveAPIKeys() = %v, want nil", keys)
+	}
+}
+
+func TestLoad_AcceptsAPIKeysWithoutAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{
+		"api_keys": ["key-1", "key-2"],
+		"host": "127.0.0.1"
+	}`
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	defer func() { _ = os.Unsetenv("OC_GO_CC_CONFIG") }()
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	keys := cfg.EffectiveAPIKeys()
+	if len(keys) != 2 {
+		t.Fatalf("len(EffectiveAPIKeys()) = %d, want 2", len(keys))
+	}
+}
+
+func TestLoadMissingAPIKey_NoKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{"host": "127.0.0.1"}`
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	defer func() { _ = os.Unsetenv("OC_GO_CC_CONFIG") }()
+
+	oldAPIKey := os.Getenv("OC_GO_CC_API_KEY")
+	_ = os.Unsetenv("OC_GO_CC_API_KEY")
+	defer func() { _ = os.Setenv("OC_GO_CC_API_KEY", oldAPIKey) }()
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() expected error for missing API key, got nil")
+	}
+}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -543,3 +543,23 @@ func TestLoad_RejectsUnresolvedAPIKeysPlaceholders(t *testing.T) {
 		t.Fatal("Load() expected error for unresolved placeholder in api_keys, got nil")
 	}
 }
+
+func TestValidateAPIKeys_RejectsEmptyEntry(t *testing.T) {
+	cfg := &Config{
+		APIKeys: []string{"valid-key", ""},
+	}
+	err := validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error for empty api_keys entry, got nil")
+	}
+}
+
+func TestValidateAPIKeys_RejectsAllEmpty(t *testing.T) {
+	cfg := &Config{
+		APIKeys: []string{""},
+	}
+	err := validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error for empty api_keys entry, got nil")
+	}
+}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -470,3 +470,43 @@ func TestLoadMissingAPIKey_NoKeys(t *testing.T) {
 		t.Fatal("Load() expected error for missing API key, got nil")
 	}
 }
+
+func TestValidateAPIKeys_RejectsUnresolvedPlaceholder(t *testing.T) {
+	cfg := &Config{
+		APIKeys: []string{"valid-key", "${UNRESOLVED_VAR}"},
+	}
+	err := validate(cfg)
+	if err == nil {
+		t.Fatal("expected validation error for unresolved placeholder, got nil")
+	}
+}
+
+func TestValidateAPIKeys_AcceptsResolvedKeys(t *testing.T) {
+	cfg := &Config{
+		APIKeys: []string{"key-1", "key-2"},
+	}
+	if err := validate(cfg); err != nil {
+		t.Errorf("expected no validation error, got %v", err)
+	}
+}
+
+func TestLoad_RejectsUnresolvedAPIKeysPlaceholders(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	cfgJSON := `{
+		"api_keys": ["real-key", "${OC_GO_CC_UNSET_TEST_PLACEHOLDER}"]
+	}`
+	if err := os.WriteFile(cfgPath, []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_ = os.Setenv("OC_GO_CC_CONFIG", cfgPath)
+	defer func() { _ = os.Unsetenv("OC_GO_CC_CONFIG") }()
+	_ = os.Unsetenv("OC_GO_CC_UNSET_TEST_PLACEHOLDER")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() expected error for unresolved placeholder in api_keys, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `api_keys` config array for round-robin key rotation
- Add `nextAPIKey()` with atomic round-robin counter for concurrent safety
- Add `EffectiveAPIKeys()` helper with backward-compatible fallback to single `api_key`
- Fix `validate()` to accept `api_keys`-only configurations
- Respect `OC_GO_CC_API_KEY` env var when `api_keys` array is configured
- Add comprehensive tests for key rotation and edge cases

## Test plan
- `make test` passes with race detector
- All packages: `config`, `client`, `handlers`, `token`, `transformer`, `types`, `router`, `daemon`
- Concurrent safety verified via goroutine stress test
- Backward compatible: single `api_key` continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)