### PR TITLE
feat(cli): add --provider flag to init command

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -8,6 +8,19 @@ Override with `ROUTATIC_PROXY_CONFIG` environment variable.
 
 For migration, `~/.config/oc-go-cc/config.json` is loaded when the new config file does not exist, and every `OC_GO_CC_*` environment variable is still accepted as a fallback for its `ROUTATIC_PROXY_*` replacement.
 
+### Provider-Specific Initialization
+
+Generate a config pre-configured for your provider with `routatic-proxy init --provider`:
+
+| Provider | Command | Models |
+|----------|---------|--------|
+| OpenCode Go | `routatic-proxy init --provider=opencode-go` | DeepSeek V4, GLM-5.2, Kimi K2.7, Qwen3.7 |
+| OpenCode Zen | `routatic-proxy init --provider=opencode-zen` | Claude Fable/Opus/Sonnet, Gemini, GPT |
+| AWS Bedrock | `routatic-proxy init --provider=aws-bedrock` | Claude on Bedrock, Amazon Nova |
+| OpenRouter | `routatic-proxy init --provider=openrouter` | 100+ models from all major providers |
+
+Each preset configures provider-specific base URLs, model selections for every scenario (default, background, think, complex, long_context, fast), fallback chains, and the correct API key environment variable placeholder. Run `routatic-proxy init --provider=openrouter` to get a ready-to-use OpenRouter config — just set your API key and start the proxy.
+
 ## Full Config Reference
 
 ```json
@@ -217,7 +230,11 @@ Environment variables override config file values. Config values also support `$
 
 | Variable                | Description                                 | Default                                          |
 | ----------------------- | ------------------------------------------- | ------------------------------------------------ |
-| `ROUTATIC_PROXY_API_KEY`      | OpenCode Go API key (**required**)          | —                                                |
+| `ROUTATIC_PROXY_API_KEY`      | Global API key (fallback)                   | —                                                |
+| `ROUTATIC_PROXY_OPENCODE_GO_API_KEY` | OpenCode Go API key                | —                                                |
+| `ROUTATIC_PROXY_OPENCODE_ZEN_API_KEY` | OpenCode Zen API key                | —                                                |
+| `ROUTATIC_PROXY_AWS_BEDROCK_API_KEY` | AWS Bedrock API key                | —                                                |
+| `ROUTATIC_PROXY_OPENROUTER_API_KEY` | OpenRouter API key                  | —                                                |
 | `ROUTATIC_PROXY_CONFIG`       | Custom config file path                     | `~/.config/routatic-proxy/config.json`                 |
 | `ROUTATIC_PROXY_HOST`         | Proxy listen host                           | `127.0.0.1`                                      |
 | `ROUTATIC_PROXY_PORT`         | Proxy listen port                           | `3456`                                           |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ Creates a default config at `~/.config/routatic-proxy/config.json`. Edit it to a
 export ROUTATIC_PROXY_API_KEY=sk-opencode-your-key-here
 ```
 
+**Provider-specific initialization** — generate a config pre-configured for your provider:
+
+```bash
+# OpenRouter (unified API for 100+ models)
+routatic-proxy init --provider=openrouter
+
+# AWS Bedrock (run models on your own AWS infrastructure)
+routatic-proxy init --provider=aws-bedrock
+
+# OpenCode Zen (pay-as-you-go Claude, GPT, Gemini)
+routatic-proxy init --provider=opencode-zen
+
+# OpenCode Go subscription (default)
+routatic-proxy init --provider=opencode-go
+```
+
+Each preset configures provider-specific models, fallback chains, and API key placeholders. Run `routatic-proxy init --help` for details.
+
 ### 3. Start the Proxy
 
 ```bash
@@ -179,6 +197,7 @@ routatic-proxy serve --port 8080  Start on a custom port
 routatic-proxy stop               Stop the running proxy server
 routatic-proxy status             Check if the proxy is running
 routatic-proxy init               Create default configuration file
+routatic-proxy init --provider=X  Create provider-specific config
 routatic-proxy validate           Validate configuration file
 routatic-proxy models             List all available models (Go, Zen, Bedrock)
 routatic-proxy autostart enable   Enable auto-start on login

