### PR TITLE
feat: add Docker image publishing to GitHub Container Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   # ── Stage 1: Test & Build Validation ──────────────────────────────
@@ -216,7 +217,47 @@ jobs:
             dist/oc-go-cc_*
             dist/checksums.txt
 
-  # ── Stage 3: Update Homebrew Tap ─────────────────────────────────
+  # ── Stage 3: Publish Docker Image ───────────────────────────────
+  docker:
+    name: Publish Docker Image
+    needs: release
+    if: github.repository == 'samueltuyizere/oc-go-cc'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ needs.release.outputs.tag }}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ needs.release.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Stage 4: Update Homebrew Tap ─────────────────────────────────
   homebrew:
     name: Update Homebrew Tap
     needs: release
@@ -344,7 +385,7 @@ jobs:
           git commit -m "Update oc-go-cc to ${VERSION}" || echo "No changes to commit"
           git push
 
-  # ── Stage 4: Update Scoop Bucket ──────────────────────────────────
+  # ── Stage 5: Update Scoop Bucket ──────────────────────────────────
   scoop:
     name: Update Scoop Bucket
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,6 @@ on:
 
 permissions:
   contents: write
-permissions:
-  contents: write
-
-jobs:
-  ...
-  docker:
-    permissions:
-      contents: read
-      packages: write
 
 jobs:
   # ── Stage 1: Test & Build Validation ──────────────────────────────
@@ -229,6 +220,9 @@ jobs:
   docker:
     name: Publish Docker Image
     needs: release
+    permissions:
+      contents: read
+      packages: write
     if: github.repository == 'samueltuyizere/oc-go-cc'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,15 @@ on:
 
 permissions:
   contents: write
-  packages: write
+permissions:
+  contents: write
+
+jobs:
+  ...
+  docker:
+    permissions:
+      contents: read
+      packages: write
 
 jobs:
   # ── Stage 1: Test & Build Validation ──────────────────────────────
@@ -253,7 +261,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: VERSION=${{ needs.release.outputs.tag }}
+          build-args: VERSION=${{ needs.release.outputs.tag | trimPrefix 'v' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=docker" -o /app/oc-go-cc ./cmd/oc-go-cc
+ARG VERSION=docker
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION}" -o /app/oc-go-cc ./cmd/oc-go-cc
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata wget && \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ make docker-up
 cp .env.example .env
 docker build -t oc-go-cc .
 docker run -d --restart unless-stopped --name oc-go-cc --env-file .env -p 3456:3456 oc-go-cc
+
+# Docker from GitHub Container Registry
+docker pull ghcr.io/samueltuyizere/oc-go-cc:latest
+docker run -d --restart unless-stopped --name oc-go-cc --env-file .env -p 3456:3456 ghcr.io/samueltuyizere/oc-go-cc:latest
 ```
 
 Or see [INSTALLATION.md](INSTALLATION.md) for more options.


### PR DESCRIPTION
## Summary

Adds automatic Docker image publishing to `ghcr.io/samueltuyizere/oc-go-cc` on every release.

### Changes

- **`.github/workflows/release.yml`** — New `docker` job that builds multi-platform images (linux/amd64 + linux/arm64) and pushes to ghcr.io. Runs in parallel with homebrew/scoop updates, depends only on the `release` job for the version tag.
- **`Dockerfile`** — Accepts `VERSION` build arg (defaults to `docker` for backward compatibility with local builds).
- **`README.md`** — Added `docker pull ghcr.io/...` instructions in the Quick Start section.

### Tag Strategy

For a release tagged `v0.3.0`, the image is published with:
- `v0.3.0` (exact version)
- `0.3` (minor)
- `0` (major)
- `latest`

### No New Secrets Required

Uses the built-in `GITHUB_TOKEN` with `packages: write` permission.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)