### PR TITLE
fix: catalog sync, validation, and models list

### DIFF
--- a/cmd/routatic-proxy/catalog.go
+++ b/cmd/routatic-proxy/catalog.go
@@ -98,6 +98,29 @@ func catalogSyncCmd() *cobra.Command {
 			cmd.Printf("  SHA256: %s\n", lock.SHA256)
 			cmd.Printf("  Bytes:  %d\n", lock.Bytes)
 			cmd.Printf("  TTL:    %d hours\n", lock.TTLHours)
+
+			// Migrate the downloaded JSON catalog to SQLite so that
+			// 'routatic-proxy models list' and other SQLite-backed commands
+			// can find it.
+			jsonPath := filepath.Join(catalogDir, "catalog.json")
+			db, err := storage.Open(storage.DefaultConfig)
+			if err != nil {
+				return fmt.Errorf("open database: %w", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			ctx := cmd.Context()
+			migrated, err := catalog.MigrateFromJSON(ctx, db, jsonPath)
+			if err != nil {
+				return fmt.Errorf("migrate catalog to SQLite: %w", err)
+			}
+
+			if migrated {
+				cmd.Println("  Catalog migrated to SQLite database")
+			} else {
+				cmd.Println("  SQLite catalog already up to date")
+			}
+
 			return nil
 		},
 	}

--- a/cmd/routatic-proxy/main.go
+++ b/cmd/routatic-proxy/main.go
@@ -389,10 +389,10 @@ Press Ctrl+C to stop the server.`,
 
 				// Open GUI (macOS: native webview, Linux/Windows: print URL)
 				if err := openGUI(guiURL); err != nil {
-				slog.Warn("GUI error", "error", err)
-				fmt.Printf("\nDashboard: %s\n", guiURL)
-				fmt.Println("\nPress Ctrl+C to stop.")
-			}
+					slog.Warn("GUI error", "error", err)
+					fmt.Printf("\nDashboard: %s\n", guiURL)
+					fmt.Println("\nPress Ctrl+C to stop.")
+				}
 			} else {
 				fmt.Println("\nRunning in headless mode (no dashboard). Press Ctrl+C to stop.")
 			}

--- a/cmd/routatic-proxy/main.go
+++ b/cmd/routatic-proxy/main.go
@@ -387,12 +387,12 @@ Press Ctrl+C to stop the server.`,
 					return fmt.Errorf("start gui server: %w", err)
 				}
 
-				// Open GUI (macOS: native webview, Linux/Windows: print URL)
-				if err := openGUI(guiURL); err != nil {
-					slog.Warn("GUI error", "error", err)
-					fmt.Printf("\nDashboard: %s\n", guiURL)
-					fmt.Println("\nPress Ctrl+C to stop.")
-				}
+			// Open GUI (macOS: native webview, Linux/Windows: print URL)
+			if err := openGUI(guiURL, cancel); err != nil {
+				slog.Warn("GUI error", "error", err)
+				fmt.Printf("\nDashboard: %s\n", guiURL)
+				fmt.Println("\nPress Ctrl+C to stop.")
+			}
 			} else {
 				fmt.Println("\nRunning in headless mode (no dashboard). Press Ctrl+C to stop.")
 			}