--- a/cmd/routatic-proxy/init_provider.go
+++ b/cmd/routatic-proxy/init_provider.go
@@ -1,0 +1,633 @@
+package main
+
+import "fmt"
+
+// ProviderPreset contains provider-specific configuration defaults.
+type ProviderPreset struct {
+	Name        string
+	EnvVarName  string // Environment variable for API key
+	Description string
+	BaseURL     string
+}
+
+// Supported provider presets.
+var providerPresets = map[string]ProviderPreset{
+	"opencode-go": {
+		Name:        "OpenCode Go",
+		EnvVarName:  "ROUTATIC_PROXY_OPENCODE_GO_API_KEY",
+		Description: "OpenCode Go subscription - $5/month with powerful coding models",
+		BaseURL:     "https://opencode.ai/zen/go/v1/chat/completions",
+	},
+	"opencode-zen": {
+		Name:        "OpenCode Zen",
+		EnvVarName:  "ROUTATIC_PROXY_OPENCODE_ZEN_API_KEY",
+		Description: "OpenCode Zen - pay-as-you-go access to Claude, GPT, Gemini, and more",
+		BaseURL:     "https://opencode.ai/zen/v1/chat/completions",
+	},
+	"aws-bedrock": {
+		Name:        "AWS Bedrock",
+		EnvVarName:  "ROUTATIC_PROXY_AWS_BEDROCK_API_KEY",
+		Description: "AWS Bedrock Mantle - run models on your own AWS infrastructure",
+		BaseURL:     "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+	},
+	"openrouter": {
+		Name:        "OpenRouter",
+		EnvVarName:  "ROUTATIC_PROXY_OPENROUTER_API_KEY",
+		Description: "OpenRouter - unified API for 100+ models from multiple providers",
+		BaseURL:     "https://openrouter.ai/api/v1/chat/completions",
+	},
+}
+
+// getProviderConfig returns a config template optimized for a specific provider.
+// The provider must be one of: "opencode-go", "opencode-zen", "aws-bedrock", "openrouter".
+func getProviderConfig(provider string) (string, error) {
+	_, ok := providerPresets[provider]
+	if !ok {
+		return "", fmt.Errorf("unknown provider %q; supported: opencode-go, opencode-zen, aws-bedrock, openrouter", provider)
+	}
+
+	switch provider {
+	case "openrouter":
+		return getOpenRouterConfig(), nil
+	case "aws-bedrock":
+		return getAWSBedrockConfig(), nil
+	case "opencode-zen":
+		return getOpenCodeZenConfig(), nil
+	default:
+		// Default to OpenCode Go config
+		return getOpenCodeGoConfig(), nil
+	}
+}
+
+// getOpenRouterConfig returns a config optimized for OpenRouter.
+func getOpenRouterConfig() string {
+	return `{
+  "api_key": "${ROUTATIC_PROXY_API_KEY}",
+  "host": "127.0.0.1",
+  "port": 3456,
+  "hot_reload": false,
+  "enable_streaming_scenario_routing": false,
+  "respect_requested_model": false,
+
+  "models": {
+    "default": {
+      "provider": "openrouter",
+      "model_id": "anthropic/claude-sonnet-4",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "background": {
+      "provider": "openrouter",
+      "model_id": "openai/gpt-4o-mini",
+      "temperature": 0.5,
+      "max_tokens": 2048
+    },
+    "think": {
+      "provider": "openrouter",
+      "model_id": "anthropic/claude-sonnet-4",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "complex": {
+      "provider": "openrouter",
+      "model_id": "anthropic/claude-opus-4",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "long_context": {
+      "provider": "openrouter",
+      "model_id": "google/gemini-2.5-pro",
+      "temperature": 0.7,
+      "max_tokens": 16384,
+      "context_threshold": 80000
+    },
+    "fast": {
+      "provider": "openrouter",
+      "model_id": "openai/gpt-4o-mini",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    }
+  },
+
+  "fallbacks": {
+    "default": [
+      { "provider": "openrouter", "model_id": "anthropic/claude-3.5-sonnet" },
+      { "provider": "openrouter", "model_id": "openai/gpt-4o" }
+    ],
+    "background": [
+      { "provider": "openrouter", "model_id": "meta-llama/llama-3.3-70b-instruct" }
+    ],
+    "think": [
+      { "provider": "openrouter", "model_id": "anthropic/claude-opus-4" }
+    ],
+    "complex": [
+      { "provider": "openrouter", "model_id": "anthropic/claude-sonnet-4" }
+    ],
+    "long_context": [
+      { "provider": "openrouter", "model_id": "anthropic/claude-sonnet-4" }
+    ],
+    "fast": [
+      { "provider": "openrouter", "model_id": "openai/gpt-4o-mini" }
+    ]
+  },
+
+  "openrouter": {
+    "base_url": "https://openrouter.ai/api/v1/chat/completions",
+    "api_key": "${ROUTATIC_PROXY_OPENROUTER_API_KEY}",
+    "api_keys": [],
+    "timeout_ms": 300000,
+    "stream_timeout_ms": 60000,
+    "streaming_timeout_ms": 600000
+  },
+
+  "logging": {
+    "level": "info",
+    "requests": true
+  }
+}
+`
+}
+
+// getAWSBedrockConfig returns a config optimized for AWS Bedrock.
+func getAWSBedrockConfig() string {
+	return `{
+  "api_key": "${ROUTATIC_PROXY_API_KEY}",
+  "host": "127.0.0.1",
+  "port": 3456,
+  "hot_reload": false,
+  "enable_streaming_scenario_routing": false,
+  "respect_requested_model": false,
+
+  "models": {
+    "default": {
+      "provider": "aws-bedrock",
+      "model_id": "anthropic.claude-sonnet-4-20250514-v1:0",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "background": {
+      "provider": "aws-bedrock",
+      "model_id": "amazon.nova-lite-v1:0",
+      "temperature": 0.5,
+      "max_tokens": 2048
+    },
+    "think": {
+      "provider": "aws-bedrock",
+      "model_id": "anthropic.claude-sonnet-4-20250514-v1:0",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "complex": {
+      "provider": "aws-bedrock",
+      "model_id": "anthropic.claude-opus-4-20250514-v1:0",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "long_context": {
+      "provider": "aws-bedrock",
+      "model_id": "anthropic.claude-sonnet-4-20250514-v1:0",
+      "temperature": 0.7,
+      "max_tokens": 16384,
+      "context_threshold": 80000
+    },
+    "fast": {
+      "provider": "aws-bedrock",
+      "model_id": "amazon.nova-lite-v1:0",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    }
+  },
+
+  "fallbacks": {
+    "default": [
+      { "provider": "aws-bedrock", "model_id": "anthropic.claude-3-5-sonnet-20241022-v2:0" },
+      { "provider": "aws-bedrock", "model_id": "amazon.nova-pro-v1:0" }
+    ],
+    "background": [
+      { "provider": "aws-bedrock", "model_id": "amazon.nova-micro-v1:0" }
+    ],
+    "think": [
+      { "provider": "aws-bedrock", "model_id": "anthropic.claude-opus-4-20250514-v1:0" }
+    ],
+    "complex": [
+      { "provider": "aws-bedrock", "model_id": "anthropic.claude-sonnet-4-20250514-v1:0" }
+    ],
+    "long_context": [
+      { "provider": "aws-bedrock", "model_id": "anthropic.claude-sonnet-4-20250514-v1:0" }
+    ],
+    "fast": [
+      { "provider": "aws-bedrock", "model_id": "amazon.nova-lite-v1:0" }
+    ]
+  },
+
+  "aws_bedrock": {
+    "base_url": "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+    "anthropic_base_url": "https://bedrock-mantle.us-east-1.api.aws/v1/messages",
+    "api_key": "${ROUTATIC_PROXY_AWS_BEDROCK_API_KEY}",
+    "api_keys": [],
+    "project_id": "",
+    "wire_format": "openai",
+    "timeout_ms": 300000,
+    "stream_timeout_ms": 60000,
+    "streaming_timeout_ms": 600000
+  },
+
+  "logging": {
+    "level": "info",
+    "requests": true
+  }
+}
+`
+}
+
+// getOpenCodeZenConfig returns a config optimized for OpenCode Zen.
+func getOpenCodeZenConfig() string {
+	return `{
+  "api_key": "${ROUTATIC_PROXY_API_KEY}",
+  "host": "127.0.0.1",
+  "port": 3456,
+  "hot_reload": false,
+  "enable_streaming_scenario_routing": false,
+  "respect_requested_model": false,
+
+  "models": {
+    "default": {
+      "provider": "opencode-zen",
+      "model_id": "claude-sonnet-4.5",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "background": {
+      "provider": "opencode-zen",
+      "model_id": "nemotron-3-ultra-free",
+      "temperature": 0.5,
+      "max_tokens": 2048
+    },
+    "think": {
+      "provider": "opencode-zen",
+      "model_id": "claude-opus-4-8",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "complex": {
+      "provider": "opencode-zen",
+      "model_id": "claude-opus-4-8",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "long_context": {
+      "provider": "opencode-zen",
+      "model_id": "gemini-3.1-pro",
+      "temperature": 0.7,
+      "max_tokens": 16384,
+      "context_threshold": 80000
+    },
+    "fast": {
+      "provider": "opencode-zen",
+      "model_id": "gemini-3.5-flash",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    }
+  },
+
+  "fallbacks": {
+    "default": [
+      { "provider": "opencode-zen", "model_id": "claude-sonnet-4" },
+      { "provider": "opencode-zen", "model_id": "gemini-3.1-pro" }
+    ],
+    "background": [
+      { "provider": "opencode-zen", "model_id": "mimo-v2.5-free" },
+      { "provider": "opencode-zen", "model_id": "deepseek-v4-flash-free" }
+    ],
+    "think": [
+      { "provider": "opencode-zen", "model_id": "claude-opus-4-6" }
+    ],
+    "complex": [
+      { "provider": "opencode-zen", "model_id": "claude-opus-4-5" }
+    ],
+    "long_context": [
+      { "provider": "opencode-zen", "model_id": "claude-sonnet-4.5" }
+    ],
+    "fast": [
+      { "provider": "opencode-zen", "model_id": "gemini-3-flash" }
+    ]
+  },
+
+  "model_overrides": {
+    "claude-fable-5": {
+      "provider": "opencode-zen",
+      "model_id": "claude-fable-5",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "claude-opus-4-8": {
+      "provider": "opencode-zen",
+      "model_id": "claude-opus-4-8",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "claude-sonnet-4.5": {
+      "provider": "opencode-zen",
+      "model_id": "claude-sonnet-4.5",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "gemini-3.5-flash": {
+      "provider": "opencode-zen",
+      "model_id": "gemini-3.5-flash",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "gemini-3.1-pro": {
+      "provider": "opencode-zen",
+      "model_id": "gemini-3.1-pro",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    }
+  },
+
+  "opencode_zen": {
+    "base_url": "https://opencode.ai/zen/v1/chat/completions",
+    "anthropic_base_url": "https://opencode.ai/zen/v1/messages",
+    "responses_base_url": "https://opencode.ai/zen/v1/responses",
+    "gemini_base_url": "https://opencode.ai/zen/v1/models",
+    "api_key": "${ROUTATIC_PROXY_OPENCODE_ZEN_API_KEY}",
+    "api_keys": [],
+    "timeout_ms": 300000,
+    "streaming_timeout_ms": 600000
+  },
+
+  "logging": {
+    "level": "info",
+    "requests": true
+  }
+}
+`
+}
+
+// getOpenCodeGoConfig returns the default config optimized for OpenCode Go.
+func getOpenCodeGoConfig() string {
+	// This is the same as getDefaultConfig() but explicit for provider
+	return `{
+  "api_key": "${ROUTATIC_PROXY_API_KEY}",
+  "host": "127.0.0.1",
+  "port": 3456,
+  "hot_reload": false,
+  "enable_streaming_scenario_routing": false,
+  "respect_requested_model": false,
+  "anthropic_first": {
+    "enabled": false,
+    "base_url": "https://api.anthropic.com"
+  },
+  "models": {
+    "background": {
+      "provider": "opencode-go",
+      "model_id": "deepseek-v4-flash",
+      "temperature": 0.5,
+      "max_tokens": 2048
+    },
+    "default": {
+      "provider": "opencode-go",
+      "model_id": "deepseek-v4-pro",
+      "temperature": 0.7,
+      "max_tokens": 8192,
+      "reasoning_effort": "max",
+      "thinking": { "type": "enabled" }
+    },
+    "long_context": {
+      "provider": "opencode-go",
+      "model_id": "minimax-m3",
+      "temperature": 0.7,
+      "max_tokens": 16384,
+      "context_threshold": 80000
+    },
+    "think": {
+      "provider": "opencode-go",
+      "model_id": "glm-5.2",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "complex": {
+      "provider": "opencode-go",
+      "model_id": "deepseek-v4-pro",
+      "temperature": 0.7,
+      "max_tokens": 8192,
+      "reasoning_effort": "max",
+      "thinking": { "type": "enabled" }
+    },
+    "fast": {
+      "provider": "opencode-go",
+      "model_id": "deepseek-v4-flash",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    },
+    "glm-5.2": {
+      "provider": "opencode-go",
+      "model_id": "glm-5.2",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "kimi-k2.7-code": {
+      "provider": "opencode-go",
+      "model_id": "kimi-k2.7-code",
+      "temperature": 0.7,
+      "max_tokens": 32768
+    },
+    "qwen3.7-plus": {
+      "provider": "opencode-go",
+      "model_id": "qwen3.7-plus",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "qwen3.7-max": {
+      "provider": "opencode-go",
+      "model_id": "qwen3.7-max",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    }
+  },
+  "fallbacks": {
+    "background": [
+      { "provider": "opencode-go", "model_id": "qwen3.7-plus" },
+      { "provider": "opencode-go", "model_id": "qwen3.7-max" },
+      { "provider": "opencode-zen", "model_id": "nemotron-3-ultra-free" },
+      { "provider": "opencode-zen", "model_id": "mimo-v2.5-free" },
+      { "provider": "opencode-zen", "model_id": "deepseek-v4-flash-free" }
+    ],
+    "default": [
+      { "provider": "opencode-go", "model_id": "qwen3.7-plus" },
+      { "provider": "opencode-go", "model_id": "qwen3.7-max" },
+      { "provider": "opencode-zen", "model_id": "nemotron-3-ultra-free" },
+      { "provider": "opencode-zen", "model_id": "mimo-v2.5-free" },
+      { "provider": "opencode-zen", "model_id": "deepseek-v4-flash-free" }
+    ],
+    "long_context": [
+      { "provider": "opencode-go", "model_id": "qwen3.7-plus" },
+      { "provider": "opencode-go", "model_id": "qwen3.7-max" },
+      { "provider": "opencode-zen", "model_id": "nemotron-3-ultra-free" },
+      { "provider": "opencode-zen", "model_id": "mimo-v2.5-free" },
+      { "provider": "opencode-zen", "model_id": "deepseek-v4-flash-free" }
+    ],
+    "think": [
+      { "provider": "opencode-go", "model_id": "qwen3.7-plus" },
+      { "provider": "opencode-go", "model_id": "qwen3.7-max" },
+      { "provider": "opencode-zen", "model_id": "nemotron-3-ultra-free" },
+      { "provider": "opencode-zen", "model_id": "mimo-v2.5-free" },
+      { "provider": "opencode-zen", "model_id": "deepseek-v4-flash-free" }
+    ],
+    "complex": [
+      { "provider": "opencode-go", "model_id": "qwen3.7-plus" },
+      { "provider": "opencode-go", "model_id": "qwen3.7-max" },
+      { "provider": "opencode-zen", "model_id": "nemotron-3-ultra-free" },
+      { "provider": "opencode-zen", "model_id": "mimo-v2.5-free" },
+      { "provider": "opencode-zen", "model_id": "deepseek-v4-flash-free" }
+    ],
+    "fast": [
+      { "provider": "opencode-go", "model_id": "qwen3.7-plus" },
+      { "provider": "opencode-go", "model_id": "qwen3.7-max" },
+      { "provider": "opencode-zen", "model_id": "nemotron-3-ultra-free" },
+      { "provider": "opencode-zen", "model_id": "mimo-v2.5-free" },
+      { "provider": "opencode-zen", "model_id": "deepseek-v4-flash-free" }
+    ],
+    "glm-5.2": [
+      { "provider": "opencode-go", "model_id": "glm-5.1" },
+      { "provider": "opencode-go", "model_id": "kimi-k2.6" }
+    ],
+    "kimi-k2.7-code": [
+      { "provider": "opencode-go", "model_id": "kimi-k2.6" },
+      { "provider": "opencode-go", "model_id": "glm-5.1" }
+    ],
+    "qwen3.7-plus": [
+      { "provider": "opencode-go", "model_id": "qwen3.6-plus" },
+      { "provider": "opencode-go", "model_id": "kimi-k2.6" }
+    ],
+    "qwen3.7-max": [
+      { "provider": "opencode-go", "model_id": "qwen3.7-plus" },
+      { "provider": "opencode-go", "model_id": "kimi-k2.6" }
+    ]
+  },
+  "model_overrides": {
+    "deepseek-v4-pro": {
+      "provider": "opencode-zen",
+      "model_id": "deepseek-v4-pro",
+      "temperature": 0.7,
+      "max_tokens": 8192,
+      "reasoning_effort": "max",
+      "thinking": {
+        "type": "enabled"
+      }
+    },
+    "deepseek-v4-flash-free": {
+      "provider": "opencode-zen",
+      "model_id": "deepseek-v4-flash-free",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    },
+    "grok-build-0.1": {
+      "provider": "opencode-zen",
+      "model_id": "grok-build-0.1",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    },
+    "big-pickle": {
+      "provider": "opencode-zen",
+      "model_id": "big-pickle",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    },
+    "mimo-v2.5-free": {
+      "provider": "opencode-zen",
+      "model_id": "mimo-v2.5-free",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    },
+    "north-mini-code-free": {
+      "provider": "opencode-zen",
+      "model_id": "north-mini-code-free",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    },
+    "nemotron-3-ultra-free": {
+      "provider": "opencode-zen",
+      "model_id": "nemotron-3-ultra-free",
+      "temperature": 0.7,
+      "max_tokens": 4096
+    },
+    "claude-fable-5": {
+      "provider": "opencode-zen",
+      "model_id": "claude-fable-5",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "claude-opus-4-8": {
+      "provider": "opencode-zen",
+      "model_id": "claude-opus-4-8",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "claude-opus-4-6": {
+      "provider": "opencode-zen",
+      "model_id": "claude-opus-4-6",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "claude-opus-4-5": {
+      "provider": "opencode-zen",
+      "model_id": "claude-opus-4-5",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "claude-opus-4-1": {
+      "provider": "opencode-zen",
+      "model_id": "claude-opus-4-1",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "claude-sonnet-4": {
+      "provider": "opencode-zen",
+      "model_id": "claude-sonnet-4",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "gemini-3.5-flash": {
+      "provider": "opencode-zen",
+      "model_id": "gemini-3.5-flash",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "gemini-3.1-pro": {
+      "provider": "opencode-zen",
+      "model_id": "gemini-3.1-pro",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    },
+    "gemini-3-flash": {
+      "provider": "opencode-zen",
+      "model_id": "gemini-3-flash",
+      "temperature": 0.7,
+      "max_tokens": 8192
+    }
+  },
+  "opencode_go": {
+    "base_url": "https://opencode.ai/zen/go/v1/chat/completions",
+    "anthropic_base_url": "https://opencode.ai/zen/go/v1/messages",
+    "api_key": "",
+    "api_keys": [],
+    "timeout_ms": 300000
+  },
+  "opencode_zen": {
+    "base_url": "https://opencode.ai/zen/v1/chat/completions",
+    "anthropic_base_url": "https://opencode.ai/zen/v1/messages",
+    "responses_base_url": "https://opencode.ai/zen/v1/responses",
+    "gemini_base_url": "https://opencode.ai/zen/v1/models",
+    "api_key": "",
+    "api_keys": [],
+    "timeout_ms": 300000
+  },
+  "logging": {
+    "level": "info",
+    "requests": true
+  }
+}
+`
+}

--- a/cmd/routatic-proxy/init_provider.go
+++ b/cmd/routatic-proxy/init_provider.go
@@ -1,6 +1,10 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // ProviderPreset contains provider-specific configuration defaults.
 type ProviderPreset struct {
@@ -41,22 +45,25 @@ var providerPresets = map[string]ProviderPreset{
 // getProviderConfig returns a config template optimized for a specific provider.
 // The provider must be one of: "opencode-go", "opencode-zen", "aws-bedrock", "openrouter".
 func getProviderConfig(provider string) (string, error) {
-	_, ok := providerPresets[provider]
+	gen, ok := providerConfigGenerators[provider]
 	if !ok {
-		return "", fmt.Errorf("unknown provider %q; supported: opencode-go, opencode-zen, aws-bedrock, openrouter", provider)
+		supported := make([]string, 0, len(providerConfigGenerators))
+		for p := range providerConfigGenerators {
+			supported = append(supported, p)
+		}
+		sort.Strings(supported)
+		return "", fmt.Errorf("unknown provider %q; supported: %s", provider, strings.Join(supported, ", "))
 	}
+	return gen(), nil
+}
 
-	switch provider {
-	case "openrouter":
-		return getOpenRouterConfig(), nil
-	case "aws-bedrock":
-		return getAWSBedrockConfig(), nil
-	case "opencode-zen":
-		return getOpenCodeZenConfig(), nil
-	default:
-		// Default to OpenCode Go config
-		return getOpenCodeGoConfig(), nil
-	}
+// providerConfigGenerators maps provider names to their config template functions.
+// Add a new entry here when supporting a new provider.
+var providerConfigGenerators = map[string]func() string{
+	"opencode-go":  getOpenCodeGoConfig,
+	"opencode-zen": getOpenCodeZenConfig,
+	"aws-bedrock":  getAWSBedrockConfig,
+	"openrouter":   getOpenRouterConfig,
 }
 
 // getOpenRouterConfig returns a config optimized for OpenRouter.

--- a/cmd/routatic-proxy/init_provider_test.go
+++ b/cmd/routatic-proxy/init_provider_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitCmd_ProviderFlag(t *testing.T) {
+	tests := []struct {
+		name           string
+		provider       string
+		wantProvider   string
+		wantErr        bool
+		wantErrContain string
+	}{
+		{
+			name:         "openrouter provider",
+			provider:     "openrouter",
+			wantProvider: "openrouter",
+		},
+		{
+			name:         "aws-bedrock provider",
+			provider:     "aws-bedrock",
+			wantProvider: "aws-bedrock",
+		},
+		{
+			name:         "opencode-zen provider",
+			provider:     "opencode-zen",
+			wantProvider: "opencode-zen",
+		},
+		{
+			name:         "opencode-go provider",
+			provider:     "opencode-go",
+			wantProvider: "opencode-go",
+		},
+		{
+			name:           "unknown provider returns error",
+			provider:       "unknown-provider",
+			wantErr:        true,
+			wantErrContain: "unknown provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.json")
+
+			// Override getConfigDir to use temp directory
+			originalGetConfigDir := getConfigDir
+			getConfigDir = func() string { return tmpDir }
+			defer func() { getConfigDir = originalGetConfigDir }()
+
+			// Create init command
+			cmd := initCmd()
+			cmd.SetArgs([]string{"--provider", tt.provider})
+
+			// Run the command
+			err := cmd.Execute()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.wantErrContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Verify config file was created
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Errorf("failed to read config file: %v", err)
+				return
+			}
+
+			// Parse and verify it's valid JSON
+			var cfg map[string]interface{}
+			if err := json.Unmarshal(data, &cfg); err != nil {
+				t.Errorf("config is not valid JSON: %v", err)
+				return
+			}
+
+			// Check that models section exists
+			models, ok := cfg["models"].(map[string]interface{})
+			if !ok {
+				t.Error("config missing 'models' section")
+				return
+			}
+
+			// Verify default model uses the correct provider
+			defaultModel, ok := models["default"].(map[string]interface{})
+			if !ok {
+				t.Error("config missing 'models.default' section")
+				return
+			}
+
+			provider, _ := defaultModel["provider"].(string)
+			if provider != tt.wantProvider {
+				t.Errorf("default model provider = %q, want %q", provider, tt.wantProvider)
+			}
+		})
+	}
+}
+
+func TestInitCmd_NoProviderFlag(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	// Override getConfigDir to use temp directory
+	originalGetConfigDir := getConfigDir
+	getConfigDir = func() string { return tmpDir }
+	defer func() { getConfigDir = originalGetConfigDir }()
+
+	// Create init command without provider flag
+	cmd := initCmd()
+
+	// Run the command
+	err := cmd.Execute()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	// Verify config file was created
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Errorf("failed to read config file: %v", err)
+		return
+	}
+
+	// Parse and verify it's valid JSON
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Errorf("config is not valid JSON: %v", err)
+		return
+	}
+
+	// Default config should use opencode-go
+	models, ok := cfg["models"].(map[string]interface{})
+	if !ok {
+		t.Error("config missing 'models' section")
+		return
+	}
+
+	defaultModel, ok := models["default"].(map[string]interface{})
+	if !ok {
+		t.Error("config missing 'models.default' section")
+		return
+	}
+
+	provider, _ := defaultModel["provider"].(string)
+	if provider != "opencode-go" {
+		t.Errorf("default model provider = %q, want 'opencode-go'", provider)
+	}
+}
+
+func TestInitCmd_ConfigAlreadyExists(t *testing.T) {
+	// Create temp directory with existing config
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	// Write existing config
+	if err := os.WriteFile(configPath, []byte(`{"existing": true}`), 0600); err != nil {
+		t.Fatalf("failed to write existing config: %v", err)
+	}
+
+	// Override getConfigDir to use temp directory
+	originalGetConfigDir := getConfigDir
+	getConfigDir = func() string { return tmpDir }
+	defer func() { getConfigDir = originalGetConfigDir }()
+
+	// Create init command
+	cmd := initCmd()
+
+	// Run the command - should not error, just inform user
+	err := cmd.Execute()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	// Verify existing config was NOT overwritten
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Errorf("failed to read config file: %v", err)
+		return
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Errorf("config is not valid JSON: %v", err)
+		return
+	}
+
+	if _, ok := cfg["existing"]; !ok {
+		t.Error("existing config was overwritten")
+	}
+}
+
+func TestGetProviderConfig_UnknownProvider(t *testing.T) {
+	_, err := getProviderConfig("invalid")
+	if err == nil {
+		t.Error("expected error for unknown provider")
+	}
+}
+
+func TestGetProviderConfig_AllProviders(t *testing.T) {
+	providers := []string{"opencode-go", "opencode-zen", "aws-bedrock", "openrouter"}
+
+	for _, provider := range providers {
+		t.Run(provider, func(t *testing.T) {
+			config, err := getProviderConfig(provider)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Verify it's valid JSON
+			var cfg map[string]interface{}
+			if err := json.Unmarshal([]byte(config), &cfg); err != nil {
+				t.Errorf("config for %s is not valid JSON: %v", provider, err)
+				return
+			}
+
+			// Verify models section exists
+			models, ok := cfg["models"].(map[string]interface{})
+			if !ok {
+				t.Errorf("config for %s missing 'models' section", provider)
+				return
+			}
+
+			// Verify default model uses correct provider
+			defaultModel, ok := models["default"].(map[string]interface{})
+			if !ok {
+				t.Errorf("config for %s missing 'models.default' section", provider)
+				return
+			}
+
+			actualProvider, _ := defaultModel["provider"].(string)
+			if actualProvider != provider {
+				t.Errorf("default model provider = %q, want %q", actualProvider, provider)
+			}
+		})
+	}
+}

