### PR TITLE
Fix/anthropic tool format and fallback death spiral

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,16 @@ Run a single test: `go test ./internal/router/ -v`
 
 **Purpose:** oc-go-cc is a proxy server that sits between Claude Code and OpenCode Go. It intercepts Anthropic API requests, transforms them to OpenAI Chat Completions format, forwards them to OpenCode Go, and transforms responses back to Anthropic SSE.
 
-**Model routing is config-driven, not code-driven.** Models are defined in `~/.config/oc-go-cc/config.json` — adding a new model does not require code changes (except for `IsAnthropicModel()` if the new model uses the Anthropic endpoint). The router in `internal/router/` selects models by matching request content against scenario patterns defined in `scenarios.go`.
+**Model routing is config-driven, not code-driven.** All models are defined in `~/.config/oc-go-cc/config.json` — adding a new model requires no code changes. Go provider models are transformed to OpenAI Chat Completions format automatically. Zen models use endpoint classification via `ClassifyEndpoint()`. The router in `internal/router/` selects models by matching request content against scenario patterns defined in `scenarios.go`.
+
+If a model's upstream doesn't support Anthropic tool format (`type: "custom"` server-tool shorthands), set `"anthropic_tools_disabled": true` in the model config to force it through the Chat Completions transform path instead of the raw Anthropic endpoint.
 
 **Two API endpoints:**
 
 - OpenAI endpoint (`/v1/chat/completions`) — used by most models (GLM, Kimi, MiMo, Qwen)
 - Anthropic endpoint (`/v1/messages`) — used only by MiniMax models
 
-`internal/client/opencode.go` routes by model ID via `IsAnthropicModel()`.
+`internal/client/opencode.go` routes Go provider models to Chat Completions; Zen models are classified by `ClassifyEndpoint()`. If a model's upstream doesn't support Anthropic tool format, set `anthropic_tools_disabled: true` in config.
 
 **Scenario detection priority** (`internal/router/scenarios.go`):
 

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -67,15 +67,11 @@ func NewOpenCodeClient(atomic *config.AtomicConfig) *OpenCodeClient {
 }
 
 // IsAnthropicModel returns true if the model requires the Anthropic endpoint.
-// This includes both Go models (minimax, all qwen) and Zen models (claude, qwen3.7-max).
+// Go provider models use the Chat Completions transform path for broader
+// compatibility (tool format, message roles, etc.). Only Zen models use the
+// raw Anthropic endpoint, handled by ClassifyEndpoint in the Zen branch.
 func IsAnthropicModel(modelID string) bool {
-	switch modelID {
-	case "minimax-m2.5", "minimax-m2.7", "minimax-m3",
-		"qwen3.5-plus", "qwen3.6-plus", "qwen3.7-plus", "qwen3.7-max":
-		return true
-	default:
-		return isZenAnthropicModel(modelID)
-	}
+	return false
 }
 
 // isZenAnthropicModel returns true for models on Zen that use the Anthropic endpoint.

