### PR TITLE
fix(router): honor small max_tokens in capacity filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ oc-go-cc
 routatic-proxy
 .trunk
 dist/
+brag-output-**
+.DS_Store

--- a/internal/router/capacity.go
+++ b/internal/router/capacity.go
@@ -44,11 +44,24 @@ func FilterByCapacity(chain []config.ModelConfig, inputTokens int, requestedMaxT
 			continue
 		}
 
-		sentMax := clampOutputTokens(model, inputTokens, requestedMaxTokens)
-		if sentMax < minimumOutputTokens {
-			decision.Skipped = append(decision.Skipped, SkippedModel{ModelID: model.ModelID, Reason: "context_window_exceeded"})
-			continue
+		// A model is capacity-ineligible only when its own context window is
+		// exhausted below the output floor. A client that requests a small
+		// max_tokens (e.g. the safety classifier asks for 64 tokens to render
+		// a yes/no verdict) must NOT trigger a skip — the model still has
+		// room, it just needs to produce fewer tokens. Skipping on the
+		// clamped value here caused every sub-256-token request to fail with
+		// "no eligible model for request capacity", which the harness surfaces
+		// as "model temporarily unavailable, auto mode cannot determine
+		// safety".
+		if model.ContextWindow > 0 {
+			remaining := model.ContextWindow - inputTokens - model.ContextMargin
+			if remaining < minimumOutputTokens {
+				decision.Skipped = append(decision.Skipped, SkippedModel{ModelID: model.ModelID, Reason: "context_window_exceeded"})
+				continue
+			}
 		}
+
+		sentMax := clampOutputTokens(model, inputTokens, requestedMaxTokens)
 		model.MaxTokens = sentMax
 		if len(decision.Models) == 0 {
 			decision.SelectedMaxTokens = sentMax

--- a/internal/router/capacity_test.go
+++ b/internal/router/capacity_test.go
@@ -54,3 +54,30 @@ func TestFilterByCapacityClampsMaxTokens(t *testing.T) {
 		t.Fatalf("max_tokens = %d, want %d", got, want)
 	}
 }
+
+// TestFilterByCapacityHonorsSmallMaxTokens guards the auto-mode classifier
+// regression: the harness's safety classifier sends a tiny non-streaming
+// request (max_tokens=64) to render a yes/no verdict. The capacity filter
+// must keep the model eligible — the model has ample context room, it just
+// needs to produce few output tokens — rather than rejecting it with "no
+// eligible model for request capacity", which the harness reports as
+// "model temporarily unavailable, auto mode cannot determine safety".
+func TestFilterByCapacityHonorsSmallMaxTokens(t *testing.T) {
+	chain := []config.ModelConfig{
+		{Provider: "opencode-go", ModelID: "glm-5.2", MaxTokens: 8192},
+	}
+
+	decision, err := FilterByCapacity(chain, 500, 64, false, false)
+	if err != nil {
+		t.Fatalf("FilterByCapacity() error = %v, want nil (small max_tokens must not skip)", err)
+	}
+	if len(decision.Models) != 1 {
+		t.Fatalf("eligible models = %+v, want exactly 1", decision.Models)
+	}
+	if got, want := decision.Models[0].MaxTokens, 64; got != want {
+		t.Fatalf("max_tokens = %d, want %d (client's small request honored)", got, want)
+	}
+	if len(decision.Skipped) != 0 {
+		t.Fatalf("skipped = %+v, want none for small max_tokens with room to spare", decision.Skipped)
+	}
+}


### PR DESCRIPTION
## Problem

Claude Code's auto-mode safety classifier sends tiny non-streaming requests (`max_tokens=64`, no tools) to get a yes/no verdict on whether a command is safe to run. The capacity filter in `internal/router/capacity.go` rejects any request whose clamped output token count falls below `minimumOutputTokens` (256) — even when the model has plenty of context room and the client simply asked for a small response.

Result: every classifier request fails with `500 "no eligible model for request capacity"`, which the harness surfaces as *"model temporarily unavailable, auto mode cannot determine safety."* This makes auto mode unusable when routing Claude Code to non-Claude models through this proxy.

<img width="1478" height="92" alt="Screenshot 2026-06-24 at 11 29 32" src="https://github.com/user-attachments/assets/56062c7c-2141-474f-a330-be20bc248020" />

## Fix

Skip a model only when its own context window is exhausted below the output floor, not when the client requested few output tokens. The clamp still applies to the sent `max_tokens`, so upstream still receives the small budget. Added a regression test (`TestFilterByCapacityHonorsSmallMaxTokens`).

## Heads up

I don't know Go — I used Claude to help diagnose and fix this. I'm opening this PR mainly to raise the issue and propose a fix; happy to revise based on feedback.