### PR TITLE
fix: make Docker images publicly pullable and use sequential beta versioning

### DIFF
--- a/.github/scripts/get-versions.sh
+++ b/.github/scripts/get-versions.sh
@@ -3,13 +3,15 @@
 #
 # This script:
 # 1. Gets the latest production version from releases branch tags
-# 2. Generates a beta version with timestamp (industry standard: base on upcoming version + timestamp)
+# 2. Generates a beta version for the upcoming patch release with a
+#    sequential, monotonically increasing beta counter
 # 3. Outputs both versions as JSON
 #
 # Version Format:
-# - Beta: v{UPCOMING_VERSION}-beta.{YYYYMMDD.HHMMSS}
-# - Example: v1.3.0-beta.20260712.143015
-# - The timestamp ensures uniqueness even with multiple beta releases in a day
+# - Upcoming: v{MAJOR}.{MINOR}.{PATCH+1}
+# - Beta:     v{UPCOMING_VERSION}-beta.{N}
+# - Example:  stable v0.5.2 -> upcoming v0.5.3 -> beta v0.5.3-beta.1
+#             next beta (before stable bump) -> v0.5.3-beta.2
 
 set -eu
 
@@ -20,22 +22,17 @@ TAG_PATTERN="v[0-9]*"
 # Default fallback version (used when no tags found)
 DEFAULT_VERSION="v0.0.0"
 
