### PR TITLE
fix: JSON-encode normalized strings in bridge; add k2.7-code and M3 metadata

### DIFF
--- a/internal/config/model_registry.go
+++ b/internal/config/model_registry.go
@@ -12,10 +12,12 @@ type ModelMetadata struct {
 var modelMetadata = map[string]ModelMetadata{
 	"deepseek-v4-pro":   {ContextWindow: 1000000, MaxOutputTokens: 8192, Vision: false, SupportsTools: true},
 	"deepseek-v4-flash": {ContextWindow: 1000000, MaxOutputTokens: 4096, Vision: false, SupportsTools: true},
+	"kimi-k2.7-code":    {ContextWindow: 256000, MaxOutputTokens: 32768, Vision: true, SupportsTools: true},
 	"kimi-k2.6":         {ContextWindow: 256000, MaxOutputTokens: 8192, Vision: true, SupportsTools: true},
 	"kimi-k2.5":         {ContextWindow: 256000, MaxOutputTokens: 8192, Vision: true, SupportsTools: true},
 	"mimo-v2.5-pro":     {ContextWindow: 1000000, MaxOutputTokens: 16384, Vision: false, SupportsTools: true},
 	"mimo-v2.5":         {ContextWindow: 1000000, MaxOutputTokens: 8192, Vision: false, SupportsTools: true},
+	"minimax-m3":        {ContextWindow: 1000000, MaxOutputTokens: 128000, Vision: false, SupportsTools: true},
 	"minimax-m2.7":      {ContextWindow: 200000, MaxOutputTokens: 8192, Vision: false, SupportsTools: true},
 	"minimax-m2.5":      {ContextWindow: 200000, MaxOutputTokens: 4096, Vision: false, SupportsTools: true},
 	"qwen3.6-plus":      {ContextWindow: 1000000, MaxOutputTokens: 8192, Vision: true, SupportsTools: true},

--- a/internal/transformer/normalized_bridge.go
+++ b/internal/transformer/normalized_bridge.go
@@ -49,10 +49,12 @@ func NormalizedToResponses(req *core.NormalizedRequest, model config.ModelConfig
 
 	// System prompt becomes a "developer" role input.
 	if req.SystemPrompt != "" {
-		responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
-			Role:    "developer",
-			Content: json.RawMessage(`"` + req.SystemPrompt + `"`),
-		})
+		if b, err := json.Marshal(req.SystemPrompt); err == nil {
+			responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
+				Role:    "developer",
+				Content: json.RawMessage(b),
+			})
+		}
 	}
 
 	// Convert messages.
@@ -68,7 +70,9 @@ func NormalizedToResponses(req *core.NormalizedRequest, model config.ModelConfig
 		}
 
 		if content != "" {
-			input.Content = json.RawMessage(`"` + content + `"`)
+			if b, err := json.Marshal(content); err == nil {
+				input.Content = json.RawMessage(b)
+			}
 		}
 		responsesReq.Input = append(responsesReq.Input, input)
 	}
@@ -288,7 +292,9 @@ func normalizedToMessageRequest(req *core.NormalizedRequest) *types.MessageReque
 
 	// Set system prompt.
 	if req.SystemPrompt != "" {
-		anthropicReq.System = json.RawMessage(`"` + req.SystemPrompt + `"`)
+		if b, err := json.Marshal(req.SystemPrompt); err == nil {
+			anthropicReq.System = json.RawMessage(b)
+		}
 	}
 
 	// Set stream.

--- a/internal/transformer/normalized_bridge.go
+++ b/internal/transformer/normalized_bridge.go
@@ -49,12 +49,10 @@ func NormalizedToResponses(req *core.NormalizedRequest, model config.ModelConfig
 
 	// System prompt becomes a "developer" role input.
 	if req.SystemPrompt != "" {
-		if b, err := json.Marshal(req.SystemPrompt); err == nil {
-			responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
-				Role:    "developer",
-				Content: json.RawMessage(b),
-			})
-		}
+		responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
+			Role:    "developer",
+			Content: rawJSONString(req.SystemPrompt),
+		})
 	}
 
 	// Convert messages.
@@ -70,9 +68,7 @@ func NormalizedToResponses(req *core.NormalizedRequest, model config.ModelConfig
 		}
 
 		if content != "" {
-			if b, err := json.Marshal(content); err == nil {
-				input.Content = json.RawMessage(b)
-			}
+			input.Content = rawJSONString(content)
 		}
 		responsesReq.Input = append(responsesReq.Input, input)
 	}
@@ -376,6 +372,14 @@ func normalizedToMessageRequest(req *core.NormalizedRequest) *types.MessageReque
 	}
 
 	return anthropicReq
+}
+
+func rawJSONString(s string) json.RawMessage {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return json.RawMessage(`""`)
+	}
+	return json.RawMessage(b)
 }
 
 // joinMessageText concatenates the content of all messages for use as a

