### PR TITLE
Fix: Narrow complex scenario keywords to prevent false-positive routing

### DIFF
--- a/internal/router/scenarios.go
+++ b/internal/router/scenarios.go
@@ -185,20 +185,18 @@ func latestUserMessages(messages []MessageContent) []MessageContent {
 	return nil
 }
 
-// hasComplexPattern looks for complex operations that need more capable models.
-// This includes tool-based operations (executing functions, writing/editing files, etc.)
+// hasComplexPattern looks for truly complex or architectural operations that need
+// the most capable models.  It is intentionally narrow: common coding/debugging
+// tasks ("build", "debug", "create file", "bash") are NOT complex, because they
+// appear constantly in tool results and ordinary conversation and would otherwise
+// route every turn to the complex model.
 func hasComplexPattern(messages []MessageContent) bool {
 	complexKeywords := []string{
-		// Architectural
+		// Architectural / large-scale design
 		"architect", "architecture", "refactor", "redesign",
 		"complex", "difficult", "challenging",
 		"optimize", "performance", "efficiency",
 		"design pattern", "best practice",
-		"bug", "debug", "error", "exception", "stack trace",
-		// Tool-related keywords indicate complex operations
-		"execute", "run command", "bash", "shell",
-		"implement", "build", "create", "add feature",
-		"write to", "edit file", "create file",
 	}
 
 	for _, msg := range messages {

--- a/internal/router/scenarios_test.go
+++ b/internal/router/scenarios_test.go
@@ -195,15 +195,17 @@ func TestDetectScenario_LatestTextVisualIntentWithoutNewImageStaysNonVision(t *t
 	}
 }
 
-func TestDetectScenario_DebugWithoutVisualIntentStaysTextComplex(t *testing.T) {
+func TestDetectScenario_DebugWithoutVisualIntentStaysTextDefault(t *testing.T) {
+	// "debug" was removed from complexKeywords because tool_result content
+	// constantly contains it, routing every turn to complex by accident.
 	messages := []MessageContent{
 		{Role: "user", Content: "Cosa vedi?", HasImage: true, ImageHashes: []string{"img1"}},
 		{Role: "assistant", Content: "Vedo una schermata."},
 		{Role: "user", Content: "debug questo codice", HasImage: false},
 	}
 	result := DetectScenario(messages, 100, mockConfig())
-	if result.Scenario != ScenarioComplex {
-		t.Errorf("Expected ScenarioComplex, got %s", result.Scenario)
+	if result.Scenario != ScenarioDefault {
+		t.Errorf("Expected ScenarioDefault (debug is no longer a complex trigger), got %s", result.Scenario)
 	}
 }
 
@@ -230,8 +232,10 @@ func TestDetectScenario_VisionLongContextTakesPriorityOverVisionComplex(t *testi
 }
 
 func TestRouteForStreaming_VisionComplexKeepsVisionComplexScenario(t *testing.T) {
+	// "bug" was removed from complexKeywords; use a retained architectural
+	// keyword ("refactor") to exercise the vision_complex path.
 	messages := []MessageContent{
-		{Role: "user", Content: "Find the bug in this screenshot", HasImage: true},
+		{Role: "user", Content: "Refactor the code shown in this screenshot", HasImage: true},
 	}
 	result := RouteForStreaming(messages, 100, mockConfig())
 	if result.Scenario != ScenarioVisionComplex {


### PR DESCRIPTION
## Problem

The scenario router was sending almost every Claude Code turn to the `complex` model (GLM-5.1) instead of `default` (Kimi K2.6) or `think` (GLM-5.2).

Root cause: `hasComplexPattern` matched a broad set of keywords (`error`, `debug`, `bug`, `build`, `create`, `bash`, `execute`, `implement`, ...) that appear constantly in `tool_result` content (bash output, file contents, stack traces) and ordinary coding messages. Since `tool_result` blocks have `role=\"user\"` in the Anthropic API, the latest-user-message scan matched on them almost every turn.

Log evidence (before):
\`\`\`
scenario=complex  model=glm-5.1  tokens=19352   # routine coding turn
scenario=complex  model=glm-5.1  tokens=44911   # routine coding turn
scenario=default  model=kimi-k2.6 tokens=386    # only \"hi\"-style greetings hit default
\`\`\`

## Fix

Narrow `hasComplexPattern` to genuinely architectural / large-scale keywords only:

- Kept: `architect`, `architecture`, `refactor`, `redesign`, `complex`, `difficult`, `challenging`, `optimize`, `performance`, `efficiency`, `design pattern`, `best practice`
- Removed: `bug`, `debug`, `error`, `exception`, `stack trace`, `execute`, `run command`, `bash`, `shell`, `implement`, `build`, `create`, `add feature`, `write to`, `edit file`, `create file`

Routine coding/debugging tasks now stay on `default` (Kimi K2.6); reasoning-heavy turns still hit `think` (GLM-5.2) via `hasThinkingPattern`; only true architectural work routes to `complex` (GLM-5.1).

Log evidence (after, same workload):
\`\`\`
scenario=default  model=kimi-k2.6  tokens=58588
\`\`\`

## Tests

- `go build ./...` passes
- `go test ./...` passes
- Updated two tests whose assertions relied on `debug`/`bug` as complex triggers:
  - `TestDetectScenario_DebugWithoutVisualIntentStaysTextComplex` → renamed to `...StaysTextDefault`
  - `TestRouteForStreaming_VisionComplexKeepsVisionComplexScenario` now uses `refactor` to exercise the vision_complex path

## Backward compatibility

No config options, public APIs, or SPI contracts changed. Only the internal keyword list for scenario detection was narrowed.