-# Get current UTC timestamp for beta version
-# Format: YYYYMMDD.HHMMSS (dot separator for SemVer compatibility)
-get_timestamp() {
-    date -u +"%Y%m%d.%H%M%S"
-}
-
-# Get the latest production version from releases branch
+# Get the latest production version from releases branch.
+# Production tags are semver only (no prerelease suffix).
 get_prod_version() {
     # Fetch tags from the releases branch
     git fetch "${RELEASES_BRANCH}" 2>/dev/null || true
 
-    # Get the latest tag matching the pattern
-    # Sort versions in descending order and take the first one
-    latest_tag=$(git tag -l "${TAG_PATTERN}" --sort=-version:refname | head -1)
+    # Latest stable tag: matches vX.Y.Z with no prerelease suffix
+    latest_tag=$(git tag -l "${TAG_PATTERN}" --sort=-version:refname \
+        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+        | head -1)
 
-    # If no tags found, use default
     if [ -z "${latest_tag}" ]; then
         echo "${DEFAULT_VERSION}"
     else
@@ -43,38 +40,54 @@ get_prod_version() {
     fi
 }
 
-# Increment minor version for beta (e.g., v1.2.3 → v1.3.0)
-increment_minor_version() {
-    local prod_version="$1"
-    # Parse version components using sed (POSIX compliant)
+# Increment patch version for the upcoming release (e.g., v0.5.2 -> v0.5.3)
+increment_patch_version() {
+    prod_version="$1"
     major=$(echo "${prod_version}" | sed 's/^v\([0-9]*\)\..*/\1/')
-    minor=$(echo "${prod_version}" | sed 's/^v[0-9]*\.\([0-9]*\).*/\1/')
-    
-    if [ -z "${major}" ] || [ -z "${minor}" ]; then
+    minor=$(echo "${prod_version}" | sed 's/^v[0-9]*\.\([0-9]*\)\..*/\1/')
+    patch=$(echo "${prod_version}" | sed 's/^v[0-9]*\.[0-9]*\.\([0-9]*\).*/\1/')
+
+    if [ -z "${major}" ] || [ -z "${minor}" ] || [ -z "${patch}" ]; then
         echo "${DEFAULT_VERSION}"
         return
     fi
-    
-    # Increment minor version, reset patch to 0
-    new_minor=$((minor + 1))
-    echo "v${major}.${new_minor}.0"
+
+    new_patch=$((patch + 1))
+    echo "v${major}.${minor}.${new_patch}"
 }
 
-# Generate beta version based on upcoming version + timestamp
-# Industry standard: v{UPCOMING_VERSION}-beta.{TIMESTAMP}
-# Example: v1.3.0-beta.20260712.143015
+# Find the next beta counter for a given upcoming version.
+# Looks at existing v{UPCOMING}-beta.{N} tags and returns max(N)+1 (min 1).
+next_beta_counter() {
+    upcoming_version="$1"
+
+    # Highest existing beta counter for this upcoming version, or 0.
+    highest=$(git tag -l "${upcoming_version}-beta.*" \
+        | sed "s/^${upcoming_version}-beta\.\([0-9]*\)$/\1/" \
+        | grep -E '^[0-9]+$' \
+        | sort -n \
+        | tail -1)
+
+    if [ -z "${highest}" ]; then
+        echo 1
+    else
+        echo $((highest + 1))
+    fi
+}
+
+# Generate beta version: v{UPCOMING_VERSION}-beta.{N}
 generate_beta_version() {
-    upcoming_version=$(increment_minor_version "$1")
-    timestamp="$2"
-    echo "${upcoming_version}-beta.${timestamp}"
+    upcoming_version="$1"
+    counter="$2"
+    echo "${upcoming_version}-beta.${counter}"
 }
 
 # Output JSON
 output_json() {
     prod_version="$1"
-    upcoming_version=$(increment_minor_version "$prod_version")
-    beta_version="$2"
-    
+    upcoming_version="$2"
+    beta_version="$3"
+
     printf '{
   "prod_version": "%s",
   "upcoming_version": "%s",
@@ -86,10 +99,11 @@ output_json() {
 # Main execution
 main() {
     prod_version=$(get_prod_version)
-    timestamp=$(get_timestamp)
-    beta_version=$(generate_beta_version "${prod_version}" "${timestamp}")
+    upcoming_version=$(increment_patch_version "${prod_version}")
+    counter=$(next_beta_counter "${upcoming_version}")
+    beta_version=$(generate_beta_version "${upcoming_version}" "${counter}")
 
-    output_json "${prod_version}" "${beta_version}"
+    output_json "${prod_version}" "${upcoming_version}" "${beta_version}"
 }
 
 main

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -252,7 +252,6 @@ jobs:
             type=raw,value=${{ needs.release.outputs.beta_tag }}
             type=raw,value=beta-${{ needs.release.outputs.prod_version }}
             type=raw,value=beta
-            type=raw,value=latest
 
       - name: Strip v prefix from version
         id: version

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -251,6 +251,8 @@ jobs:
           tags: |
             type=raw,value=${{ needs.release.outputs.beta_tag }}
             type=raw,value=beta-${{ needs.release.outputs.prod_version }}
+            type=raw,value=beta
+            type=raw,value=latest
 
       - name: Strip v prefix from version
         id: version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,9 @@ This project uses a dual release channel system for separating beta and producti
 
 ### Beta Channel (Automatic)
 - **Trigger:** Every push to `main` branch (see `.github/workflows/beta-release.yml`)
-- **Version format:** `v{UPCOMING}.beta.{YYYYMMDD.HHMMSS}` (e.g., `v1.3.0-beta.20260712.143015`)
+- **Version format:** `v{UPCOMING}-beta.{N}` (e.g., `v0.5.3-beta.1`), where `{N}` is a sequential counter
 - **GitHub release:** Marked as `prerelease: true`
-- **Docker tags:** `v{UPCOMING}.beta.{YYYYMMDD.HHMMSS}` and `beta-{UPCOMING}`
+- **Docker tags:** `v{UPCOMING}-beta.{N}`, `beta-{UPCOMING}`, and `beta` (rolling pointer to newest beta)
 
 Beta releases are fully automated and include:
 - Test suite validation
@@ -163,16 +163,16 @@ Production releases include all beta features plus:
 ### Version Detection Script
 
 `.github/scripts/get-versions.sh` is used by the beta workflow to:
-1. Fetch tags from the `origin/releases` branch to get current production version (e.g., `v1.2.3`)
-2. Increment to the next version (e.g., `v1.3.0`) - **beta is based on upcoming release**
-3. Generate beta version by appending `.beta.{YYYYMMDD.HHMMSS}` - **timestamp ensures uniqueness even with multiple releases per day**
+1. Fetch tags from the `origin/releases` branch to get current production version (e.g., `v0.5.2`)
+2. Increment the **patch** to the next version (e.g., `v0.5.3`) - **beta is based on the upcoming patch release**
+3. Generate beta version by appending `-beta.{N}`, where `{N}` is `max(existing beta counters for this upcoming version) + 1` - **the counter resets to 1 once the upcoming version ships as stable**
 4. Output both versions as JSON for CI consumption
 
 
 **Version Format Explanation:**
-- `v1.3.0` = The upcoming production version (minor incremented from latest production)
-- `beta.20260712.143015` = Timestamp-based prerelease tag
-- Full example: `v1.3.0-beta.20260712.143015`
+- `v0.5.3` = The upcoming production version (patch incremented from latest production)
+- `beta.1` = Sequential prerelease counter for that upcoming version
+- Full example: stable `v0.5.2` → `v0.5.3-beta.1`, then `v0.5.3-beta.2`, ... until `v0.5.3` ships → `v0.5.4-beta.1`
 
 ### Creating a Production Release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ARG VERSION=docker
 RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=${VERSION}" -o /app/routatic-proxy ./cmd/routatic-proxy
 
 FROM alpine:3.21
+LABEL org.opencontainers.image.source="https://github.com/routatic/proxy"
+LABEL org.opencontainers.image.description="Proxy Claude Code requests to OpenCode Go API"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-only"
 RUN apk add --no-cache ca-certificates tzdata wget && \
     addgroup -S appgroup && adduser -S appuser -G appgroup && \
     mkdir -p /etc/routatic-proxy && \

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -55,6 +55,21 @@ Homebrew and Scoop installs also provide `oc-go-cc` as an alias for `routatic-pr
 
 ## Docker
 
+### Pull the prebuilt image
+
+Prebuilt multi-arch images (linux/amd64, linux/arm64) are published to GitHub Container Registry:
+
+```bash
+# Latest beta
+docker pull ghcr.io/routatic/proxy:latest
+
+# A specific stable release
+docker pull ghcr.io/routatic/proxy:v1.0.0
+
+docker run -d --restart unless-stopped --name routatic-proxy \
+  --env-file .env -p 3456:3456 ghcr.io/routatic/proxy:latest
+```
+
 ### Quick start with Makefile
 
 ```bash

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -60,8 +60,11 @@ Homebrew and Scoop installs also provide `oc-go-cc` as an alias for `routatic-pr
 Prebuilt multi-arch images (linux/amd64, linux/arm64) are published to GitHub Container Registry:
 
 ```bash
-# Latest beta
+# Latest stable release
 docker pull ghcr.io/routatic/proxy:latest
+
+# Latest beta (newest prerelease build)
+docker pull ghcr.io/routatic/proxy:beta
 
 # A specific stable release
 docker pull ghcr.io/routatic/proxy:v1.0.0

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This project uses a dual release channel system. See [RELEASE_PROCESS.md](RELEAS
 
 ### Beta Channel (Automatic)
 - **Trigger:** Every push to `main` branch
-- **Version format:** `v{UPCOMING}.beta.{YYYYMMDD.HHMMSS}` (e.g., `v1.3.0-beta.20260712.143015`)
+- **Version format:** `v{UPCOMING}-beta.{N}` (e.g., `v0.5.3-beta.1`), where `{N}` is a sequential counter
 - **GitHub release:** Marked as prerelease
 - **Use case:** Get the latest features and bug fixes immediately; ideal for testing
 


### PR DESCRIPTION
## Summary                                                                   
  
  Fixes #117 (Docker images not publicly pullable) and reworks beta version
  numbering to use a sequential, patch-based scheme instead of timestamps.
  
  ## Docker distribution (#117)
  
  - Add OCI image labels (`org.opencontainers.image.source`, `description`,
    `licenses`) to the `Dockerfile` so the GHCR package links to the public    
    repo and can inherit its visibility.
  - Publish a rolling `beta` tag from beta builds so users can pull the newest
    prerelease before a stable release exists.
  - Reserve the `latest` tag for the stable release pipeline only — beta builds
    must not clobber `latest` with prerelease images (addresses a supply-chain
    tag-collision concern).
  - Document `docker pull ghcr.io/routatic/proxy:latest` / `:beta` in
    `INSTALLATION.md`.
    
  
  ## Beta versioning
  
  Beta versions now increment the **patch** of the latest stable release and
  use a **sequential counter** instead of a timestamp:

  stable v0.5.2  →  v0.5.3-beta.1  →  v0.5.3-beta.2  →  ...
  (after v0.5.3 ships stable)  →  v0.5.4-beta.1   # counter resets

  The counter is `max(existing beta counters for the upcoming version) + 1`,   
  with numeric sorting so `beta.10` correctly follows `beta.9`.
  
  ## Testing                                                                   

  `.github/scripts/get-versions.sh` verified against a scratch git repo:

  | Stable | Existing betas | Next beta |
  |--------|----------------|-----------|
  | v0.5.2 | none           | v0.5.3-beta.1 |
  | v0.5.2 | beta.1         | v0.5.3-beta.2 |
  | v0.5.3 | none           | v0.5.4-beta.1 (reset) |
  | v0.5.3 | beta.9, beta.10 | v0.5.4-beta.11 (numeric sort) | 