### PR TITLE
Fix Dockerfile Go version mismatch (1.24 → 1.25)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
go.mod requires go >= 1.25 but the builder image was golang:1.24-alpine, causing build to fail with: `go: go.mod requires go >= 1.25 (running go 1.24.13; GOTOOLCHAIN=local)`