### PR TITLE
Adding aws bedrock as a provider

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -138,7 +138,9 @@ routatic-proxy supports three providers for upstream API calls:
 ### AWS Bedrock (`aws-bedrock`)
 
 - Models hosted on AWS Bedrock Mantle
-- Uses OpenAI Chat Completions endpoint format
+- Supports two wire formats:
+  - **OpenAI Chat Completions** (`/v1/chat/completions`) — default, works with most models
+  - **Anthropic Messages** (`/v1/messages`) — for Claude and other Anthropic-native models
 - Supports the `OpenAI-Project` header for project-based routing
 - Bedrock-specific API key falls back to the global key pool if unset
 - Set `"provider": "aws-bedrock"` in your model config to use Bedrock
@@ -147,14 +149,18 @@ routatic-proxy supports three providers for upstream API calls:
 {
   "aws_bedrock": {
     "base_url": "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+    "anthropic_base_url": "https://bedrock-mantle.us-east-1.api.aws/v1/messages",
     "api_key": "${BEDROCK_API_KEY}",
     "project_id": "proj_xxx",
+    "wire_format": "openai",
     "timeout_ms": 300000,
     "stream_timeout_ms": 60000,
     "streaming_timeout_ms": 600000
   }
 }
 ```
+
+Set `wire_format: "anthropic"` for models that need raw Anthropic Messages format (e.g., Claude on Bedrock). Requires `anthropic_base_url` to be configured.
 
 ## Environment Variables
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -117,7 +117,7 @@ For migration, `~/.config/oc-go-cc/config.json` is loaded when the new config fi
 
 ## Providers
 
-routatic-proxy supports two providers for upstream API calls:
+routatic-proxy supports three providers for upstream API calls:
 
 ### OpenCode Go (`opencode-go`)
 
@@ -134,6 +134,27 @@ routatic-proxy supports two providers for upstream API calls:
   - **OpenAI Responses** (`/v1/responses`) — GPT models
   - **Google Gemini** (`/v1/models/{id}`) — Gemini models
 - Set `"provider": "opencode-zen"` in your model config to use Zen
+
+### AWS Bedrock (`aws-bedrock`)
+
+- Models hosted on AWS Bedrock Mantle
+- Uses OpenAI Chat Completions endpoint format
+- Supports the `OpenAI-Project` header for project-based routing
+- Bedrock-specific API key falls back to the global key pool if unset
+- Set `"provider": "aws-bedrock"` in your model config to use Bedrock
+
+```json
+{
+  "aws_bedrock": {
+    "base_url": "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+    "api_key": "${BEDROCK_API_KEY}",
+    "project_id": "proj_xxx",
+    "timeout_ms": 300000,
+    "stream_timeout_ms": 60000,
+    "streaming_timeout_ms": 600000
+  }
+}
+```
 
 ## Environment Variables
 
@@ -234,7 +255,7 @@ When a request arrives, the proxy checks `model_overrides[<model>]` **first**. I
 }
 ```
 
-Each entry accepts the same fields as a `ModelConfig` (`provider`, `model_id`, `temperature`, `max_tokens`, `reasoning_effort`, `thinking`, etc.). `model_id` is required; `provider` must be `"opencode-go"` or `"opencode-zen"` (or omitted to inherit the default).
+Each entry accepts the same fields as a `ModelConfig` (`provider`, `model_id`, `temperature`, `max_tokens`, `reasoning_effort`, `thinking`, etc.). `model_id` is required; `provider` must be `"opencode-go"`, `"opencode-zen"`, or `"aws-bedrock"` (or omitted to inherit the default).
 
 See `routatic-proxy models` for the complete list of available Zen models across all endpoint types (Claude, GPT, Gemini, and free-tier).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ configs/
 - **Real-time stream proxying**: SSE events are transformed in-flight, not buffered. This means Claude Code sees responses as they arrive from upstream.
 - **Circuit breaker per model**: Each model gets its own circuit breaker. After 3 consecutive failures, the model is skipped for 30 seconds, then tested again.
 - **Environment variable interpolation**: Config values like `"${ROUTATIC_PROXY_API_KEY}"` are resolved at load time, so you never need to put secrets in the config file.
-- **Provider-aware routing**: The `provider` field in model config determines which upstream service to use (Go or Zen). Zen models are further classified by endpoint type (Chat Completions, Anthropic, Responses, Gemini).
+- **Provider-aware routing**: The `provider` field in model config determines which upstream service to use (Go, Zen, or Bedrock). Zen models are further classified by endpoint type (Chat Completions, Anthropic, Responses, Gemini). Bedrock models use OpenAI Chat Completions format.
 
 ## API Endpoints
 

--- a/MODELS.md
+++ b/MODELS.md
@@ -35,6 +35,12 @@ Comprehensive guide to OpenCode Go and Zen models with capabilities, costs, and 
 - Additional endpoint formats: Responses (GPT), Gemini
 - Best for: GPT models, Gemini models, premium Anthropic models
 
+### AWS Bedrock (`aws-bedrock`)
+
+- Models hosted on AWS Bedrock Mantle
+- OpenAI Chat Completions endpoint format
+- Best for: Models deployed on your own AWS infrastructure
+
 ## Important: API Endpoints
 
 ⚠️ **Critical:** Not all models use the same API endpoint! routatic-proxy handles this automatically, but you should know:

--- a/MODELS.md
+++ b/MODELS.md
@@ -38,7 +38,8 @@ Comprehensive guide to OpenCode Go and Zen models with capabilities, costs, and 
 ### AWS Bedrock (`aws-bedrock`)
 
 - Models hosted on AWS Bedrock Mantle