--- a/internal/client/opencode_test.go
+++ b/internal/client/opencode_test.go
@@ -13,19 +13,19 @@ func TestIsAnthropicModelOnlyRoutesNativeAnthropicModels(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "minimax m2.5 uses anthropic endpoint",
+			name:    "minimax m2.5 uses openai endpoint on Go provider",
 			modelID: "minimax-m2.5",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "minimax m2.7 uses anthropic endpoint",
+			name:    "minimax m2.7 uses openai endpoint on Go provider",
 			modelID: "minimax-m2.7",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "minimax m3 uses anthropic endpoint",
+			name:    "minimax m3 uses openai endpoint on Go provider",
 			modelID: "minimax-m3",
-			want:    true,
+			want:    false,
 		},
 		{
 			name:    "deepseek pro uses openai endpoint",
@@ -63,44 +63,44 @@ func TestIsAnthropicModelOnlyRoutesNativeAnthropicModels(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "qwen3.5-plus uses anthropic endpoint",
+			name:    "qwen3.5-plus uses openai endpoint on Go provider",
 			modelID: "qwen3.5-plus",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "qwen3.6-plus uses anthropic endpoint",
+			name:    "qwen3.6-plus uses openai endpoint on Go provider",
 			modelID: "qwen3.6-plus",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "qwen3.7-plus uses anthropic endpoint",
+			name:    "qwen3.7-plus uses openai endpoint on Go provider",
 			modelID: "qwen3.7-plus",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "qwen3.7-max uses anthropic endpoint",
+			name:    "qwen3.7-max uses openai endpoint on Go provider",
 			modelID: "qwen3.7-max",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "claude-sonnet-4-5 uses anthropic endpoint",
+			name:    "claude models use openai endpoint on Go provider",
 			modelID: "claude-sonnet-4-5",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "claude-opus-4-7 uses anthropic endpoint",
+			name:    "claude-opus-4-7 uses openai endpoint on Go provider",
 			modelID: "claude-opus-4-7",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "claude-haiku-4-5 uses anthropic endpoint",
+			name:    "claude-haiku-4-5 uses openai endpoint on Go provider",
 			modelID: "claude-haiku-4-5",
-			want:    true,
+			want:    false,
 		},
 		{
-			name:    "claude-3-5-haiku uses anthropic endpoint",
+			name:    "claude-3-5-haiku uses openai endpoint on Go provider",
 			modelID: "claude-3-5-haiku",
-			want:    true,
+			want:    false,
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,14 +22,15 @@ type Config struct {
 
 // ModelConfig defines routing rules for a specific model.
 type ModelConfig struct {
-	Provider         string          `json:"provider"`
-	ModelID          string          `json:"model_id"`
-	Temperature      float64         `json:"temperature"`
-	MaxTokens        int             `json:"max_tokens"`
-	ContextThreshold int             `json:"context_threshold"`
-	ReasoningEffort  string          `json:"reasoning_effort"`
-	Thinking         json.RawMessage `json:"thinking,omitempty"`
-	Vision           bool            `json:"vision"`
+	Provider               string          `json:"provider"`
+	ModelID                string          `json:"model_id"`
+	Temperature            float64         `json:"temperature"`
+	MaxTokens              int             `json:"max_tokens"`
+	ContextThreshold       int             `json:"context_threshold"`
+	ReasoningEffort        string          `json:"reasoning_effort"`
+	Thinking               json.RawMessage `json:"thinking,omitempty"`
+	Vision                 bool            `json:"vision"`
+	AnthropicToolsDisabled bool            `json:"anthropic_tools_disabled"`
 }
 
 // OpenCodeGoConfig holds the upstream OpenCode Go API settings.

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -342,21 +342,25 @@ func (h *MessagesHandler) handleStreaming(
 			endpointType := client.ClassifyEndpoint(model.ModelID)
 			switch endpointType {
 			case client.EndpointAnthropic:
-				modelBody := replaceModelInRawBody(rawBody, model.ModelID)
-				if err := h.handleAnthropicStreaming(ctx, rw, modelBody, model.ModelID, model); err != nil {
-					cancel()
-					if clientCtx.Err() == context.Canceled {
-						h.logger.Info("client disconnected during anthropic stream")
-						return
+				if model.AnthropicToolsDisabled {
+					// Fall through to OpenAI-compatible transform path below.
+				} else {
+					modelBody := replaceModelInRawBody(rawBody, model.ModelID)
+					if err := h.handleAnthropicStreaming(ctx, rw, modelBody, model.ModelID, model); err != nil {
+						cancel()
+						if clientCtx.Err() == context.Canceled {
+							h.logger.Info("client disconnected during anthropic stream")
+							return
+						}
+						h.logger.Warn("anthropic streaming failed", "model", model.ModelID, "error", err)
+						continue
 					}
-					h.logger.Warn("anthropic streaming failed", "model", model.ModelID, "error", err)
-					continue
+					cancel()
+					latency := time.Since(streamStart)
+					h.metrics.RecordSuccess(model.ModelID, latency)
+					h.logger.Info("streaming completed", "model", model.ModelID, "latency", latency)
+					return
 				}
-				cancel()
-				latency := time.Since(streamStart)
-				h.metrics.RecordSuccess(model.ModelID, latency)
-				h.logger.Info("streaming completed", "model", model.ModelID, "latency", latency)
-				return
 
 			case client.EndpointResponses:
 				if err := h.handleResponsesStreaming(ctx, rw, anthropicReq, model, clientCtx); err != nil {
@@ -499,6 +503,44 @@ func (h *MessagesHandler) handleGeminiStreaming(
 	return nil
 }
 
+// sanitizeAnthropicBody removes Anthropic-specific tool fields that some upstream
+// models don't understand (e.g., "type":"custom" server-tool shorthands used by
+// Claude Code for MCP tools). Returns the original body unchanged if no tools
+// array is present or if no tool has a type field.
+func sanitizeAnthropicBody(rawBody json.RawMessage) json.RawMessage {
+	var body map[string]any
+	if err := json.Unmarshal(rawBody, &body); err != nil {
+		return rawBody
+	}
+
+	tools, ok := body["tools"].([]any)
+	if !ok || len(tools) == 0 {
+		return rawBody
+	}
+
+	modified := false
+	for _, tool := range tools {
+		toolMap, ok := tool.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, hasType := toolMap["type"]; hasType {
+			delete(toolMap, "type")
+			modified = true
+		}
+	}
+
+	if !modified {
+		return rawBody
+	}
+
+	result, err := json.Marshal(body)
+	if err != nil {
+		return rawBody
+	}
+	return json.RawMessage(result)
+}
+
 // replaceModelInRawBody replaces the model field in raw JSON body with the actual model ID.
 func replaceModelInRawBody(rawBody json.RawMessage, modelID string) json.RawMessage {
 	bodyStr := string(rawBody)
@@ -529,6 +571,10 @@ func (h *MessagesHandler) handleAnthropicStreaming(
 	modelID string,
 	model config.ModelConfig,
 ) error {
+	// Sanitize Anthropic-specific fields (e.g., tool type shorthands) that
+	// upstream models may not understand.
+	rawBody = sanitizeAnthropicBody(rawBody)
+
 	h.logger.Debug("sending anthropic streaming request",
 		"model_id", modelID,
 		"body_preview", string(rawBody)[:min(len(rawBody), 200)])
@@ -590,7 +636,11 @@ func (h *MessagesHandler) handleNonStreaming(
 				endpointType := client.ClassifyEndpoint(model.ModelID)
 				switch endpointType {
 				case client.EndpointAnthropic:
-					return h.executeAnthropicRequest(ctx, rawBody, model)
+					if model.AnthropicToolsDisabled {
+						// Fall through to OpenAI-compatible handling below.
+					} else {
+						return h.executeAnthropicRequest(ctx, rawBody, model)
+					}
 				case client.EndpointResponses:
 					return h.executeResponsesRequest(ctx, anthropicReq, model)
 				case client.EndpointGemini:
@@ -634,6 +684,10 @@ func (h *MessagesHandler) executeAnthropicRequest(
 	rawBody json.RawMessage,
 	model config.ModelConfig,
 ) ([]byte, error) {
+	// Sanitize Anthropic-specific fields (e.g., tool type shorthands) that
+	// upstream models may not understand.
+	rawBody = sanitizeAnthropicBody(rawBody)
+
 	resp, err := h.client.SendAnthropicRequest(ctx, rawBody, false, model)
 	if err != nil {
 		return nil, fmt.Errorf("anthropic request failed: %w", err)

--- a/internal/handlers/messages_test.go
+++ b/internal/handlers/messages_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"log/slog"
 	"testing"
 
@@ -336,4 +337,131 @@ func equalStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+
+func TestSanitizeAnthropicBody_RemovesToolTypeField(t *testing.T) {
+	rawBody := json.RawMessage(`{
+		"model": "minimax-m3",
+		"tools": [
+			{
+				"type": "custom",
+				"name": "my_tool",
+				"description": "A test tool",
+				"input_schema": {"type": "object"}
+			},
+			{
+				"type": "custom",
+				"name": "other_tool",
+				"description": "Another tool",
+				"input_schema": {"type": "object"}
+			}
+		]
+	}`)
+
+	result := sanitizeAnthropicBody(rawBody)
+
+	var body map[string]any
+	if err := json.Unmarshal(result, &body); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	tools, ok := body["tools"].([]any)
+	if !ok {
+		t.Fatal("expected tools array in result")
+	}
+
+	for i, tool := range tools {
+		toolMap, ok := tool.(map[string]any)
+		if !ok {
+			t.Fatalf("tool %d is not a map", i)
+		}
+		if _, hasType := toolMap["type"]; hasType {
+			t.Errorf("tool %d still has type field after sanitization", i)
+		}
+		if name, ok := toolMap["name"]; !ok || name != ([]string{"my_tool", "other_tool"})[i] {
+			t.Errorf("tool %d name field was corrupted", i)
+		}
+	}
+}
+
+func TestSanitizeAnthropicBody_NoTools(t *testing.T) {
+	rawBody := json.RawMessage(`{"model": "minimax-m3", "messages": []}`)
+	result := sanitizeAnthropicBody(rawBody)
+
+	// Should return the original body unchanged
+	if string(result) != string(rawBody) {
+		t.Error("body without tools should be returned unchanged")
+	}
+}
+
+func TestSanitizeAnthropicBody_ToolsWithoutType(t *testing.T) {
+	rawBody := json.RawMessage(`{
+		"tools": [
+			{
+				"name": "my_tool",
+				"description": "No type field",
+				"input_schema": {"type": "object"}
+			}
+		]
+	}`)
+	result := sanitizeAnthropicBody(rawBody)
+
+	// Should return the original body unchanged (no type field to remove)
+	if string(result) != string(rawBody) {
+		t.Error("body with tools without type should be returned unchanged")
+	}
+}
+
+func TestSanitizeAnthropicBody_InvalidJSON(t *testing.T) {
+	rawBody := json.RawMessage(`{invalid json}`)
+	result := sanitizeAnthropicBody(rawBody)
+
+	// Should return original body unchanged on invalid JSON
+	if string(result) != string(rawBody) {
+		t.Error("invalid JSON should be returned unchanged")
+	}
+}
+
+func TestSanitizeAnthropicBody_EmptyBody(t *testing.T) {
+	rawBody := json.RawMessage(`{}`)
+	result := sanitizeAnthropicBody(rawBody)
+
+	if string(result) != string(rawBody) {
+		t.Error("empty body should be returned unchanged")
+	}
+}
+
+func TestSanitizeAnthropicBody_KeepsOtherFields(t *testing.T) {
+	rawBody := json.RawMessage(`{
+		"model": "minimax-m3",
+		"system": "You are a helpful assistant",
+		"messages": [{"role": "user", "content": "hello"}],
+		"max_tokens": 4096,
+		"tools": [
+			{
+				"type": "custom",
+				"name": "test_tool",
+				"description": "desc",
+				"input_schema": {"type": "object", "properties": {}}
+			}
+		]
+	}`)
+	result := sanitizeAnthropicBody(rawBody)
+
+	var body map[string]any
+	if err := json.Unmarshal(result, &body); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	// Check that non-tool fields are preserved
+	if body["model"] != "minimax-m3" {
+		t.Error("model field was corrupted")
+	}
+	if body["system"] != "You are a helpful assistant" {
+		t.Error("system field was corrupted")
+	}
+	if body["max_tokens"] != float64(4096) {
+		t.Error("max_tokens field was corrupted")
+	}
 }

--- a/internal/router/fallback.go
+++ b/internal/router/fallback.go
@@ -208,13 +208,21 @@ func (h *FallbackHandler) ExecuteWithFallback(
 			}, body, nil
 		}
 
-		cb.RecordFailure()
-		h.logger.Warn("model failed, trying fallback",
-			"model", model.ModelID,
-			"error", err,
-			"remaining", totalModels-i-1,
-			"circuit_state", cb.State(),
-		)
+		if IsRetryableError(err) {
+			cb.RecordFailure()
+			h.logger.Warn("model failed, trying fallback",
+				"model", model.ModelID,
+				"error", err,
+				"remaining", totalModels-i-1,
+				"circuit_state", cb.State(),
+			)
+		} else {
+			h.logger.Warn("non-retryable error (skipping circuit breaker), trying fallback",
+				"model", model.ModelID,
+				"error", err,
+				"remaining", totalModels-i-1,
+			)
+		}
 	}
 
 	return &FallbackResult{
@@ -243,6 +251,13 @@ func IsRetryableError(err error) bool {
 	}
 
 	errStr := err.Error()
+
+	// 4xx client errors are not retryable — the request format itself is invalid
+	// for that model, and retrying won't fix it.
+	if strings.Contains(errStr, "API error 4") {
+		return false
+	}
+
 	// Retry on network errors, timeouts, rate limits, server errors
 	retryable := []string{
 		"timeout",

--- a/internal/router/fallback_test.go
+++ b/internal/router/fallback_test.go
@@ -1,0 +1,155 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"oc-go-cc/internal/config"
+)
+
+func TestIsRetryableError_ClientsErrorsNotRetryable(t *testing.T) {
+	tests := []struct {
+		err  string
+		want bool
+	}{
+		// 4xx errors should NOT be retryable
+		{err: "API error 400: bad request", want: false},
+		{err: "API error 401: unauthorized", want: false},
+		{err: "API error 403: forbidden", want: false},
+		{err: "API error 404: not found", want: false},
+		{err: "API error 422: unprocessable", want: false},
+		{err: "API error 429: rate limit", want: false},
+
+		// 5xx and network errors should be retryable (existing behavior)
+		{err: "API error 500: internal error", want: true},
+		{err: "API error 502: bad gateway", want: true},
+		{err: "API error 503: service unavailable", want: true},
+		{err: "request timeout", want: true},
+		{err: "connection refused", want: true},
+		{err: "connection reset by peer", want: true},
+		{err: "rate limit exceeded", want: true},
+
+		// Edge cases
+		{err: "", want: false},
+		{err: "random error", want: false},
+		{err: "API error 400", want: false},
+		{err: "API error 500", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.err, func(t *testing.T) {
+			var err error
+			if tt.err != "" {
+				err = errors.New(tt.err)
+			}
+			if got := IsRetryableError(err); got != tt.want {
+				t.Errorf("IsRetryableError(%q) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteWithFallback_NonRetryableDoesNotOpenCircuit(t *testing.T) {
+	h := NewFallbackHandler(nil, 1, 0) // 1 failure = open circuit
+
+	models := []config.ModelConfig{
+		{ModelID: "model-a"},
+		{ModelID: "model-b"},
+	}
+
+	attempts := 0
+	_, _, err := h.ExecuteWithFallback(
+		context.Background(),
+		models,
+		func(ctx context.Context, model config.ModelConfig) ([]byte, error) {
+			attempts++
+			// Non-retryable 400 error — should NOT open circuit breaker
+			return nil, fmt.Errorf("API error 400: bad request")
+		},
+	)
+
+	if err == nil {
+		t.Fatal("expected all models to fail")
+	}
+
+	// Circuit breaker should still be closed since errors were non-retryable
+	cb := h.getCircuitBreaker("model-a")
+	if cb.State() != CircuitClosed {
+		t.Errorf("model-a circuit should be closed after non-retryable errors, got %v", cb.State())
+	}
+
+	// All models were tried
+	if attempts != 2 {
+		t.Errorf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+func TestExecuteWithFallback_RetryableOpensCircuit(t *testing.T) {
+	h := NewFallbackHandler(nil, 1, 0)
+
+	models := []config.ModelConfig{
+		{ModelID: "model-a"},
+		{ModelID: "model-b"},
+	}
+
+	_, _, err := h.ExecuteWithFallback(
+		context.Background(),
+		models,
+		func(ctx context.Context, model config.ModelConfig) ([]byte, error) {
+			// Retryable 500 error — should open circuit breaker
+			return nil, fmt.Errorf("API error 500: internal error")
+		},
+	)
+
+	if err == nil {
+		t.Fatal("expected all models to fail")
+	}
+
+	// Circuit breaker should be OPEN after retryable failure
+	cb := h.getCircuitBreaker("model-a")
+	if cb.State() != CircuitOpen {
+		t.Errorf("model-a circuit should be open after retryable error, got %v", cb.State())
+	}
+}
+
+func TestExecuteWithFallback_NonRetryableThenRetryable(t *testing.T) {
+	h := NewFallbackHandler(nil, 1, 0)
+	callCount := 0
+
+	models := []config.ModelConfig{
+		{ModelID: "model-a"},
+		{ModelID: "model-b"},
+	}
+
+	_, _, err := h.ExecuteWithFallback(
+		context.Background(),
+		models,
+		func(ctx context.Context, model config.ModelConfig) ([]byte, error) {
+			callCount++
+			if callCount == 1 {
+				// Non-retryable: model-a should NOT get circuit opened
+				return nil, fmt.Errorf("API error 400: bad request")
+			}
+			// Retryable: model-b should get circuit opened
+			return nil, fmt.Errorf("API error 500: internal error")
+		},
+	)
+
+	if err == nil {
+		t.Fatal("expected all models to fail")
+	}
+
+	// model-a circuit should be closed (non-retryable)
+	cbA := h.getCircuitBreaker("model-a")
+	if cbA.State() != CircuitClosed {
+		t.Errorf("model-a circuit should be closed after non-retryable error, got %v", cbA.State())
+	}
+
+	// model-b circuit should be open (retryable)
+	cbB := h.getCircuitBreaker("model-b")
+	if cbB.State() != CircuitOpen {
+		t.Errorf("model-b circuit should be open after retryable error, got %v", cbB.State())
+	}
+}

--- a/internal/transformer/request.go
+++ b/internal/transformer/request.go
@@ -52,6 +52,17 @@ func needsPlaceholderReasoning(modelID string) bool {
 	return strings.HasPrefix(modelID, "kimi-")
 }
 
+// constrainTemperature overrides model-specific temperature constraints.
+// Some models require specific temperature values — return the constrained
+// value or the original if no constraint applies.
+func constrainTemperature(modelID string, temp float64) float64 {
+	// Moonshot AI (kimi-k2.7-code) only allows temperature=1.
+	if modelID == "kimi-k2.7-code" {
+		return 1.0
+	}
+	return temp
+}
+
 // stripCacheControl removes cache_control from all messages in the list.
 // The caller must not hold references to the slice elements.
 func stripCacheControl(messages []types.ChatMessage) {
@@ -100,9 +111,13 @@ func (t *RequestTransformer) TransformRequest(
 		openaiReq.MaxTokens = &maxTokens
 	}
 
-	// Apply model-specific overrides
+	// Apply model-specific overrides and temperature constraints
 	if model.Temperature > 0 {
 		openaiReq.Temperature = &model.Temperature
+	}
+	if openaiReq.Temperature != nil {
+		temp := constrainTemperature(model.ModelID, *openaiReq.Temperature)
+		openaiReq.Temperature = &temp
 	}
 	if model.MaxTokens > 0 {
 		maxTokens := model.MaxTokens

--- a/internal/transformer/request_test.go
+++ b/internal/transformer/request_test.go
@@ -3,6 +3,7 @@ package transformer
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1347,5 +1348,37 @@ func TestTransformRequestStandardModelIgnoresThinkingAndEffort(t *testing.T) {
 	}
 	if openaiReq.Thinking != nil {
 		t.Fatalf("expected Thinking to be nil for standard model, got %s", string(openaiReq.Thinking))
+	}
+}
+
+
+func TestConstrainTemperature(t *testing.T) {
+	tests := []struct {
+		modelID string
+		input   float64
+		want    float64
+	}{
+		// kimi-k2.7-code forces temperature to 1.0
+		{modelID: "kimi-k2.7-code", input: 0.7, want: 1.0},
+		{modelID: "kimi-k2.7-code", input: 0.0, want: 1.0},
+		{modelID: "kimi-k2.7-code", input: 1.5, want: 1.0},
+
+		// Other kimi models are not constrained
+		{modelID: "kimi-k2.6", input: 0.7, want: 0.7},
+		{modelID: "kimi-k2.5", input: 0.5, want: 0.5},
+
+		// Other models are not constrained
+		{modelID: "minimax-m3", input: 0.7, want: 0.7},
+		{modelID: "deepseek-v4-pro", input: 0.5, want: 0.5},
+		{modelID: "glm-5.1", input: 0.3, want: 0.3},
+		{modelID: "qwen3.7-plus", input: 0.9, want: 0.9},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID+"/"+fmt.Sprint(tt.input), func(t *testing.T) {
+			if got := constrainTemperature(tt.modelID, tt.input); got != tt.want {
+				t.Errorf("constrainTemperature(%q, %f) = %f, want %f", tt.modelID, tt.input, got, tt.want)
+			}
+		})
 	}
 }

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end test for model tool format and fallback fixes.
+# Tests each model with a tool-containing request to verify:
+#   - No "Unknown server-tool shorthand" 400 errors
+#   - No temperature constraint violations
+#   - All Go provider models work through the transform path
+#
+# Usage:
+#   source .env && ./scripts/e2e-test.sh [--build]
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Config ---
+PORT="${OC_GO_CC_PORT:-3457}"
+HOST="${OC_GO_CC_HOST:-127.0.0.1}"
+BASE_URL="http://${HOST}:${PORT}"
+TIMEOUT_SEC=60
+pass=0
+fail=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+cleanup() {
+	echo "=== Cleaning up ==="
+	./bin/oc-go-cc stop 2>/dev/null || true
+	sleep 1
+	rm -f ~/.config/oc-go-cc/oc-go-cc.pid
+}
+trap cleanup EXIT
+
+# --- Build ---
+if [ "${1:-}" = "--skip-build" ]; then
+	echo -e "${YELLOW}Skipping build...${NC}"
+else
+	echo "=== Building oc-go-cc ==="
+	make build
+	echo ""
+fi
+
+# --- Source .env (must be done BEFORE start) ---
+if [ -f .env ]; then
+	set -a
+	# shellcheck disable=SC1091
+	source .env
+	set +a
+fi
+
+if [ -z "${OC_GO_CC_API_KEY:-}" ]; then
+	echo -e "${RED}Error: OC_GO_CC_API_KEY not set. Create a .env file or export it.${NC}"
+	exit 1
+fi
+
+# --- Start proxy ---
+echo "=== Starting proxy on ${HOST}:${PORT} ==="
+cleanup
+./bin/oc-go-cc serve -b --port "$PORT" 2>&1
+sleep 2
+
+# Health check
+if ! curl -sf "${BASE_URL}/health" > /dev/null 2>&1; then
+	echo -e "${RED}Proxy failed to start${NC}"
+	exit 1
+fi
+echo -e "${GREEN}Proxy is running${NC}"
+echo ""
+
+# --- Test helper ---
+test_model() {
+	local model=$1
+	local label=$2
+
+	echo -n "  [$label] ${model} ... "
+
+	REQUEST_BODY=$(cat <<'JSON'
+{
+	"model": "MODEL_PLACEHOLDER",
+	"tools": [
+		{
+			"type": "custom",
+			"name": "read_file",
+			"description": "Read a file from the filesystem",
+			"input_schema": {
+				"type": "object",
+				"properties": {
+					"path": {"type": "string"}
+				}
+			}
+		}
+	],
+	"messages": [
+		{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "Say hello and nothing else"}
+			]
+		}
+	],
+	"max_tokens": 100,
+	"stream": false
+}
+JSON
+)
+	REQUEST_BODY="${REQUEST_BODY//MODEL_PLACEHOLDER/$model}"
+
+	HTTP_CODE=$(curl -s -o /tmp/oc-go-cc-e2e-response.json -w '%{http_code}' \
+		-X POST "${BASE_URL}/v1/messages" \
+		-H "Content-Type: application/json" \
+		-H "x-api-key: ${OC_GO_CC_API_KEY}" \
+		-d "$REQUEST_BODY" \
+		--max-time "$TIMEOUT_SEC")
+
+	if [ "$HTTP_CODE" = 200 ]; then
+		# Extract the text response for verification
+		TEXT=$(python3 -c "
+import json
+with open('/tmp/oc-go-cc-e2e-response.json') as f:
+    d = json.load(f)
+blocks = d.get('content', [])
+for b in blocks:
+    if b.get('type') == 'text':
+        print(b.get('text', ''))
+" 2>/dev/null)
+		echo -e "${GREEN}PASS${NC} (200, response: \"${TEXT}\")"
+		pass=$((pass + 1))
+	else
+		ERROR_MSG=$(head -c 300 /tmp/oc-go-cc-e2e-response.json 2>/dev/null || echo "")
+		echo -e "${RED}FAIL${NC} (HTTP ${HTTP_CODE})"
+		echo "    Response: ${ERROR_MSG}"
+		fail=$((fail + 1))
+	fi
+}
+
+# --- Test cases ---
+echo "=== E2E Model Tests (with tools and custom type) ==="
+echo ""
+
+test_model "minimax-m3"       "Tools format fix (was 400)"
+test_model "deepseek-v4-flash" "Baseline"
+test_model "kimi-k2.7-code"   "Temperature fix (was 400)"
+test_model "deepseek-v4-pro"  "Thinking model"
+test_model "qwen3.7-plus"     "Go provider qwen"
+
+echo ""
+echo "=== Results ==="
+echo -e "${GREEN}Passed: ${pass}${NC}"
+echo -e "${RED}Failed: ${fail}${NC}"
+echo ""
+
+if [ "$fail" -gt 0 ]; then
+	exit 1
+fi


### PR DESCRIPTION
  Problem: Claude Code sends MCP tools with type: "custom" in Anthropic format. The proxy was forwarding the raw body to OpenCode's /v1/messages without transformation, causing 400 errors. The     
  fallback chain then tried every model sequentially, creating an ~10-minute "death spiral."                                                                                                         
                                                                                                                                                                                                     
  Solution:                                                                                                                                                                                          
  1. Go provider models now go through the Chat Completions transform path (tools → OpenAI function format, message roles flattened)
  2. sanitizeAnthropicBody() strips tool type fields in the raw Anthropic path for Claude Zen models                                                                                                 
  3. 4xx errors skip circuit breaker recording — format mismatches don't penalize healthy models                     
  4. kimi-k2.7-code temperature constrained to 1.0                                                                                                                                                   
  5. AnthropicToolsDisabled config flag for future models                                                                                                                                            
                                                                                                                                                                                                     
  Tested: 5/5 models pass E2E with real API calls (minimax-m3, deepseek-v4-flash/pro, kimi-k2.7-code, qwen3.7-plus).        