--- a/cmd/routatic-proxy/main.go
+++ b/cmd/routatic-proxy/main.go
@@ -260,9 +260,20 @@ func statusCmd() *cobra.Command {
 
 // initCmd returns the command to create a default configuration file.
 func initCmd() *cobra.Command {
-	return &cobra.Command{
+	var provider string
+
+	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Create default configuration file",
+		Long: `Create a default configuration file optimized for a specific provider.
+
+The --provider flag pre-configures the config with provider-specific defaults:
+  - opencode-go: OpenCode Go subscription ($5/month, powerful coding models)
+  - opencode-zen: OpenCode Zen (pay-as-you-go, Claude/GPT/Gemini)
+  - aws-bedrock: AWS Bedrock Mantle (run models on your AWS infrastructure)
+  - openrouter: OpenRouter (unified API for 100+ models)
+
+Without --provider, a default config optimized for OpenCode Go is created.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configDir := getConfigDir()
 			configPath := filepath.Join(configDir, "config.json")
@@ -278,15 +289,42 @@ func initCmd() *cobra.Command {
 				return fmt.Errorf("failed to create config directory: %w", err)
 			}
 
-			if err := os.WriteFile(configPath, []byte(getDefaultConfig()), 0600); err != nil {
+			// Get the appropriate config template
+			var configContent string
+			var err error
+			if provider != "" {
+				configContent, err = getProviderConfig(provider)
+				if err != nil {
+					return err
+				}
+			} else {
+				configContent = getDefaultConfig()
+			}
+
+			if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
 				return fmt.Errorf("failed to write config file: %w", err)
 			}
 
-			fmt.Printf("Created default config at %s\n", configPath)
-			fmt.Println("Edit the file and add your OpenCode Go API key.")
+			// Print helpful message based on provider
+			fmt.Printf("Created config at %s\n", configPath)
+			if provider != "" {
+				preset, ok := providerPresets[provider]
+				if ok {
+					fmt.Printf("\nProvider: %s\n", preset.Name)
+					fmt.Printf("Set your API key: export %s=your-api-key-here\n", preset.EnvVarName)
+				}
+			} else {
+				fmt.Println("\nEdit the file and add your OpenCode Go API key.")
+				fmt.Println("Or use --provider to generate a provider-specific config.")
+			}
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&provider, "provider", "",
+		"Provider preset: opencode-go, opencode-zen, aws-bedrock, openrouter")
+
+	return cmd
 }
 
 // validateCmd returns the command to validate the configuration file.
@@ -551,7 +589,7 @@ func selectProviders(provider string, cfg *config.Config) []string {
 }
 
 // getConfigDir returns the default configuration directory path.
-func getConfigDir() string {
+var getConfigDir = func() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".config", "routatic-proxy")
 }

--- a/docs/fedora-setup.md
+++ b/docs/fedora-setup.md
@@ -142,8 +142,13 @@ docker run -d --restart unless-stopped --name routatic-proxy \
 ### Initialize Configuration
 
 ```bash
-# Create default config file
+# Create default config file (OpenCode Go)
 routatic-proxy init
+
+# Or create a provider-specific config:
+routatic-proxy init --provider=openrouter
+routatic-proxy init --provider=aws-bedrock
+routatic-proxy init --provider=opencode-zen
 ```
 
 This creates `~/.config/routatic-proxy/config.json` with default settings.


### PR DESCRIPTION
## Summary

Adds a `--provider` flag to `routatic-proxy init` that generates provider-specific configuration templates instead of the default generic config.

## Usage

```bash
# OpenRouter - 100+ models from all major providers
routatic-proxy init --provider=openrouter

# AWS Bedrock - run models on your own AWS infrastructure
routatic-proxy init --provider=aws-bedrock

# OpenCode Zen - pay-as-you-go Claude, GPT, Gemini
routatic-proxy init --provider=opencode-zen

# OpenCode Go subscription (default)
routatic-proxy init --provider=opencode-go
```

## What each preset generates

| Provider | Default Model | Fallback | Env Var |
|----------|--------------|----------|---------|
| OpenRouter | Claude Sonnet 4 | Claude 3.5 Sonnet, GPT-4o, Llama-3.3 | `ROUTATIC_PROXY_OPENROUTER_API_KEY` |
| AWS Bedrock | Claude Sonnet 4 on Bedrock | Nova Pro, Claude 3.5 Sonnet | `ROUTATIC_PROXY_AWS_BEDROCK_API_KEY` |
| OpenCode Zen | Claude Sonnet 4.5 | Sonnet 4, Gemini 3.1 Pro | `ROUTATIC_PROXY_OPENCODE_ZEN_API_KEY` |
| OpenCode Go | DeepSeek V4 Pro | Qwen3.7 Plus, Zen free models | `ROUTATIC_PROXY_OPENCODE_GO_API_KEY` |

## Changes

- **cmd/routatic-proxy/init_provider.go** (new) - Provider preset definitions and template generators
- **cmd/routatic-proxy/init_provider_test.go** (new) - Tests for all 4 providers + edge cases
- **cmd/routatic-proxy/main.go** (modified) - Updated init command with --provider flag
- **README.md, CONFIGURATION.md, docs/fedora-setup.md** - Documentation updates

All tests pass with race detector.