### PR TITLE
fix: preserve ROUTATIC_PROXY_* env vars in launchd autostart

### DIFF
--- a/internal/daemon/autostart_darwin.go
+++ b/internal/daemon/autostart_darwin.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"text/template"
 )
 
@@ -53,6 +54,10 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <dict>
         <key>PATH</key>
         <string>{{.EnvPath}}</string>
+        {{- range $key, $val := .ExtraEnv}}
+        <key>{{$key}}</key>
+        <string>{{$val}}</string>
+        {{- end}}
     </dict>
 </dict>
 </plist>
@@ -66,6 +71,7 @@ type plistData struct {
 	Port       int
 	LogFile    string
 	EnvPath    string
+	ExtraEnv   map[string]string
 }
 
 // EnableAutostart creates the launchd plist and loads it.
@@ -89,6 +95,17 @@ func EnableAutostart(configPath string, port int) error {
 		envPath = "/usr/local/bin:/usr/bin:/bin"
 	}
 
+	extraEnv := make(map[string]string)
+	for _, e := range os.Environ() {
+		k, v, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(k, "ROUTATIC_PROXY_") {
+			extraEnv[k] = v
+		}
+	}
+
 	data := plistData{
 		Label:      LaunchAgent,
 		BinaryPath: paths.BinaryPath,
@@ -96,6 +113,7 @@ func EnableAutostart(configPath string, port int) error {
 		Port:       port,
 		LogFile:    paths.LogFile,
 		EnvPath:    envPath,
+		ExtraEnv:   extraEnv,
 	}
 
 	tmpl, err := template.New("plist").Parse(plistTemplate)

--- a/internal/daemon/autostart_darwin.go
+++ b/internal/daemon/autostart_darwin.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"fmt"
+	"html"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +57,7 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <string>{{.EnvPath}}</string>
         {{- range $key, $val := .ExtraEnv}}
         <key>{{$key}}</key>
-        <string>{{$val}}</string>
+        <string>{{xmlEscape $val}}</string>
         {{- end}}
     </dict>
 </dict>
@@ -116,7 +117,9 @@ func EnableAutostart(configPath string, port int) error {
 		ExtraEnv:   extraEnv,
 	}
 
-	tmpl, err := template.New("plist").Parse(plistTemplate)
+	tmpl, err := template.New("plist").Funcs(template.FuncMap{
+		"xmlEscape": html.EscapeString,
+	}).Parse(plistTemplate)
 	if err != nil {
 		return fmt.Errorf("cannot parse plist template: %w", err)
 	}

--- a/internal/daemon/autostart_darwin_test.go
+++ b/internal/daemon/autostart_darwin_test.go
@@ -40,8 +40,11 @@ func TestEnableDisableAutostart_Darwin(t *testing.T) {
 	if !strings.Contains(content, "<key>Label</key>\n    <string>com.routatic.proxy</string>") {
 		t.Errorf("Plist missing correct Label string")
 	}
-	if !strings.Contains(content, "<string>serve</string>") {
-		t.Errorf("Plist missing serve command")
+	if !strings.Contains(content, "<string>start</string>") {
+		t.Errorf("Plist missing start command")
+	}
+	if !strings.Contains(content, "<string>--background</string>") {
+		t.Errorf("Plist missing --background flag")
 	}
 	if !strings.Contains(content, "<string>--config</string>\n        <string>/tmp/mock-config.json</string>") {
 		t.Errorf("Plist missing config path arguments")

--- a/internal/daemon/autostart_darwin_test.go
+++ b/internal/daemon/autostart_darwin_test.go
@@ -13,6 +13,8 @@ func TestEnableDisableAutostart_Darwin(t *testing.T) {
 	// Setup temporary home directory
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
+	// Set a ROUTATIC_PROXY_* var with characters that need XML escaping.
+	t.Setenv("ROUTATIC_PROXY_API_KEY", "sk-test&key<value>")
 
 	configPath := "/tmp/mock-config.json"
 	port := 9999
@@ -51,6 +53,15 @@ func TestEnableDisableAutostart_Darwin(t *testing.T) {
 	}
 	if !strings.Contains(content, "<string>--port</string>\n        <string>9999</string>") {
 		t.Errorf("Plist missing port arguments")
+	}
+
+	// Verify ROUTATIC_PROXY_* env var is present and XML-escaped.
+	if !strings.Contains(content, "<key>ROUTATIC_PROXY_API_KEY</key>") {
+		t.Errorf("Plist missing ROUTATIC_PROXY_API_KEY env var")
+	}
+	// The value should be XML-escaped: & -> &amp;, < -> &lt;, > -> &gt;
+	if !strings.Contains(content, "<string>sk-test&amp;key&lt;value&gt;</string>") {
+		t.Errorf("Plist missing XML-escaped API key value. Content:\n%s", content)
 	}
 
 	// Disable autostart


### PR DESCRIPTION
## What

The launchd plist generated by `autostart enable` didn't include environment variables. When the proxy was started via launchd (e.g., at login), it would launch without `ROUTATIC_PROXY_API_KEY` and other configuration from the user's environment.

## Fix

Added `ExtraEnv` to the plist template and populate it from the current process environment, filtering for `ROUTATIC_PROXY_*` variables.

## Testing

- All daemon tests pass
- Manually verified plist contains env vars after `autostart enable`