--- a/internal/transformer/normalized_bridge_test.go
+++ b/internal/transformer/normalized_bridge_test.go
@@ -71,4 +71,24 @@ func TestNormalizedToResponses_SystemPromptWithNewline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("json.Marshal failed: %v", err)
 	}
+
+	if len(responsesReq.Input) != 2 {
+		t.Fatalf("input count mismatch: got %d, want 2", len(responsesReq.Input))
+	}
+
+	var systemPrompt string
+	if err := json.Unmarshal(responsesReq.Input[0].Content, &systemPrompt); err != nil {
+		t.Fatalf("system prompt content was not valid JSON: %v", err)
+	}
+	if systemPrompt != req.SystemPrompt {
+		t.Fatalf("system prompt mismatch: got %q, want %q", systemPrompt, req.SystemPrompt)
+	}
+
+	var messageContent string
+	if err := json.Unmarshal(responsesReq.Input[1].Content, &messageContent); err != nil {
+		t.Fatalf("message content was not valid JSON: %v", err)
+	}
+	if messageContent != req.Messages[0].Content {
+		t.Fatalf("message content mismatch: got %q, want %q", messageContent, req.Messages[0].Content)
+	}
 }

--- a/internal/transformer/normalized_bridge_test.go
+++ b/internal/transformer/normalized_bridge_test.go
@@ -1,0 +1,74 @@
+package transformer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/routatic/proxy/internal/config"
+	"github.com/routatic/proxy/internal/core"
+)
+
+func TestNormalizedToAnthropic_SystemPromptWithNewline(t *testing.T) {
+	req := &core.NormalizedRequest{
+		Model:        "minimax-m3",
+		SystemPrompt: "Line one\nLine two\nLine three",
+		MaxTokens:    100,
+		Messages: []core.NormalizedMessage{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	anthropicReq := NormalizedToAnthropic(req, config.ModelConfig{ModelID: "minimax-m3"})
+
+	// The bug: marshaling the request failed when the system prompt contained
+	// unescaped newlines because we built the RawMessage by wrapping the raw
+	// string in quotes instead of JSON-encoding it.
+	_, err := json.Marshal(anthropicReq)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	if got := anthropicReq.SystemText(); got != req.SystemPrompt {
+		t.Fatalf("system text mismatch: got %q, want %q", got, req.SystemPrompt)
+	}
+}
+
+func TestNormalizedToAnthropic_MessageContentWithNewline(t *testing.T) {
+	req := &core.NormalizedRequest{
+		Model:     "minimax-m3",
+		MaxTokens: 100,
+		Messages: []core.NormalizedMessage{
+			{Role: "user", Content: "Hello\nWorld"},
+		},
+	}
+
+	anthropicReq := NormalizedToAnthropic(req, config.ModelConfig{ModelID: "minimax-m3"})
+
+	_, err := json.Marshal(anthropicReq)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	blocks := anthropicReq.Messages[0].ContentBlocks()
+	if len(blocks) != 1 || blocks[0].Text != "Hello\nWorld" {
+		t.Fatalf("unexpected content blocks: %+v", blocks)
+	}
+}
+
+func TestNormalizedToResponses_SystemPromptWithNewline(t *testing.T) {
+	req := &core.NormalizedRequest{
+		Model:        "gpt-5",
+		SystemPrompt: "Line one\nLine two",
+		MaxTokens:    100,
+		Messages: []core.NormalizedMessage{
+			{Role: "user", Content: "Hello\nWorld"},
+		},
+	}
+
+	responsesReq := NormalizedToResponses(req, config.ModelConfig{ModelID: "gpt-5"})
+
+	_, err := json.Marshal(responsesReq)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- The Anthropic and Responses bridges wrapped `system` prompts and message `content` with naive string concatenation when assigning to `json.RawMessage`. A literal newline (or quote/backslash) in the source string produced invalid JSON, causing `json.Marshal` on the final request to fail.
- Replace the raw-quote wrapping with `json.Marshal` of the string, so the content is properly escaped. Add regression tests covering system prompts and message content that contain newlines.
- Register `kimi-k2.7-code` (256k context, 32k output) and `minimax-m3` (1M context, 128k output) in `internal/config/model_registry.go`.

## Why

A user-supplied system prompt or message containing a real newline (e.g. multi-line instructions) would make the upstream request fail to marshal, dropping the request entirely. The fix uses the standard library to encode the string and restores normal behavior.

## Test plan

- `go test ./internal/transformer/` — 3 new tests pass:
  - `TestNormalizedToAnthropic_SystemPromptWithNewline`
  - `TestNormalizedToAnthropic_MessageContentWithNewline`
  - `TestNormalizedToResponses_SystemPromptWithNewline`
- `go build ./...` — clean build, no compile errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)