-- OpenAI Chat Completions endpoint format
+- Supports OpenAI Chat Completions (default) and Anthropic Messages formats
+- Set `wire_format: "anthropic"` for Claude and other Anthropic-native models
 - Best for: Models deployed on your own AWS infrastructure
 
 ## Important: API Endpoints

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # routatic-proxy (prev OC-GO-CC)
 
-A Go CLI proxy that lets you use your [OpenCode Go](https://opencode.ai/docs/go/) or [OpenCode Zen](https://opencode.ai/docs/zen/) subscription with [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+A Go CLI proxy that lets you route [Claude Code](https://docs.anthropic.com/en/docs/claude-code) requests through multiple upstream providers — [OpenCode Go](https://opencode.ai/docs/go/), [OpenCode Zen](https://opencode.ai/docs/zen/), and [AWS Bedrock](https://aws.amazon.com/bedrock/) — with automatic model selection and format transformation.
 
-`routatic-proxy` sits between Claude Code and OpenCode, intercepting Anthropic API requests, transforming them to the appropriate format (OpenAI, Responses, or Gemini), and forwarding them to OpenCode's endpoints. Claude Code thinks it's talking to Anthropic — but your requests go to affordable open models instead.
+`routatic-proxy` sits between Claude Code and your chosen providers, intercepting Anthropic API requests, transforming them to the appropriate format (OpenAI, Anthropic, Responses, or Gemini), and forwarding them upstream. Claude Code thinks it's talking to Anthropic — but your requests go to the models and providers you configure.
 
 `oc-go-cc` remains available as a compatibility alias, and existing `OC_GO_CC_*` environment variables and `~/.config/oc-go-cc/config.json` files are still recognized.
 
 ## Why?
 
-OpenCode Go gives you access to powerful open coding models for **$5/month** (then $10/month). OpenCode Zen provides curated, tested models with pay-as-you-go pricing. This proxy makes both work seamlessly with Claude Code's interface — no patches, no forks, just set two environment variables and go.
+OpenCode Go gives you access to powerful open coding models for **$5/month** (then $10/month). OpenCode Zen provides curated, tested models with pay-as-you-go pricing. AWS Bedrock lets you run models on your own AWS infrastructure. This proxy makes all three work seamlessly with Claude Code's interface — no patches, no forks, just set two environment variables and go.
 
 ## Features
 
-- **Transparent Proxy** — Claude Code sends Anthropic-format requests, proxy transforms to OpenAI/Responses/Gemini format and back
-- **Dual Provider Support** — Route models through OpenCode Go or OpenCode Zen based on your needs
+- **Multi-Provider** — Route through OpenCode Go, OpenCode Zen, or AWS Bedrock from a single config
+- **Transparent Proxy** — Claude Code sends Anthropic-format requests, proxy transforms to provider-native format and back
 - **Model Routing** — Automatically routes to different models based on context (default, thinking, long context, background)
 - **Streaming Scenario Routing** — Configurable routing for streaming requests; enables proper scenario selection for Claude Code multi-agent and review workflows (see [CONFIGURATION.md](CONFIGURATION.md#streaming-scenario-routing))
 - **Fallback Chains** — If a model fails, automatically tries the next one in your configured chain
@@ -100,7 +100,7 @@ routatic-proxy stop               Stop the running proxy server
 routatic-proxy status             Check if the proxy is running
 routatic-proxy init               Create default configuration file
 routatic-proxy validate           Validate configuration file
-routatic-proxy models             List all available models (Go + Zen)
+routatic-proxy models             List all available models (Go, Zen, Bedrock)
 routatic-proxy autostart enable   Enable auto-start on login
 routatic-proxy autostart disable  Disable auto-start on login
 routatic-proxy autostart status   Check autostart status

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -182,6 +182,15 @@
     }
   },
 
+  "aws_bedrock": {
+    "base_url": "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+    "api_key": "",
+    "project_id": "",
+    "timeout_ms": 300000,
+    "stream_timeout_ms": 60000,
+    "streaming_timeout_ms": 600000
+  },
+
   "opencode_go": {
     "base_url": "https://opencode.ai/zen/go/v1/chat/completions",
     "anthropic_base_url": "https://opencode.ai/zen/go/v1/messages",

--- a/configs/config.example.json
+++ b/configs/config.example.json
@@ -184,8 +184,10 @@
 
   "aws_bedrock": {
     "base_url": "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+    "anthropic_base_url": "",
     "api_key": "",
     "project_id": "",
+    "wire_format": "openai",
     "timeout_ms": 300000,
     "stream_timeout_ms": 60000,
     "streaming_timeout_ms": 600000

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,7 @@ Anthropic's `system` and `content` fields accept both strings and arrays. The `p
 
 **Why config-driven routing?** Adding a new model requires zero code changes — just add an entry to `config.json`. The scenario detector, fallback chains, and model metadata are all declarative.
 
-**Why not use Anthropic format everywhere?** Most upstream models only support OpenAI Chat Completions format. The proxy handles the translation so Claude Code doesn't need to know which provider it's talking to.
+**Why not use Anthropic format everywhere?** Most upstream models only support OpenAI Chat Completions format. The proxy handles the translation so Claude Code doesn't need to know which provider it's talking to. Bedrock Mantle models also use Chat Completions format via the `aws-bedrock` provider.
 
 **Why per-read idle timeout instead of WriteTimeout?** Claude Code's tool execution can pause streams for minutes. A server-level timeout would kill active streams. The per-byte watchdog only triggers when the upstream is truly stuck.
 

--- a/docs/howto-add-model.md
+++ b/docs/howto-add-model.md
@@ -14,6 +14,7 @@ Determine which upstream provider the model uses and which endpoint format it ac
 | `opencode-zen` | `/v1/messages` | Anthropic Messages (Claude, Qwen) |
 | `opencode-zen` | `/v1/responses` | OpenAI Responses (GPT models) |
 | `opencode-zen` | `/v1/models/{id}` | Gemini |
+| `aws-bedrock` | `/v1/chat/completions` | OpenAI Chat Completions (Bedrock Mantle) |
 
 ## Step 2: Add Model Metadata
 

--- a/docs/howto-add-model.md
+++ b/docs/howto-add-model.md
@@ -15,6 +15,7 @@ Determine which upstream provider the model uses and which endpoint format it ac
 | `opencode-zen` | `/v1/responses` | OpenAI Responses (GPT models) |
 | `opencode-zen` | `/v1/models/{id}` | Gemini |
 | `aws-bedrock` | `/v1/chat/completions` | OpenAI Chat Completions (Bedrock Mantle) |
+| `aws-bedrock` | `/v1/messages` | Anthropic Messages (Bedrock Mantle, requires `wire_format: "anthropic"`) |
 
 ## Step 2: Add Model Metadata
 

--- a/internal/client/opencode.go
+++ b/internal/client/opencode.go
@@ -19,6 +19,7 @@ import (
 const (
 	ProviderOpenCodeGo  = "opencode-go"
 	ProviderOpenCodeZen = "opencode-zen"
+	ProviderAWSBedrock  = "aws-bedrock"
 )
 
 // APIError represents an HTTP API error returned by an upstream provider.
@@ -75,8 +76,8 @@ func NewOpenCodeClient(atomic *config.AtomicConfig) *OpenCodeClient {
 // for a model. The stream lives as long as data keeps flowing; only an idle
 // period longer than this value is treated as a stuck connection and aborted.
 // Go provider models use OpenCodeGo.StreamTimeoutMs; Zen models use
-// OpenCodeZen.StreamTimeoutMs. Falls back to 5 minutes if the config is
-// unavailable or the value is zero.
+// OpenCodeZen.StreamTimeoutMs; Bedrock models use AWSBedrock.StreamTimeoutMs.
+// Falls back to 5 minutes if the config is unavailable or the value is zero.
 func (c *OpenCodeClient) StreamIdleTimeout(modelConfig config.ModelConfig) time.Duration {
 	const fallback = 5 * time.Minute
 	if c == nil || c.atomic == nil {
@@ -84,13 +85,22 @@ func (c *OpenCodeClient) StreamIdleTimeout(modelConfig config.ModelConfig) time.
 	}
 	cfg := c.atomic.Get()
 	var ms int
-	if IsZen(modelConfig) {
+	switch {
+	case IsBedrock(modelConfig):
+		ms = cfg.AWSBedrock.StreamTimeoutMs
+		if ms <= 0 {
+			ms = cfg.AWSBedrock.TimeoutMs
+		}
+	case IsZen(modelConfig):
 		ms = cfg.OpenCodeZen.StreamTimeoutMs
-	} else {
+		if ms <= 0 {
+			ms = cfg.OpenCodeZen.TimeoutMs
+		}
+	default:
 		ms = cfg.OpenCodeGo.StreamTimeoutMs
-	}
-	if ms <= 0 {
-		ms = cfg.OpenCodeGo.TimeoutMs
+		if ms <= 0 {
+			ms = cfg.OpenCodeGo.TimeoutMs
+		}
 	}
 	if ms <= 0 {
 		return fallback
@@ -105,9 +115,12 @@ func (c *OpenCodeClient) RequestTimeout(model config.ModelConfig) time.Duration 
 	}
 	cfg := c.atomic.Get()
 	var timeoutMs int
-	if IsZen(model) {
+	switch {
+	case IsBedrock(model):
+		timeoutMs = cfg.AWSBedrock.TimeoutMs
+	case IsZen(model):
 		timeoutMs = cfg.OpenCodeZen.TimeoutMs
-	} else {
+	default:
 		timeoutMs = cfg.OpenCodeGo.TimeoutMs
 	}
 	if timeoutMs > 0 {
@@ -123,12 +136,18 @@ func (c *OpenCodeClient) StreamingTimeout(model config.ModelConfig) time.Duratio
 	}
 	cfg := c.atomic.Get()
 	var timeoutMs int
-	if IsZen(model) {
+	switch {
+	case IsBedrock(model):
+		timeoutMs = cfg.AWSBedrock.StreamingTimeoutMs
+		if timeoutMs <= 0 {
+			timeoutMs = cfg.AWSBedrock.TimeoutMs
+		}
+	case IsZen(model):
 		timeoutMs = cfg.OpenCodeZen.StreamingTimeoutMs
 		if timeoutMs <= 0 {
 			timeoutMs = cfg.OpenCodeZen.TimeoutMs
 		}
-	} else {
+	default:
 		timeoutMs = cfg.OpenCodeGo.StreamingTimeoutMs
 		if timeoutMs <= 0 {
 			timeoutMs = cfg.OpenCodeGo.TimeoutMs
@@ -182,6 +201,11 @@ func Provider(model config.ModelConfig) string {
 // IsZen returns true if the model uses the OpenCode Zen provider.
 func IsZen(model config.ModelConfig) bool {
 	return Provider(model) == ProviderOpenCodeZen
+}
+
+// IsBedrock returns true if the model uses the AWS Bedrock provider.
+func IsBedrock(model config.ModelConfig) bool {
+	return Provider(model) == ProviderAWSBedrock
 }
 
 // EndpointType determines which Zen endpoint format to use.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	Models                         map[string]ModelConfig   `json:"models"`
 	Fallbacks                      map[string][]ModelConfig `json:"fallbacks"`
 	ModelOverrides                 map[string]ModelConfig   `json:"model_overrides"`
-	AWSBedrock                     AWSBedrockConfig          `json:"aws_bedrock"`
+	AWSBedrock                     AWSBedrockConfig         `json:"aws_bedrock"`
 	OpenCodeGo                     OpenCodeGoConfig         `json:"opencode_go"`
 	OpenCodeZen                    OpenCodeZenConfig        `json:"opencode_zen"`
 	Logging                        LoggingConfig            `json:"logging"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Models                         map[string]ModelConfig   `json:"models"`
 	Fallbacks                      map[string][]ModelConfig `json:"fallbacks"`
 	ModelOverrides                 map[string]ModelConfig   `json:"model_overrides"`
+	AWSBedrock                     AWSBedrockConfig          `json:"aws_bedrock"`
 	OpenCodeGo                     OpenCodeGoConfig         `json:"opencode_go"`
 	OpenCodeZen                    OpenCodeZenConfig        `json:"opencode_zen"`
 	Logging                        LoggingConfig            `json:"logging"`
@@ -36,6 +37,16 @@ type ModelConfig struct {
 	Thinking               json.RawMessage `json:"thinking,omitempty"`
 	Vision                 bool            `json:"vision"`
 	AnthropicToolsDisabled bool            `json:"anthropic_tools_disabled"`
+}
+
+// AWSBedrockConfig holds the upstream AWS Bedrock Mantle API settings.
+type AWSBedrockConfig struct {
+	BaseURL            string `json:"base_url"`
+	APIKey             string `json:"api_key,omitempty"`
+	ProjectID          string `json:"project_id,omitempty"`
+	TimeoutMs          int    `json:"timeout_ms"`
+	StreamTimeoutMs    int    `json:"stream_timeout_ms"`
+	StreamingTimeoutMs int    `json:"streaming_timeout_ms,omitempty"`
 }
 
 // OpenCodeGoConfig holds the upstream OpenCode Go API settings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,8 +42,10 @@ type ModelConfig struct {
 // AWSBedrockConfig holds the upstream AWS Bedrock Mantle API settings.
 type AWSBedrockConfig struct {
 	BaseURL            string `json:"base_url"`
+	AnthropicBaseURL   string `json:"anthropic_base_url,omitempty"`
 	APIKey             string `json:"api_key,omitempty"`
 	ProjectID          string `json:"project_id,omitempty"`
+	WireFormat         string `json:"wire_format,omitempty"` // "openai" (default), "anthropic"
 	TimeoutMs          int    `json:"timeout_ms"`
 	StreamTimeoutMs    int    `json:"stream_timeout_ms"`
 	StreamingTimeoutMs int    `json:"streaming_timeout_ms,omitempty"`

--- a/internal/provider/aws_bedrock.go
+++ b/internal/provider/aws_bedrock.go
@@ -17,7 +17,7 @@ import (
 )
 
 // AWSBedrockProvider implements core.Provider for the AWS Bedrock Mantle backend.
-// Bedrock Mantle exposes an OpenAI-compatible /v1/chat/completions endpoint.
+// Bedrock Mantle exposes OpenAI-compatible and optionally Anthropic-compatible endpoints.
 type AWSBedrockProvider struct {
 	baseProvider
 }
@@ -48,9 +48,14 @@ func (p *AWSBedrockProvider) ModelCapabilities(modelID string) (core.ProviderCap
 	return p.Capabilities(), true
 }
 
-// WireFormat returns the wire format for Bedrock models. Bedrock Mantle uses
-// OpenAI Chat Completions format exclusively.
+// WireFormat returns the wire format for Bedrock models. Defaults to OpenAI
+// Chat Completions. Set wire_format: "anthropic" in aws_bedrock config for
+// models that need raw Anthropic Messages format.
 func (p *AWSBedrockProvider) WireFormat(modelID string) core.WireFormat {
+	cfg := p.atomic.Get()
+	if cfg != nil && cfg.AWSBedrock.WireFormat == "anthropic" {
+		return core.WireFormatAnthropic
+	}
 	return core.WireFormatOpenAIChat
 }
 
@@ -75,6 +80,27 @@ func (p *AWSBedrockProvider) StreamIdleTimeout(model config.ModelConfig) time.Du
 
 // Execute sends a non-streaming request and returns the response.
 func (p *AWSBedrockProvider) Execute(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (*core.ExecuteResult, error) {
+	switch p.WireFormat(model.ModelID) {
+	case core.WireFormatAnthropic:
+		return p.executeAnthropic(ctx, req, model)
+	default:
+		return p.executeOpenAI(ctx, req, model)
+	}
+}
+
+// Stream sends a streaming request and returns an io.ReadCloser for SSE events.
+func (p *AWSBedrockProvider) Stream(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (io.ReadCloser, error) {
+	switch p.WireFormat(model.ModelID) {
+	case core.WireFormatAnthropic:
+		return p.streamAnthropic(ctx, req, model)
+	default:
+		return p.streamOpenAI(ctx, req, model)
+	}
+}
+
+// ── OpenAI Chat Completions ────────────────────────────────────────────
+
+func (p *AWSBedrockProvider) executeOpenAI(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (*core.ExecuteResult, error) {
 	cfg := p.atomic.Get()
 	endpoint := cfg.AWSBedrock.BaseURL
 	apiKey := p.bedrockAPIKey(cfg)
@@ -114,8 +140,7 @@ func (p *AWSBedrockProvider) Execute(ctx context.Context, req *core.NormalizedRe
 	}, nil
 }
 
-// Stream sends a streaming request and returns an io.ReadCloser for SSE events.
-func (p *AWSBedrockProvider) Stream(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (io.ReadCloser, error) {
+func (p *AWSBedrockProvider) streamOpenAI(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (io.ReadCloser, error) {
 	cfg := p.atomic.Get()
 	endpoint := cfg.AWSBedrock.BaseURL
 	apiKey := p.bedrockAPIKey(cfg)
@@ -131,6 +156,97 @@ func (p *AWSBedrockProvider) Stream(ctx context.Context, req *core.NormalizedReq
 
 	return resp.Body, nil
 }
+
+// ── Anthropic Messages ────────────────────────────────────────────────
+
+func (p *AWSBedrockProvider) executeAnthropic(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (*core.ExecuteResult, error) {
+	cfg := p.atomic.Get()
+	endpoint := cfg.AWSBedrock.AnthropicBaseURL
+	if endpoint == "" {
+		return nil, fmt.Errorf("anthropic_base_url not configured for aws-bedrock provider")
+	}
+	apiKey := p.bedrockAPIKey(cfg)
+
+	anthropicReq := transformer.NormalizedToAnthropic(req, model)
+	rawBody, err := json.Marshal(anthropicReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal anthropic request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(rawBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	if cfg.AWSBedrock.ProjectID != "" {
+		httpReq.Header.Set("OpenAI-Project", cfg.AWSBedrock.ProjectID)
+	}
+
+	start := time.Now()
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, &client.APIError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return &core.ExecuteResult{
+		Body:    body,
+		ModelID: model.ModelID,
+		Latency: time.Since(start),
+	}, nil
+}
+
+func (p *AWSBedrockProvider) streamAnthropic(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (io.ReadCloser, error) {
+	cfg := p.atomic.Get()
+	endpoint := cfg.AWSBedrock.AnthropicBaseURL
+	if endpoint == "" {
+		return nil, fmt.Errorf("anthropic_base_url not configured for aws-bedrock provider")
+	}
+	apiKey := p.bedrockAPIKey(cfg)
+
+	anthropicReq := transformer.NormalizedToAnthropic(req, model)
+	rawBody, err := json.Marshal(anthropicReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal anthropic request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(rawBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	if cfg.AWSBedrock.ProjectID != "" {
+		httpReq.Header.Set("OpenAI-Project", cfg.AWSBedrock.ProjectID)
+	}
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, &client.APIError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
+	}
+
+	return resp.Body, nil
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
 
 // bedrockAPIKey returns the Bedrock-specific API key if configured, otherwise
 // falls back to the global API key pool.

--- a/internal/provider/aws_bedrock.go
+++ b/internal/provider/aws_bedrock.go
@@ -1,0 +1,177 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/routatic/proxy/internal/client"
+	"github.com/routatic/proxy/internal/config"
+	"github.com/routatic/proxy/internal/core"
+	"github.com/routatic/proxy/internal/transformer"
+	"github.com/routatic/proxy/pkg/types"
+)
+
+// AWSBedrockProvider implements core.Provider for the AWS Bedrock Mantle backend.
+// Bedrock Mantle exposes an OpenAI-compatible /v1/chat/completions endpoint.
+type AWSBedrockProvider struct {
+	baseProvider
+}
+
+// NewAWSBedrockProvider creates a new AWSBedrockProvider.
+func NewAWSBedrockProvider(atomic *config.AtomicConfig) *AWSBedrockProvider {
+	return &AWSBedrockProvider{baseProvider: newBaseProvider(atomic)}
+}
+
+// Name returns the provider identifier.
+func (p *AWSBedrockProvider) Name() string { return "aws-bedrock" }
+
+// Capabilities returns provider-level capabilities.
+func (p *AWSBedrockProvider) Capabilities() core.ProviderCapabilities {
+	return core.ProviderCapabilities{
+		SupportsStreaming:  true,
+		SupportsTools:      true,
+		SupportsThinking:   true,
+		SupportsImageInput: true,
+		MaxContextLength:   200_000,
+		DefaultMaxTokens:   4096,
+	}
+}
+
+// ModelCapabilities returns per-model capabilities. Returns true for all models
+// since Bedrock hosts many different model families.
+func (p *AWSBedrockProvider) ModelCapabilities(modelID string) (core.ProviderCapabilities, bool) {
+	return p.Capabilities(), true
+}
+
+// WireFormat returns the wire format for Bedrock models. Bedrock Mantle uses
+// OpenAI Chat Completions format exclusively.
+func (p *AWSBedrockProvider) WireFormat(modelID string) core.WireFormat {
+	return core.WireFormatOpenAIChat
+}
+
+// RoundTripName returns the model ID to use in the upstream request.
+func (p *AWSBedrockProvider) RoundTripName(model config.ModelConfig) string {
+	return model.ModelID
+}
+
+// StreamIdleTimeout returns the maximum gap between bytes on an active stream.
+func (p *AWSBedrockProvider) StreamIdleTimeout(model config.ModelConfig) time.Duration {
+	const fallback = 5 * time.Minute
+	cfg := p.atomic.Get()
+	ms := cfg.AWSBedrock.StreamTimeoutMs
+	if ms <= 0 {
+		ms = cfg.AWSBedrock.TimeoutMs
+	}
+	if ms <= 0 {
+		return fallback
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// Execute sends a non-streaming request and returns the response.
+func (p *AWSBedrockProvider) Execute(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (*core.ExecuteResult, error) {
+	cfg := p.atomic.Get()
+	endpoint := cfg.AWSBedrock.BaseURL
+	apiKey := p.bedrockAPIKey(cfg)
+
+	openaiReq := transformer.TransformRequestFromNormalized(req, model)
+	streamFalse := false
+	openaiReq.Stream = &streamFalse
+
+	start := time.Now()
+	resp, err := p.doBedrockRequest(ctx, endpoint, apiKey, cfg.AWSBedrock.ProjectID, openaiReq, false)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var chatResp types.ChatCompletionResponse
+	if err := json.Unmarshal(body, &chatResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	normResp := transformer.OpenAIResponseToNormalized(&chatResp, model.ModelID)
+	anthropicResp := core.DenormalizeResponse(normResp)
+	resultBody, err := json.Marshal(anthropicResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	return &core.ExecuteResult{
+		Body:    resultBody,
+		ModelID: model.ModelID,
+		Latency: time.Since(start),
+	}, nil
+}
+
+// Stream sends a streaming request and returns an io.ReadCloser for SSE events.
+func (p *AWSBedrockProvider) Stream(ctx context.Context, req *core.NormalizedRequest, model config.ModelConfig) (io.ReadCloser, error) {
+	cfg := p.atomic.Get()
+	endpoint := cfg.AWSBedrock.BaseURL
+	apiKey := p.bedrockAPIKey(cfg)
+
+	openaiReq := transformer.TransformRequestFromNormalized(req, model)
+	streamTrue := true
+	openaiReq.Stream = &streamTrue
+
+	resp, err := p.doBedrockRequest(ctx, endpoint, apiKey, cfg.AWSBedrock.ProjectID, openaiReq, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+// bedrockAPIKey returns the Bedrock-specific API key if configured, otherwise
+// falls back to the global API key pool.
+func (p *AWSBedrockProvider) bedrockAPIKey(cfg *config.Config) string {
+	if cfg.AWSBedrock.APIKey != "" {
+		return cfg.AWSBedrock.APIKey
+	}
+	return p.nextAPIKey(cfg.EffectiveAPIKeys())
+}
+
+// doBedrockRequest sends an HTTP request to the Bedrock Mantle endpoint with
+// the OpenAI-Project header when configured.
+func (p *AWSBedrockProvider) doBedrockRequest(ctx context.Context, endpoint, apiKey, projectID string, req any, stream bool) (*http.Response, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	if projectID != "" {
+		httpReq.Header.Set("OpenAI-Project", projectID)
+	}
+	if stream {
+		httpReq.Header.Set("Accept", "text/event-stream")
+	}
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, &client.APIError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
+	}
+
+	return resp, nil
+}

--- a/internal/provider/aws_bedrock_test.go
+++ b/internal/provider/aws_bedrock_test.go
@@ -1,0 +1,260 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/routatic/proxy/internal/client"
+	"github.com/routatic/proxy/internal/config"
+	"github.com/routatic/proxy/internal/core"
+	"github.com/routatic/proxy/pkg/types"
+)
+
+func TestAWSBedrockProvider_Name(t *testing.T) {
+	p := NewAWSBedrockProvider(nil)
+	if got := p.Name(); got != "aws-bedrock" {
+		t.Errorf("Name() = %q, want %q", got, "aws-bedrock")
+	}
+}
+
+func TestAWSBedrockProvider_WireFormat(t *testing.T) {
+	p := NewAWSBedrockProvider(nil)
+	if got := p.WireFormat("any-model"); got != core.WireFormatOpenAIChat {
+		t.Errorf("WireFormat() = %v, want WireFormatOpenAIChat", got)
+	}
+}
+
+func TestAWSBedrockProvider_RoundTripName(t *testing.T) {
+	p := NewAWSBedrockProvider(nil)
+	model := config.ModelConfig{ModelID: "moonshotai.kimi-k2.5"}
+	if got := p.RoundTripName(model); got != "moonshotai.kimi-k2.5" {
+		t.Errorf("RoundTripName() = %q, want %q", got, "moonshotai.kimi-k2.5")
+	}
+}
+
+func TestAWSBedrockProvider_Capabilities(t *testing.T) {
+	p := NewAWSBedrockProvider(nil)
+	caps := p.Capabilities()
+	if !caps.SupportsStreaming {
+		t.Error("SupportsStreaming = false, want true")
+	}
+	if !caps.SupportsTools {
+		t.Error("SupportsTools = false, want true")
+	}
+	if !caps.SupportsImageInput {
+		t.Error("SupportsImageInput = false, want true")
+	}
+}
+
+func TestAWSBedrockProvider_ModelCapabilities(t *testing.T) {
+	p := NewAWSBedrockProvider(nil)
+	caps, ok := p.ModelCapabilities("any-model")
+	if !ok {
+		t.Error("ModelCapabilities() returned false, want true")
+	}
+	if !caps.SupportsStreaming {
+		t.Error("ModelCapabilities().SupportsStreaming = false, want true")
+	}
+}
+
+func TestAWSBedrockProvider_StreamIdleTimeout_Default(t *testing.T) {
+	cfg := &config.Config{}
+	atomic := config.NewAtomicConfig(cfg, "")
+	p := NewAWSBedrockProvider(atomic)
+	model := config.ModelConfig{}
+	got := p.StreamIdleTimeout(model)
+	if got != 5*60*1000*1000*1000 { // 5 minutes
+		t.Errorf("StreamIdleTimeout() = %v, want 5m", got)
+	}
+}
+
+func TestAWSBedrockProvider_StreamIdleTimeout_Configured(t *testing.T) {
+	cfg := &config.Config{
+		AWSBedrock: config.AWSBedrockConfig{
+			StreamTimeoutMs: 30000,
+		},
+	}
+	atomic := config.NewAtomicConfig(cfg, "")
+	p := NewAWSBedrockProvider(atomic)
+	model := config.ModelConfig{}
+	got := p.StreamIdleTimeout(model)
+	if got != 30*1000*1000*1000 { // 30 seconds
+		t.Errorf("StreamIdleTimeout() = %v, want 30s", got)
+	}
+}
+
+func TestAWSBedrockProvider_Execute(t *testing.T) {
+	// Mock upstream server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify headers
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want %q", r.Header.Get("Authorization"), "Bearer test-key")
+		}
+		if r.Header.Get("OpenAI-Project") != "proj_123" {
+			t.Errorf("OpenAI-Project = %q, want %q", r.Header.Get("OpenAI-Project"), "proj_123")
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type = %q, want %q", r.Header.Get("Content-Type"), "application/json")
+		}
+
+		// Return a valid OpenAI response
+		resp := types.ChatCompletionResponse{
+			ID:    "cmpl-test",
+			Model: "moonshotai.kimi-k2.5",
+			Choices: []types.ChatCompletionChoice{
+				{
+					Index: 0,
+					Message: types.ChatCompletionMessage{
+						Role:    "assistant",
+						Content: "Hello from Bedrock",
+					},
+					FinishReason: "stop",
+				},
+			},
+			Usage: types.Usage{
+				PromptTokens:     10,
+				CompletionTokens: 5,
+				TotalTokens:      15,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		AWSBedrock: config.AWSBedrockConfig{
+			BaseURL: server.URL,
+			APIKey:  "test-key",
+			ProjectID: "proj_123",
+		},
+	}
+	atomic := config.NewAtomicConfig(cfg, "")
+	p := NewAWSBedrockProvider(atomic)
+
+	req := &core.NormalizedRequest{
+		Model:    "moonshotai.kimi-k2.5",
+		Messages: []core.NormalizedMessage{{Role: "user", Content: "Hi"}},
+	}
+	model := config.ModelConfig{ModelID: "moonshotai.kimi-k2.5"}
+
+	result, err := p.Execute(context.Background(), req, model)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("Execute() returned nil result")
+	}
+	if result.ModelID != "moonshotai.kimi-k2.5" {
+		t.Errorf("ModelID = %q, want %q", result.ModelID, "moonshotai.kimi-k2.5")
+	}
+	if len(result.Body) == 0 {
+		t.Error("Body is empty")
+	}
+}
+
+func TestAWSBedrockProvider_Stream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want %q", r.Header.Get("Authorization"), "Bearer test-key")
+		}
+		if r.Header.Get("OpenAI-Project") != "proj_123" {
+			t.Errorf("OpenAI-Project = %q, want %q", r.Header.Get("OpenAI-Project"), "proj_123")
+		}
+		if r.Header.Get("Accept") != "text/event-stream" {
+			t.Errorf("Accept = %q, want %q", r.Header.Get("Accept"), "text/event-stream")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"))
+		w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		AWSBedrock: config.AWSBedrockConfig{
+			BaseURL:   server.URL,
+			APIKey:    "test-key",
+			ProjectID: "proj_123",
+		},
+	}
+	atomic := config.NewAtomicConfig(cfg, "")
+	p := NewAWSBedrockProvider(atomic)
+
+	req := &core.NormalizedRequest{
+		Model:    "moonshotai.kimi-k2.5",
+		Messages: []core.NormalizedMessage{{Role: "user", Content: "Hi"}},
+		Stream:   true,
+	}
+	model := config.ModelConfig{ModelID: "moonshotai.kimi-k2.5"}
+
+	body, err := p.Stream(context.Background(), req, model)
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	defer body.Close()
+
+	buf := make([]byte, 1024)
+	n, _ := body.Read(buf)
+	if n == 0 {
+		t.Error("Stream() returned empty body")
+	}
+}
+
+func TestAWSBedrockProvider_Execute_NoProjectID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("OpenAI-Project") != "" {
+			t.Errorf("OpenAI-Project = %q, want empty", r.Header.Get("OpenAI-Project"))
+		}
+		resp := types.ChatCompletionResponse{
+			ID:    "cmpl-test",
+			Model: "test-model",
+			Choices: []types.ChatCompletionChoice{
+				{Index: 0, Message: types.ChatCompletionMessage{Role: "assistant", Content: "ok"}, FinishReason: "stop"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		AWSBedrock: config.AWSBedrockConfig{
+			BaseURL: server.URL,
+			APIKey:  "test-key",
+		},
+	}
+	atomic := config.NewAtomicConfig(cfg, "")
+	p := NewAWSBedrockProvider(atomic)
+
+	req := &core.NormalizedRequest{
+		Model:    "test-model",
+		Messages: []core.NormalizedMessage{{Role: "user", Content: "Hi"}},
+	}
+	model := config.ModelConfig{ModelID: "test-model"}
+
+	_, err := p.Execute(context.Background(), req, model)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+}
+
+func TestIsBedrock(t *testing.T) {
+	tests := []struct {
+		model  config.ModelConfig
+		want   bool
+	}{
+		{config.ModelConfig{Provider: "aws-bedrock"}, true},
+		{config.ModelConfig{Provider: "opencode-go"}, false},
+		{config.ModelConfig{Provider: "opencode-zen"}, false},
+		{config.ModelConfig{}, false},
+	}
+	for _, tt := range tests {
+		if got := IsBedrock(tt.model); got != tt.want {
+			t.Errorf("IsBedrock(%v) = %v, want %v", tt.model, got, tt.want)
+		}
+	}
+}

--- a/internal/provider/aws_bedrock_test.go
+++ b/internal/provider/aws_bedrock_test.go
@@ -21,9 +21,24 @@ func TestAWSBedrockProvider_Name(t *testing.T) {
 }
 
 func TestAWSBedrockProvider_WireFormat(t *testing.T) {
-	p := NewAWSBedrockProvider(nil)
+	cfg := &config.Config{}
+	atomic := config.NewAtomicConfig(cfg, "")
+	p := NewAWSBedrockProvider(atomic)
 	if got := p.WireFormat("any-model"); got != core.WireFormatOpenAIChat {
 		t.Errorf("WireFormat() = %v, want WireFormatOpenAIChat", got)
+	}
+}
+
+func TestAWSBedrockProvider_WireFormat_Anthropic(t *testing.T) {
+	cfg := &config.Config{
+		AWSBedrock: config.AWSBedrockConfig{
+			WireFormat: "anthropic",
+		},
+	}
+	atomic := config.NewAtomicConfig(cfg, "")
+	p := NewAWSBedrockProvider(atomic)
+	if got := p.WireFormat("any-model"); got != core.WireFormatAnthropic {
+		t.Errorf("WireFormat() = %v, want WireFormatAnthropic", got)
 	}
 }
 

--- a/internal/provider/aws_bedrock_test.go
+++ b/internal/provider/aws_bedrock_test.go
@@ -104,17 +104,17 @@ func TestAWSBedrockProvider_Execute(t *testing.T) {
 		resp := types.ChatCompletionResponse{
 			ID:    "cmpl-test",
 			Model: "moonshotai.kimi-k2.5",
-			Choices: []types.ChatCompletionChoice{
+			Choices: []types.Choice{
 				{
 					Index: 0,
-					Message: types.ChatCompletionMessage{
+					Message: types.ChatMessage{
 						Role:    "assistant",
 						Content: "Hello from Bedrock",
 					},
 					FinishReason: "stop",
 				},
 			},
-			Usage: types.Usage{
+			Usage: types.UsageInfo{
 				PromptTokens:     10,
 				CompletionTokens: 5,
 				TotalTokens:      15,
@@ -127,8 +127,8 @@ func TestAWSBedrockProvider_Execute(t *testing.T) {
 
 	cfg := &config.Config{
 		AWSBedrock: config.AWSBedrockConfig{
-			BaseURL: server.URL,
-			APIKey:  "test-key",
+			BaseURL:   server.URL,
+			APIKey:    "test-key",
 			ProjectID: "proj_123",
 		},
 	}
@@ -212,8 +212,8 @@ func TestAWSBedrockProvider_Execute_NoProjectID(t *testing.T) {
 		resp := types.ChatCompletionResponse{
 			ID:    "cmpl-test",
 			Model: "test-model",
-			Choices: []types.ChatCompletionChoice{
-				{Index: 0, Message: types.ChatCompletionMessage{Role: "assistant", Content: "ok"}, FinishReason: "stop"},
+			Choices: []types.Choice{
+				{Index: 0, Message: types.ChatMessage{Role: "assistant", Content: "ok"}, FinishReason: "stop"},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -244,8 +244,8 @@ func TestAWSBedrockProvider_Execute_NoProjectID(t *testing.T) {
 
 func TestIsBedrock(t *testing.T) {
 	tests := []struct {
-		model  config.ModelConfig
-		want   bool
+		model config.ModelConfig
+		want  bool
 	}{
 		{config.ModelConfig{Provider: "aws-bedrock"}, true},
 		{config.ModelConfig{Provider: "opencode-go"}, false},
@@ -253,7 +253,7 @@ func TestIsBedrock(t *testing.T) {
 		{config.ModelConfig{}, false},
 	}
 	for _, tt := range tests {
-		if got := IsBedrock(tt.model); got != tt.want {
+		if got := client.IsBedrock(tt.model); got != tt.want {
 			t.Errorf("IsBedrock(%v) = %v, want %v", tt.model, got, tt.want)
 		}
 	}

--- a/internal/provider/aws_bedrock_test.go
+++ b/internal/provider/aws_bedrock_test.go
@@ -109,7 +109,7 @@ func TestAWSBedrockProvider_Execute(t *testing.T) {
 					Index: 0,
 					Message: types.ChatMessage{
 						Role:    "assistant",
-						Content: "Hello from Bedrock",
+						Content: json.RawMessage(`"Hello from Bedrock"`),
 					},
 					FinishReason: "stop",
 				},
@@ -121,7 +121,7 @@ func TestAWSBedrockProvider_Execute(t *testing.T) {
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -169,8 +169,8 @@ func TestAWSBedrockProvider_Stream(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "text/event-stream")
-		w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"))
-		w.Write([]byte("data: [DONE]\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	}))
 	defer server.Close()
 
@@ -195,7 +195,7 @@ func TestAWSBedrockProvider_Stream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stream() error = %v", err)
 	}
-	defer body.Close()
+	defer func() { _ = body.Close() }()
 
 	buf := make([]byte, 1024)
 	n, _ := body.Read(buf)
@@ -213,11 +213,11 @@ func TestAWSBedrockProvider_Execute_NoProjectID(t *testing.T) {
 			ID:    "cmpl-test",
 			Model: "test-model",
 			Choices: []types.Choice{
-				{Index: 0, Message: types.ChatMessage{Role: "assistant", Content: "ok"}, FinishReason: "stop"},
+				{Index: 0, Message: types.ChatMessage{Role: "assistant", Content: json.RawMessage(`"ok"`)}, FinishReason: "stop"},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,6 +58,7 @@ func NewServer(atomic *config.AtomicConfig) (*Server, error) {
 	providerRegistry := core.NewProviderRegistry()
 	_ = providerRegistry.Register(provider.NewOpenCodeGoProvider(atomic))
 	_ = providerRegistry.Register(provider.NewOpenCodeZenProvider(atomic))
+	_ = providerRegistry.Register(provider.NewAWSBedrockProvider(atomic))
 
 	// Create status store for the statusline endpoint.
 	statusStore := status.NewStore(0)


### PR DESCRIPTION
Adds support for routing requests to models hosted on AWS Bedrock Mantle. Users can now configure Bedrock models in their config and route Claude Code requests through them.