@@ -763,10 +763,19 @@ func runModelsList(cmd *cobra.Command, configPath, provider string) error {
 
 	cat, err := catalog.LoadFromSQLite(ctx, db)
 	if err != nil {
-		return fmt.Errorf("catalog not found; run 'routatic-proxy catalog sync' first")
+		cmd.Println("catalog not found; run 'routatic-proxy catalog sync' first")
+		return nil
 	}
 
-	providers := selectProviders(provider, cfg)
+	// When a specific provider is requested, use it directly. Otherwise
+	// show all providers that have models in the catalog.
+	var providers []string
+	if provider != "" {
+		providers = []string{provider}
+	} else {
+		providers = catalogProviders(cat)
+	}
+
 	if len(providers) == 0 {
 		if provider != "" {
 			cmd.Printf("No models found for provider %q.\n", provider)
@@ -810,30 +819,17 @@ func runModelsList(cmd *cobra.Command, configPath, provider string) error {
 	return nil
 }
 
-// selectProviders returns the providers to display. If provider is non-empty,
-// only that provider is returned when it exists in the catalog; otherwise all
-// configured (enabled) providers are returned.
-func selectProviders(provider string, cfg *config.Config) []string {
-	if provider != "" {
-		return []string{provider}
-	}
-
-	globalKeys := cfg.EffectiveAPIKeys()
-	providerKeys := map[string][]string{
-		"opencode-go":  cfg.OpenCodeGo.EffectiveAPIKeys(),
-		"opencode-zen": cfg.OpenCodeZen.EffectiveAPIKeys(),
-		"aws-bedrock":  cfg.AWSBedrock.EffectiveAPIKeys(),
-		"openrouter":   cfg.OpenRouter.EffectiveAPIKeys(),
-	}
-
-	var enabled []string
-	for p, keys := range providerKeys {
-		if len(keys) > 0 || len(globalKeys) > 0 {
-			enabled = append(enabled, p)
+// catalogProviders returns all provider names from the catalog that have at
+// least one model, sorted.
+func catalogProviders(cat *catalog.IndexedCatalog) []string {
+	providers := make([]string, 0, len(cat.ProviderModels))
+	for p := range cat.ProviderModels {
+		if len(cat.ProviderModels[p]) > 0 {
+			providers = append(providers, p)
 		}
 	}
-	sort.Strings(enabled)
-	return enabled
+	sort.Strings(providers)
+	return providers
 }
 
 // autostartCmd returns the command to manage autostart on login.

--- a/cmd/routatic-proxy/main.go
+++ b/cmd/routatic-proxy/main.go
@@ -387,8 +387,8 @@ Press Ctrl+C to stop the server.`,
 					return fmt.Errorf("start gui server: %w", err)
 				}
 
-			// Open GUI (macOS: native webview, Linux/Windows: print URL)
-			if err := openGUI(guiURL); err != nil {
+				// Open GUI (macOS: native webview, Linux/Windows: print URL)
+				if err := openGUI(guiURL); err != nil {
 				slog.Warn("GUI error", "error", err)
 				fmt.Printf("\nDashboard: %s\n", guiURL)
 				fmt.Println("\nPress Ctrl+C to stop.")

--- a/cmd/routatic-proxy/main.go
+++ b/cmd/routatic-proxy/main.go
@@ -388,7 +388,7 @@ Press Ctrl+C to stop the server.`,
 				}
 
 			// Open GUI (macOS: native webview, Linux/Windows: print URL)
-			if err := openGUI(guiURL, cancel); err != nil {
+			if err := openGUI(guiURL); err != nil {
 				slog.Warn("GUI error", "error", err)
 				fmt.Printf("\nDashboard: %s\n", guiURL)
 				fmt.Println("\nPress Ctrl+C to stop.")

--- a/cmd/routatic-proxy/main.go
+++ b/cmd/routatic-proxy/main.go
@@ -774,6 +774,7 @@ func runModelsList(cmd *cobra.Command, configPath, provider string) error {
 
 	cat, err := catalog.LoadFromSQLite(ctx, db)
 	if err != nil {
+		slog.Warn("catalog not available", "error", err)
 		cmd.Println("catalog not found; run 'routatic-proxy catalog sync' first")
 		return nil
 	}

--- a/cmd/routatic-proxy/main_models_test.go
+++ b/cmd/routatic-proxy/main_models_test.go
@@ -167,15 +167,21 @@ func TestRunModelsList_MissingCatalog(t *testing.T) {
 	configPath := writeTestConfig(t, tmp, `{"api_key": "test-global-key"}`)
 	// Intentionally do not write catalog.json.
 
-	cmd, _ := newCaptureCommand(t)
+	// Override the storage path to use a temp directory so we don't
+	// accidentally pick up the user's real catalog.
+	origDBPath := storage.DefaultConfig.DatabasePath
+	storage.DefaultConfig.DatabasePath = filepath.Join(tmp, "data.db")
+	defer func() { storage.DefaultConfig.DatabasePath = origDBPath }()
+
+	cmd, buf := newCaptureCommand(t)
 	t.Setenv("ROUTATIC_PROXY_CONFIG", configPath)
 
 	err := runModelsList(cmd, configPath, "")
-	if err == nil {
-		t.Fatal("expected error for missing catalog, got nil")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	want := "catalog not found; run 'routatic-proxy catalog sync' first"
-	if !strings.Contains(err.Error(), want) {
-		t.Fatalf("expected error containing %q, got: %v", want, err)
+	output := buf.String()
+	if !strings.Contains(output, "catalog not found") {
+		t.Fatalf("expected output containing %q, got: %s", "catalog not found", output)
 	}
 }

--- a/cmd/routatic-proxy/main_models_test.go
+++ b/cmd/routatic-proxy/main_models_test.go
@@ -169,6 +169,7 @@ func TestRunModelsList_MissingCatalog(t *testing.T) {
 
 	// Override the storage path to use a temp directory so we don't
 	// accidentally pick up the user's real catalog.
+	// NOTE: mutates package-level var — this test must NOT use t.Parallel().
 	origDBPath := storage.DefaultConfig.DatabasePath
 	storage.DefaultConfig.DatabasePath = filepath.Join(tmp, "data.db")
 	defer func() { storage.DefaultConfig.DatabasePath = origDBPath }()

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -61,7 +61,7 @@ func validateCatalog(catalog *Catalog) error {
 		return errors.New("catalog models map is empty")
 	}
 
-	var hasUnknown bool
+	var toDelete []string
 	for key := range catalog.Models {
 		provider := ProviderFromModelKey(key)
 		if provider == "" {
@@ -69,12 +69,15 @@ func validateCatalog(catalog *Catalog) error {
 		}
 		if _, ok := catalog.Providers[provider]; !ok {
 			slog.Warn("skipping model with unknown provider", "model", key, "provider", provider)
-			delete(catalog.Models, key)
-			hasUnknown = true
+			toDelete = append(toDelete, key)
 		}
 	}
 
-	if hasUnknown && len(catalog.Models) == 0 {
+	for _, key := range toDelete {
+		delete(catalog.Models, key)
+	}
+
+	if len(toDelete) > 0 && len(catalog.Models) == 0 {
 		return errors.New("all models reference unknown providers, catalog is unusable")
 	}
 

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 )
 
@@ -60,14 +61,21 @@ func validateCatalog(catalog *Catalog) error {
 		return errors.New("catalog models map is empty")
 	}
 
+	var hasUnknown bool
 	for key := range catalog.Models {
 		provider := ProviderFromModelKey(key)
 		if provider == "" {
 			return fmt.Errorf("model key %q does not include a provider prefix (expected format: provider/model)", key)
 		}
 		if _, ok := catalog.Providers[provider]; !ok {
-			return fmt.Errorf("model key %q references unknown provider %q", key, provider)
+			slog.Warn("skipping model with unknown provider", "model", key, "provider", provider)
+			delete(catalog.Models, key)
+			hasUnknown = true
 		}
+	}
+
+	if hasUnknown && len(catalog.Models) == 0 {
+		return errors.New("all models reference unknown providers, catalog is unusable")
 	}
 
 	return nil

--- a/internal/catalog/resolve.go
+++ b/internal/catalog/resolve.go
@@ -150,6 +150,18 @@ func (ic *IndexedCatalog) ListProviderModels(provider string) []ResolvedModel {
 		return nil
 	}
 
+	// Prefer the pre-built ProviderModels index (populated during Load /
+	// LoadFromSQLite). Fall back to iterating Models by key prefix for
+	// backward compatibility with hand-built catalogs (e.g. tests).
+	if len(ic.ProviderModels) > 0 {
+		models := ic.ProviderModels[provider]
+		result := make([]ResolvedModel, 0, len(models))
+		for _, model := range models {
+			result = append(result, resolvedModel(providerCfg, model.ID, model))
+		}
+		return result
+	}
+
 	prefix := provider + "/"
 	var result []ResolvedModel
 	for key, model := range ic.Models {


### PR DESCRIPTION
## What

Four fixes for the catalog and `models list` command:

1. **`catalog sync` now migrates JSON to SQLite** — previously it only downloaded the JSON file, so `models list` (which reads from SQLite) would always show "catalog not found".

2. **`validateCatalog()` handles orphan models gracefully** — the upstream catalog may contain models for providers not yet in the catalog. Instead of failing the entire sync, orphan models are now skipped with a warning. Currently 7 models are affected:
   - `deepreinforce/ornith-1.0-31b`
   - `deepreinforce/ornith-1.0-35b`
   - `deepreinforce/ornith-1.0-397b`
   - `deepreinforce/ornith-1.0-9b`
   - `meituan/longcat-2.0`
   - `microsoft/mai-code-1-flash`
   - `tencent/hy3-preview`

   These reference providers (`deepreinforce`, `meituan`, `microsoft`, `tencent`) not yet present in the upstream `providers` map.

3. **`ListProviderModels()` uses the pre-built index** — the new catalog format uses a `ProviderModels` map built during load. Previously it fell through to a `strings.HasPrefix` scan that did not match the new key format, returning 0 models.

4. **`models list` without `--provider` shows catalog providers** — instead of returning routing intermediaries with no models, it now lists all catalog providers that have models.

## Testing

- All 72 catalog tests pass
- All 32 main command tests pass (31 existing + 1 updated)
- Manually verified: `catalog sync` then `models list` shows all providers