### PR TITLE
feat: CC-Switch compatibility and `/v1/models` endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Precedence: `*_API_KEYS` → `*_API_KEY` → global `API_KEYS` → global `API_K
 - `internal/config/` — Config types and JSON loader with `${VAR}` env interpolation.
 - `internal/transformer/` — Request/response format conversion (Anthropic ↔ OpenAI).
 - `internal/router/fallback.go` — Circuit breaker per model (3 failures = 30s skip).
+- `internal/handlers/models.go` — `GET /v1/models` (OpenAI-style listing). Used by provider-switching tools like CC-Switch's "Fetch Models" button; sources IDs from `ModelRouter.ListModels` (config aliases + `model_overrides` keys + catalog canonical names).
 - `configs/config.example.json` — Reference config with all options documented.
 - `internal/gui/` — Embedded HTTP server for the dashboard (serves static assets + API endpoints).
 - `internal/gui/assets/` — HTML/CSS/JS for the dashboard (Overview, History, Analytics, Settings tabs).

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -622,3 +622,53 @@ Recommended setup for Claude Code review workflows:
 ```
 
 Use the `fast` scenario for short/simple requests. Use `complex` or `long_context` for code review, multi-agent dispatch, large diffs, many tools, or long-context Claude Code sessions.
+
+## Using with CC-Switch
+
+[CC-Switch](https://github.com/farion1231/cc-switch) is a desktop app for managing and hot-switching Claude Code providers. routatic-proxy works with it out of the box — the proxy speaks the Anthropic API that Claude Code (and therefore CC-Switch) already expects, so you add it like any other custom provider.
+
+### Add routatic-proxy as a custom provider
+
+1. Start the proxy: `routatic-proxy serve` (default listen address `http://127.0.0.1:3456`).
+2. In CC-Switch, click **Add Provider → Custom** and fill in:
+
+   | CC-Switch field | Value |
+   |-----------------|-------|
+   | **Name** | `routatic-proxy` (any label) |
+   | **Endpoint URL** | `http://127.0.0.1:3456` |
+   | **API Key** | any non-empty value (e.g. `unused`) — see note below |
+
+   CC-Switch writes these into Claude Code's config as:
+
+   ```json
+   {
+     "env": {
+       "ANTHROPIC_BASE_URL": "http://127.0.0.1:3456",
+       "ANTHROPIC_AUTH_TOKEN": "unused"
+     }
+   }
+   ```
+
+   These are the exact two environment variables the proxy relies on — the same ones from the manual quickstart in the [README](README.md).
+3. **Enable** the provider. Claude Code hot-reloads it, so no restart is needed.
+
+> **About the API Key field:** the token in `ANTHROPIC_AUTH_TOKEN` is what Claude Code sends to the *proxy*, not what the proxy sends upstream. Your real upstream keys live in the proxy's own config (`opencode_go.api_key`, `openrouter.api_key`, etc.) or environment (`ROUTATIC_PROXY_*`). If you set `api_key` / `api_keys` in the proxy config, that value must match what CC-Switch sends; if you leave proxy auth unset, any non-empty token works.
+
+### Configure specific models
+
+You have two ways to control which model a CC-Switch-selected request runs on:
+
+- **Let Claude Code pick, and honor it** — with `respect_requested_model: true` (the default), the proxy uses whatever model string Claude Code sends, resolving it against your `models` config and the catalog. Set it to `false` to force scenario-based routing regardless of the requested model.
+- **Pin a model alias** — use [`model_overrides`](#model-overrides-model_overrides) to map a client-visible model name to a fixed upstream model. For example, requesting `claude-sonnet-4.5` can be routed to any provider/model you choose.
+
+### CC-Switch "Fetch Models" button
+
+CC-Switch's custom-provider form has a **Fetch Models** button that calls the OpenAI-style `GET /v1/models` endpoint to populate a model dropdown. The proxy implements this endpoint: it returns every model identifier you can request — config `models` aliases, `model_overrides` keys, and catalog canonical names (`provider/model`). See [docs/reference-api.md](docs/reference-api.md#get-v1models).
+
+If the dropdown looks short, it usually means the model catalog has not synced into local storage yet; the scenario aliases (`default`, `fast`, `complex`, …) and any `model_overrides` keys always appear.
+
+### Troubleshooting
+
+- **CC-Switch reports the provider is unreachable** — confirm the proxy is running (`routatic-proxy status`) and the endpoint URL/port match `host`/`port` in your proxy config.
+- **401 / auth errors from the proxy** — the token CC-Switch sends must satisfy the proxy's `api_key` / `api_keys` (or those must be unset). This is proxy-side auth, unrelated to your upstream provider keys.
+- **Wrong model runs** — check routing precedence: `model_overrides` wins, then `respect_requested_model`, then scenario routing. See [Routing precedence](#routing-precedence).

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -623,6 +623,40 @@ Recommended setup for Claude Code review workflows:
 
 Use the `fast` scenario for short/simple requests. Use `complex` or `long_context` for code review, multi-agent dispatch, large diffs, many tools, or long-context Claude Code sessions.
 
+## Claude Code Model Picker
+
+You can select proxy models from Claude Code's `/model` picker in two ways.
+
+### Type any model name (always works)
+
+Claude Code's `/model` picker also accepts a free-form model name. Type any value the proxy understands — a scenario alias (`default`, `fast`, `complex`, …), a `model_overrides` key, or a catalog canonical name like `opencode-go/kimi-k2.6` — and the proxy routes it. No extra configuration is needed; this works regardless of Claude Code version.
+
+### Gateway model discovery (opt-in, adds entries to the picker)
+
+Recent Claude Code versions can auto-populate the picker by querying the proxy's [`GET /v1/models`](docs/reference-api.md#get-v1models) endpoint. When enabled, discovered models appear in `/model` labeled **"From gateway"** alongside the built-in entries (Sonnet, Opus, …).
+
+Enable it by setting, alongside `ANTHROPIC_BASE_URL`:
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
+export ANTHROPIC_AUTH_TOKEN=unused
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+```
+
+Discovery only runs when all of these hold: `ANTHROPIC_BASE_URL` is set, `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, no `CLAUDE_CODE_USE_*` provider variable is set, the base URL is not `api.anthropic.com`, and the Claude Code version supports it (≥ 2.1.129). Results are cached to `~/.claude/cache/gateway-models.json`.
+
+> **Important — Claude Code filters discovered model IDs.** Claude Code only shows discovered models whose `id` begins with **`claude`** or **`anthropic`**. The proxy's scenario aliases (`default`, `fast`, …) and catalog names (`opencode-go/kimi-k2.6`) are therefore **filtered out of the picker**. To make a proxy model appear via discovery, give it a `claude-*` name — the natural fit is a [`model_overrides`](#model-overrides-model_overrides) key:
+>
+> ```json
+> {
+>   "model_overrides": {
+>     "claude-glm-5.2": { "provider": "opencode-go", "model_id": "glm-5.2" }
+>   }
+> }
+> ```
+>
+> `claude-glm-5.2` then appears in the picker (labeled "From gateway"), and selecting it routes to GLM-5.2. Models with non-`claude`/`anthropic` IDs remain fully usable — just type them into `/model` directly.
+
 ## Using with CC-Switch
 
 [CC-Switch](https://github.com/farion1231/cc-switch) is a desktop app for managing and hot-switching Claude Code providers. routatic-proxy works with it out of the box — the proxy speaks the Anthropic API that Claude Code (and therefore CC-Switch) already expects, so you add it like any other custom provider.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ claude
 
 See [INSTALLATION.md](INSTALLATION.md) for Homebrew, Scoop, Docker, and build-from-source options.
 
+Prefer a GUI for switching providers? routatic-proxy works with [CC-Switch](https://github.com/farion1231/cc-switch) — see [Using with CC-Switch](CONFIGURATION.md#using-with-cc-switch).
+
 ## CLI Commands
 
 ```

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -64,6 +64,32 @@ Counts tokens for a message array without generating a response.
 }
 ```
 
+### `GET /v1/models`
+
+Returns the set of model identifiers a client may request, in the OpenAI
+`/v1/models` envelope. Provider-switching tools such as
+[CC-Switch](../CONFIGURATION.md#using-with-cc-switch) call this endpoint to
+populate a model picker (its "Fetch Models" button).
+
+The listing merges config `models` aliases, `model_overrides` keys, and — when
+a catalog is available — catalog canonical names (`provider/model`). Any value
+in the list is valid in the `model` field of `POST /v1/messages`.
+
+**Response:**
+
+```json
+{
+  "object": "list",
+  "data": [
+    { "id": "default", "object": "model", "owned_by": "opencode-go" },
+    { "id": "claude-sonnet-4-5-20250929", "object": "model", "owned_by": "opencode-zen" },
+    { "id": "opencode-go/kimi-k2.6", "object": "model", "owned_by": "opencode-go", "name": "Kimi K2.6" }
+  ]
+}
+```
+
+Only `GET` is allowed; other methods return `405`.
+
 ### `GET /health`
 
 Returns server health status.

--- a/docs/reference-api.md
+++ b/docs/reference-api.md
@@ -67,9 +67,16 @@ Counts tokens for a message array without generating a response.
 ### `GET /v1/models`
 
 Returns the set of model identifiers a client may request, in the OpenAI
-`/v1/models` envelope. Provider-switching tools such as
-[CC-Switch](../CONFIGURATION.md#using-with-cc-switch) call this endpoint to
-populate a model picker (its "Fetch Models" button).
+`/v1/models` envelope. Two consumers use it:
+
+- **[CC-Switch](../CONFIGURATION.md#using-with-cc-switch)** — its "Fetch Models"
+  button populates a model dropdown from this endpoint.
+- **Claude Code gateway model discovery** — when enabled, Claude Code calls
+  `GET /v1/models?limit=1000` and adds the results to its `/model` picker
+  (labeled "From gateway"). It reads the `display_name` field and **only
+  surfaces models whose `id` begins with `claude` or `anthropic`** — all other
+  ids are silently filtered from the picker (see
+  [Claude Code model picker](../CONFIGURATION.md#claude-code-model-picker)).
 
 The listing merges config `models` aliases, `model_overrides` keys, and — when
 a catalog is available — catalog canonical names (`provider/model`). Any value
@@ -83,12 +90,14 @@ in the list is valid in the `model` field of `POST /v1/messages`.
   "data": [
     { "id": "default", "object": "model", "owned_by": "opencode-go" },
     { "id": "claude-sonnet-4-5-20250929", "object": "model", "owned_by": "opencode-zen" },
-    { "id": "opencode-go/kimi-k2.6", "object": "model", "owned_by": "opencode-go", "name": "Kimi K2.6" }
+    { "id": "opencode-go/kimi-k2.6", "object": "model", "owned_by": "opencode-go", "name": "Kimi K2.6", "display_name": "Kimi K2.6" }
   ]
 }
 ```
 
-Only `GET` is allowed; other methods return `405`.
+The `limit` query parameter (sent by Claude Code) is accepted and currently
+ignored — the full list is always returned. Only `GET` is allowed; other
+methods return `405`.
 
 ### `GET /health`
 

--- a/internal/handlers/models.go
+++ b/internal/handlers/models.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/routatic/proxy/internal/router"
+)
+
+// ModelsHandler serves the OpenAI-compatible model listing endpoint.
+//
+// Tools that manage Claude Code providers — notably CC-Switch's "Fetch Models"
+// button — call GET /v1/models to populate a model picker. The proxy answers
+// with every model identifier a client may put in the request "model" field:
+// config aliases, model_overrides keys, and catalog canonical names.
+type ModelsHandler struct {
+	modelRouter *router.ModelRouter
+}
+
+// NewModelsHandler creates a new models listing handler.
+func NewModelsHandler(modelRouter *router.ModelRouter) *ModelsHandler {
+	return &ModelsHandler{modelRouter: modelRouter}
+}
+
+// openAIModel mirrors an entry in the OpenAI /v1/models response. Fields beyond
+// "id" are informational; clients key off "id".
+type openAIModel struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	OwnedBy string `json:"owned_by,omitempty"`
+	Name    string `json:"name,omitempty"`
+}
+
+// openAIModelList is the OpenAI /v1/models envelope: {"object":"list","data":[...]}.
+type openAIModelList struct {
+	Object string        `json:"object"`
+	Data   []openAIModel `json:"data"`
+}
+
+// HandleListModels handles GET /v1/models.
+func (h *ModelsHandler) HandleListModels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	infos := h.modelRouter.ListModels()
+	data := make([]openAIModel, 0, len(infos))
+	for _, info := range infos {
+		data = append(data, openAIModel{
+			ID:      info.ID,
+			Object:  "model",
+			OwnedBy: info.Provider,
+			Name:    info.DisplayName,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(openAIModelList{Object: "list", Data: data})
+}

--- a/internal/handlers/models.go
+++ b/internal/handlers/models.go
@@ -50,7 +50,7 @@ func (h *ModelsHandler) HandleListModels(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	infos := h.modelRouter.ListModels()
+	infos := h.modelRouter.ListModels(r.Context())
 	data := make([]openAIModel, 0, len(infos))
 	for _, info := range infos {
 		data = append(data, openAIModel{

--- a/internal/handlers/models.go
+++ b/internal/handlers/models.go
@@ -24,11 +24,17 @@ func NewModelsHandler(modelRouter *router.ModelRouter) *ModelsHandler {
 
 // openAIModel mirrors an entry in the OpenAI /v1/models response. Fields beyond
 // "id" are informational; clients key off "id".
+//
+// display_name is included for Claude Code's gateway model discovery, which
+// reads that field when it queries GET /v1/models?limit=1000. Note that Claude
+// Code only surfaces discovered models whose id begins with "claude" or
+// "anthropic"; other ids are silently filtered from its picker.
 type openAIModel struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	OwnedBy string `json:"owned_by,omitempty"`
-	Name    string `json:"name,omitempty"`
+	ID          string `json:"id"`
+	Object      string `json:"object"`
+	OwnedBy     string `json:"owned_by,omitempty"`
+	Name        string `json:"name,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
 }
 
 // openAIModelList is the OpenAI /v1/models envelope: {"object":"list","data":[...]}.
@@ -48,10 +54,11 @@ func (h *ModelsHandler) HandleListModels(w http.ResponseWriter, r *http.Request)
 	data := make([]openAIModel, 0, len(infos))
 	for _, info := range infos {
 		data = append(data, openAIModel{
-			ID:      info.ID,
-			Object:  "model",
-			OwnedBy: info.Provider,
-			Name:    info.DisplayName,
+			ID:          info.ID,
+			Object:      "model",
+			OwnedBy:     info.Provider,
+			Name:        info.DisplayName,
+			DisplayName: info.DisplayName,
 		})
 	}
 

--- a/internal/handlers/models_test.go
+++ b/internal/handlers/models_test.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/routatic/proxy/internal/config"
+	"github.com/routatic/proxy/internal/router"
+)
+
+func TestHandleListModels_ReturnsOpenAIEnvelope(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"default":   {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+			"kimi-k2.6": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		ModelOverrides: map[string]config.ModelConfig{
+			"claude-sonnet-4-5-20250929": {Provider: "opencode-zen", ModelID: "minimax"},
+		},
+	}
+	atomic := config.NewAtomicConfig(cfg, "/tmp/test-config.json")
+	handler := NewModelsHandler(router.NewModelRouter(atomic))
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	handler.HandleListModels(recorder, req)
+
+	if got, want := recorder.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d; body: %s", got, want, recorder.Body.String())
+	}
+
+	var resp openAIModelList
+	if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is invalid JSON: %v", err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("object = %q, want \"list\"", resp.Object)
+	}
+
+	ids := make(map[string]openAIModel, len(resp.Data))
+	for _, m := range resp.Data {
+		if m.Object != "model" {
+			t.Errorf("model %q object = %q, want \"model\"", m.ID, m.Object)
+		}
+		ids[m.ID] = m
+	}
+	for _, want := range []string{"default", "kimi-k2.6", "claude-sonnet-4-5-20250929"} {
+		if _, ok := ids[want]; !ok {
+			t.Errorf("expected model %q in listing", want)
+		}
+	}
+}
+
+func TestHandleListModels_RejectsNonGET(t *testing.T) {
+	atomic := config.NewAtomicConfig(&config.Config{}, "/tmp/test-config.json")
+	handler := NewModelsHandler(router.NewModelRouter(atomic))
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/models", nil)
+	handler.HandleListModels(recorder, req)
+
+	if got, want := recorder.Code, http.StatusMethodNotAllowed; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+}

--- a/internal/handlers/models_test.go
+++ b/internal/handlers/models_test.go
@@ -44,6 +44,11 @@ func TestHandleListModels_ReturnsOpenAIEnvelope(t *testing.T) {
 		if m.Object != "model" {
 			t.Errorf("model %q object = %q, want \"model\"", m.ID, m.Object)
 		}
+		// name and display_name carry the same value so both OpenAI clients
+		// (CC-Switch) and Claude Code gateway discovery see a label.
+		if m.Name != m.DisplayName {
+			t.Errorf("model %q: name %q != display_name %q", m.ID, m.Name, m.DisplayName)
+		}
 		ids[m.ID] = m
 	}
 	for _, want := range []string{"default", "kimi-k2.6", "claude-sonnet-4-5-20250929"} {

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -39,7 +39,7 @@ func NewModelRouterWithCatalog(atomic *config.AtomicConfig, catalogPath string) 
 	return &ModelRouter{atomic: atomic, catalogPath: catalogPath}
 }
 
-func (r *ModelRouter) catalog() (*catalog.IndexedCatalog, error) {
+func (r *ModelRouter) catalog(ctx context.Context) (*catalog.IndexedCatalog, error) {
 	if r.db == nil && r.catalogPath == "" {
 		slog.Warn("catalog not available — model resolution falling back to legacy config")
 		return nil, nil
@@ -52,7 +52,7 @@ func (r *ModelRouter) catalog() (*catalog.IndexedCatalog, error) {
 		return r.cat, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	if r.db != nil {
@@ -101,7 +101,7 @@ func (r *ModelRouter) resolveRequestedModel(cfg *config.Config, requestedModel s
 		sel, parseErr := catalog.ParseModelRef(requestedModel)
 		providerQualified := parseErr == nil && sel.Provider != ""
 
-		cat, _ := r.catalog()
+		cat, _ := r.catalog(context.Background())
 		if cat != nil {
 			if catalogPrimary, catalogOk := r.resolveFromCatalog(cat, requestedModel, sel); catalogOk {
 				primary = catalogPrimary
@@ -235,7 +235,7 @@ func (r *ModelRouter) Route(messages []MessageContent, tokenCount int, requested
 	// a non-empty catalog is available, prefer the cheapest matching catalog
 	// model while preserving the legacy fallback chain.
 	primary, ok := cfg.Models[scenarioKey]
-	if cat, catErr := r.catalog(); cfg.CostBasedRoutingEnabled() && cat != nil && catErr == nil && len(cat.Models) > 0 {
+	if cat, catErr := r.catalog(context.Background()); cfg.CostBasedRoutingEnabled() && cat != nil && catErr == nil && len(cat.Models) > 0 {
 		constraints := requestConstraints(messages, tokenCount)
 		selector := NewSelector(cat, cfg)
 		if resolved, err := selector.SelectCheapest(scenarioKey, constraints); err == nil {
@@ -329,7 +329,10 @@ type ModelInfo struct {
 //
 // Any of these is a valid value for the request "model" field, so surfacing
 // all of them lets a picker present every route the proxy understands.
-func (r *ModelRouter) ListModels() []ModelInfo {
+//
+// ctx bounds the catalog load; when the caller (e.g. an HTTP handler) cancels
+// it, an in-flight catalog read is abandoned rather than churning to completion.
+func (r *ModelRouter) ListModels(ctx context.Context) []ModelInfo {
 	cfg := r.atomic.Get()
 	seen := make(map[string]ModelInfo)
 
@@ -359,7 +362,7 @@ func (r *ModelRouter) ListModels() []ModelInfo {
 		add(alias, "", mc.Provider)
 	}
 
-	if cat, err := r.catalog(); err == nil && cat != nil {
+	if cat, err := r.catalog(ctx); err == nil && cat != nil {
 		for key, model := range cat.Models {
 			add(key, model.DisplayName(), catalog.ProviderFromModelKey(key))
 		}
@@ -400,7 +403,7 @@ func (r *ModelRouter) RouteForStreaming(messages []MessageContent, tokenCount in
 	// a non-empty catalog is available, prefer the cheapest matching catalog
 	// model while preserving the legacy fallback chain.
 	primary, ok := cfg.Models[scenarioKey]
-	if cat, catErr := r.catalog(); cfg.CostBasedRoutingEnabled() && cat != nil && catErr == nil && len(cat.Models) > 0 {
+	if cat, catErr := r.catalog(context.Background()); cfg.CostBasedRoutingEnabled() && cat != nil && catErr == nil && len(cat.Models) > 0 {
 		constraints := requestConstraints(messages, tokenCount)
 		selector := NewSelector(cat, cfg)
 		if resolved, err := selector.SelectCheapest(scenarioKey, constraints); err == nil {

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -355,10 +355,14 @@ func (r *ModelRouter) ListModels(ctx context.Context) []ModelInfo {
 		seen[id] = existing
 	}
 
-	for alias, mc := range cfg.Models {
+	// ModelOverrides is walked before Models so that, for a key present in
+	// both, the override's provider is what surfaces in the listing — matching
+	// the routing precedence (model_overrides wins). add() keeps the first
+	// source's fields, so first-write must be the winning source.
+	for alias, mc := range cfg.ModelOverrides {
 		add(alias, "", mc.Provider)
 	}
-	for alias, mc := range cfg.ModelOverrides {
+	for alias, mc := range cfg.Models {
 		add(alias, "", mc.Provider)
 	}
 

--- a/internal/router/model_router.go
+++ b/internal/router/model_router.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -305,6 +306,71 @@ func (r *ModelRouter) RouteWithOverride(requestedModel string) (RouteResult, boo
 		Fallbacks: fallbacks,
 		Scenario:  ScenarioOverride,
 	}, true
+}
+
+// ModelInfo describes a model that clients can request by name. It is the
+// data source for the OpenAI-compatible /v1/models listing consumed by tools
+// such as CC-Switch's "Fetch Models" button.
+type ModelInfo struct {
+	// ID is the string a client puts in the request "model" field.
+	ID string
+	// DisplayName is a human-readable label when available.
+	DisplayName string
+	// Provider is the upstream provider that serves the model, when known.
+	Provider string
+}
+
+// ListModels returns the set of model identifiers a client may request,
+// deduplicated and sorted by ID. The list is assembled from:
+//
+//   - legacy config "models" aliases,
+//   - "model_overrides" keys (the Claude aliases users pin),
+//   - catalog canonical names (provider/model), when a catalog is available.
+//
+// Any of these is a valid value for the request "model" field, so surfacing
+// all of them lets a picker present every route the proxy understands.
+func (r *ModelRouter) ListModels() []ModelInfo {
+	cfg := r.atomic.Get()
+	seen := make(map[string]ModelInfo)
+
+	add := func(id, name, provider string) {
+		if id == "" {
+			return
+		}
+		existing, ok := seen[id]
+		if !ok {
+			seen[id] = ModelInfo{ID: id, DisplayName: name, Provider: provider}
+			return
+		}
+		// Fill in missing fields from later sources without overwriting.
+		if existing.DisplayName == "" {
+			existing.DisplayName = name
+		}
+		if existing.Provider == "" {
+			existing.Provider = provider
+		}
+		seen[id] = existing
+	}
+
+	for alias, mc := range cfg.Models {
+		add(alias, "", mc.Provider)
+	}
+	for alias, mc := range cfg.ModelOverrides {
+		add(alias, "", mc.Provider)
+	}
+
+	if cat, err := r.catalog(); err == nil && cat != nil {
+		for key, model := range cat.Models {
+			add(key, model.DisplayName(), catalog.ProviderFromModelKey(key))
+		}
+	}
+
+	result := make([]ModelInfo, 0, len(seen))
+	for _, info := range seen {
+		result = append(result, info)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
 }
 
 // GetModelChain returns the full chain of models to try (primary + fallbacks).

--- a/internal/router/model_router_test.go
+++ b/internal/router/model_router_test.go
@@ -912,3 +912,46 @@ func TestRoute_LegacyConfigFixtures(t *testing.T) {
 		}
 	})
 }
+
+func TestListModels_MergesConfigAndOverrides(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"default":   {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+			"kimi-k2.6": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		ModelOverrides: map[string]config.ModelConfig{
+			"claude-sonnet-4-5-20250929": {Provider: "opencode-zen", ModelID: "minimax"},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+	models := router.ListModels()
+
+	byID := make(map[string]ModelInfo, len(models))
+	for _, m := range models {
+		byID[m.ID] = m
+	}
+
+	for _, want := range []string{"default", "kimi-k2.6", "claude-sonnet-4-5-20250929"} {
+		if _, ok := byID[want]; !ok {
+			t.Errorf("expected model %q in listing, got %+v", want, models)
+		}
+	}
+	if got := byID["claude-sonnet-4-5-20250929"].Provider; got != "opencode-zen" {
+		t.Errorf("expected override provider opencode-zen, got %q", got)
+	}
+
+	// Sorted ascending by ID.
+	for i := 1; i < len(models); i++ {
+		if models[i-1].ID > models[i].ID {
+			t.Errorf("models not sorted: %q before %q", models[i-1].ID, models[i].ID)
+		}
+	}
+}
+
+func TestListModels_Empty(t *testing.T) {
+	router := NewModelRouter(newTestAtomicConfig(&config.Config{}))
+	if models := router.ListModels(); len(models) != 0 {
+		t.Errorf("expected no models, got %+v", models)
+	}
+}

--- a/internal/router/model_router_test.go
+++ b/internal/router/model_router_test.go
@@ -950,6 +950,32 @@ func TestListModels_MergesConfigAndOverrides(t *testing.T) {
 	}
 }
 
+func TestListModels_OverrideProviderWinsOnCollision(t *testing.T) {
+	// A key present in both models and model_overrides must surface the
+	// override's provider, matching routing precedence (model_overrides wins).
+	cfg := &config.Config{
+		Models: map[string]config.ModelConfig{
+			"claude-sonnet-4-5-20250929": {Provider: "opencode-go", ModelID: "kimi-k2.6"},
+		},
+		ModelOverrides: map[string]config.ModelConfig{
+			"claude-sonnet-4-5-20250929": {Provider: "opencode-zen", ModelID: "minimax"},
+		},
+	}
+
+	router := NewModelRouter(newTestAtomicConfig(cfg))
+	models := router.ListModels(context.Background())
+
+	var got string
+	for _, m := range models {
+		if m.ID == "claude-sonnet-4-5-20250929" {
+			got = m.Provider
+		}
+	}
+	if got != "opencode-zen" {
+		t.Errorf("expected override provider opencode-zen to win, got %q", got)
+	}
+}
+
 func TestListModels_Empty(t *testing.T) {
 	router := NewModelRouter(newTestAtomicConfig(&config.Config{}))
 	if models := router.ListModels(context.Background()); len(models) != 0 {

--- a/internal/router/model_router_test.go
+++ b/internal/router/model_router_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -925,7 +926,7 @@ func TestListModels_MergesConfigAndOverrides(t *testing.T) {
 	}
 
 	router := NewModelRouter(newTestAtomicConfig(cfg))
-	models := router.ListModels()
+	models := router.ListModels(context.Background())
 
 	byID := make(map[string]ModelInfo, len(models))
 	for _, m := range models {
@@ -951,7 +952,7 @@ func TestListModels_MergesConfigAndOverrides(t *testing.T) {
 
 func TestListModels_Empty(t *testing.T) {
 	router := NewModelRouter(newTestAtomicConfig(&config.Config{}))
-	if models := router.ListModels(); len(models) != 0 {
+	if models := router.ListModels(context.Background()); len(models) != 0 {
 		t.Errorf("expected no models, got %+v", models)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -126,6 +126,7 @@ func NewServer(atomic *config.AtomicConfig, captureLogger *debug.CaptureLogger) 
 		storageWriter,
 	)
 	healthHandler := handlers.NewHealthHandler(tokenCounter, fallbackHandler, metrics, statusStore)
+	modelsHandler := handlers.NewModelsHandler(modelRouter)
 
 	// Setup router.
 	mux := http.NewServeMux()
@@ -133,6 +134,7 @@ func NewServer(atomic *config.AtomicConfig, captureLogger *debug.CaptureLogger) 
 	// API routes.
 	mux.Handle("/v1/messages", handlers.NewAnthropicFirstHandler(atomic, http.HandlerFunc(messagesHandler.HandleMessages)))
 	mux.HandleFunc("/v1/messages/count_tokens", healthHandler.HandleCountTokens)
+	mux.HandleFunc("/v1/models", modelsHandler.HandleListModels)
 	mux.HandleFunc("/health", healthHandler.HandleHealth)
 	mux.HandleFunc("/statusline", healthHandler.HandleStatusline)
 


### PR DESCRIPTION
## Summary                                                                   

  Closes #37 — "How do I configure cc-switch? Can I configure specific models?"
                                                                               
  routatic-proxy is already compatible with [CC-Switch](https://github.com/farion1231/cc-switch)
  at the core level: CC-Switch just writes `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`
  into Claude Code's config — the exact two variables the proxy already consumes.
  And "configure specific models" is already supported via `respect_requested_model`
  and `model_overrides`.

  The one missing piece was an OpenAI-style `GET /v1/models` endpoint, which both
  CC-Switch's "Fetch Models" button and Claude Code's gateway model discovery use
  to populate their model pickers. This PR adds that endpoint and documents both
  integrations.                                                                

  ## Changes

  **New endpoint — `GET /v1/models`**
  - `ModelRouter.ListModels()` returns a deduplicated, sorted set of requestable
    model IDs: config `models` aliases, `model_overrides` keys, and (when a catalog
    is synced) catalog canonical names (`provider/model`).                     
  - `ModelsHandler` serves the OpenAI `{"object":"list","data":[...]}` envelope.
    Each entry includes `display_name` (read by Claude Code's discovery) and
    `name`/`owned_by` (for OpenAI-style clients like CC-Switch). Accepts and
    ignores the `?limit` param; non-GET returns `405`.
  - Gracefully degrades: when no catalog is available it still returns config  
    aliases and `model_overrides` keys.
  
  **Documentation**                                                            
  - `CONFIGURATION.md` — "Using with CC-Switch" (add-provider steps, the config
    CC-Switch writes, API-key semantics, pinning models) and "Claude Code Model
    Picker" (manual typing vs. opt-in gateway discovery, plus the important caveat
    that Claude Code only surfaces discovered IDs starting with `claude`/`anthropic`).
  - `docs/reference-api.md` — documents `GET /v1/models`.
  - `README.md` — pointer to the CC-Switch guide.
  - `CLAUDE.md` — notes the new handler in Key Files.

  ## Notes / limitations
                                                                               
  - **Claude Code picker filter:** gateway discovery only displays models whose
    `id` begins with `claude` or `anthropic`. Scenario aliases and catalog names
    are filtered out of the picker; the documented workaround is a `claude-*`
    `model_overrides` key. Manual typing into `/model` works for any proxy model
    regardless.
  - Gateway discovery is opt-in (`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`,
    Claude Code ≥ 2.1.129).

  ## Testing
                                                                               
  - `internal/handlers/models_test.go` — response envelope shape, `name`/`display_name`
    consistency, method rejection.
  - `internal/router/model_router_test.go` — `ListModels` merge/sort/empty cases.
  - `go build ./...`, `go vet`, and full `go test ./...` pass.
  - Verified end-to-end against a running proxy: `GET /v1/models` → 200 with a valid
    list; `POST` → 405; `?limit=1000` accepted.
