### PR TITLE
fix(gui): 'Test model' dropdown, catalog refresh, and send request

### DIFF
--- a/cmd/routatic-proxy/main.go
+++ b/cmd/routatic-proxy/main.go
@@ -373,11 +373,13 @@ Press Ctrl+C to stop the server.`,
 			if !headless {
 				// Start GUI server on port 3445.
 				guiSrv = gui.New(gui.Options{
-					History:      srv.History,
-					Metrics:      srv.Metrics(),
-					AtomicConfig: atomicCfg,
-					ProxyPort:    cfg.Port,
-					Storage:      srv.Storage(),
+					History:          srv.History,
+					Metrics:          srv.Metrics(),
+					AtomicConfig:     atomicCfg,
+					ProxyPort:        cfg.Port,
+					Storage:          srv.Storage(),
+					CatalogDir:       resolveCatalogDir(configPath),
+					CatalogSourceURL: cfg.Catalog.SourceURL,
 				})
 				guiSrv.SetProxyRunning(true)
 

--- a/internal/gui/assets/app.js
+++ b/internal/gui/assets/app.js
@@ -1575,14 +1575,19 @@ const TestModule = {
     this.testModelSelect.innerHTML = '<option value="">Select a model...</option>';
 
     try {
-      const r = await fetch('/api/metrics');
+      const r = await fetch('/api/proxy/config');
       if (!r.ok) return;
       const data = await r.json();
-      const models = Object.keys(data.model_counts || {});
-      models.sort().forEach(m => {
+      const modelIds = new Set();
+      // Only collect model_overrides and model_family_overrides — the
+      // top-level "models" keys are routing scenarios (fast, default,
+      // long_context, etc.), not real model IDs.
+      Object.keys(data.model_overrides || {}).forEach(k => modelIds.add(k));
+      Object.keys(data.model_family_overrides || {}).forEach(k => modelIds.add(k));
+      [...modelIds].sort().forEach(id => {
         const opt = document.createElement('option');
-        opt.value = m;
-        opt.textContent = m;
+        opt.value = id;
+        opt.textContent = id;
         this.testModelSelect.appendChild(opt);
       });
     } catch (e) {}
@@ -1617,7 +1622,7 @@ const TestModule = {
 
     const start = performance.now();
     try {
-      const r = await fetch('/v1/messages', {
+      const r = await fetch('/api/test/send', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/internal/gui/server.go
+++ b/internal/gui/server.go
@@ -477,7 +477,7 @@ func (s *Server) handleTestSend(w http.ResponseWriter, r *http.Request) {
 	proxyURL := fmt.Sprintf("http://127.0.0.1:%d/v1/messages", proxyPort)
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxTestRequestBody)
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -504,7 +504,7 @@ func (s *Server) handleTestSend(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("proxy request failed: %v", err), http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// Copy status code and headers.
 	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))

--- a/internal/gui/server.go
+++ b/internal/gui/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -461,6 +462,8 @@ type catalogLockResponse struct {
 	Synced     bool       `json:"synced"`
 }
 
+const maxTestRequestBody = 1 << 20
+
 // handleTestSend proxies a chat request to the proxy server and streams the
 // response back. This avoids CORS issues that would arise from the browser
 // calling the proxy port directly.
@@ -473,13 +476,19 @@ func (s *Server) handleTestSend(w http.ResponseWriter, r *http.Request) {
 	proxyPort := s.getProxyPort()
 	proxyURL := fmt.Sprintf("http://127.0.0.1:%d/v1/messages", proxyPort)
 
-	// Read the incoming body.
+	r.Body = http.MaxBytesReader(w, r.Body, maxTestRequestBody)
+	defer r.Body.Close()
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "failed to read request body", http.StatusBadRequest)
 		return
 	}
-	defer r.Body.Close()
 
 	// Forward to the proxy.
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, proxyURL, bytes.NewReader(body))

--- a/internal/gui/server.go
+++ b/internal/gui/server.go
@@ -509,7 +509,14 @@ func (s *Server) handleTestSend(w http.ResponseWriter, r *http.Request) {
 	// Copy status code and headers.
 	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
 	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
+	written, err := io.Copy(w, resp.Body)
+	if err != nil {
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Error("failed to stream proxy response", "err", err, "bytes_written", written)
+	}
 }
 
 func (s *Server) handleCatalogLock(w http.ResponseWriter, r *http.Request) {

--- a/internal/gui/server.go
+++ b/internal/gui/server.go
@@ -3,10 +3,12 @@
 package gui
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net"
@@ -174,6 +176,7 @@ func (s *Server) Start(ctx context.Context) (string, error) {
 	mux.HandleFunc("/api/proxy/stop", s.handleProxyStop)
 	mux.HandleFunc("/api/catalog/lock", s.handleCatalogLock)
 	mux.HandleFunc("/api/catalog/sync", s.handleCatalogSync)
+	mux.HandleFunc("/api/test/send", s.handleTestSend)
 
 	// New endpoints for advanced GUI features
 
@@ -456,6 +459,48 @@ type catalogLockResponse struct {
 	TTLHours   int        `json:"ttl_hours,omitempty"`
 	AgeSeconds int64      `json:"age_seconds"`
 	Synced     bool       `json:"synced"`
+}
+
+// handleTestSend proxies a chat request to the proxy server and streams the
+// response back. This avoids CORS issues that would arise from the browser
+// calling the proxy port directly.
+func (s *Server) handleTestSend(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	proxyPort := s.getProxyPort()
+	proxyURL := fmt.Sprintf("http://127.0.0.1:%d/v1/messages", proxyPort)
+
+	// Read the incoming body.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// Forward to the proxy.
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, proxyURL, bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, "failed to create proxy request", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("proxy request failed: %v", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy status code and headers.
+	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 }
 
 func (s *Server) handleCatalogLock(w http.ResponseWriter, r *http.Request) {

--- a/internal/gui/server_test.go
+++ b/internal/gui/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -159,18 +160,6 @@ func TestHandleCatalogSync_UpstreamError(t *testing.T) {
 	}
 }
 
-func TestHandleTestSend_MethodNotAllowed(t *testing.T) {
-	s := &Server{}
-	req := httptest.NewRequest(http.MethodGet, "/api/test/send", nil)
-	rr := httptest.NewRecorder()
-
-	s.handleTestSend(rr, req)
-
-	if rr.Code != http.StatusMethodNotAllowed {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusMethodNotAllowed)
-	}
-}
-
 func TestHandleTestSend_RequestBodyTooLarge(t *testing.T) {
 	s := &Server{proxyPort: 1}
 	req := httptest.NewRequest(
@@ -187,18 +176,86 @@ func TestHandleTestSend_RequestBodyTooLarge(t *testing.T) {
 	}
 }
 
-func TestHandleTestSend_ForwardsRequest(t *testing.T) {
-	const requestBody = `{"model":"test-model","messages":[{"role":"user","content":"hello"}]}`
+func TestHandleTestSend(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		setup      func(t *testing.T) (*Server, func())
+		writer     func() http.ResponseWriter
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "method not allowed",
+			method:     http.MethodGet,
+			setup:      func(t *testing.T) (*Server, func()) { return &Server{}, func() {} },
+			writer:     func() http.ResponseWriter { return httptest.NewRecorder() },
+			wantStatus: http.StatusMethodNotAllowed,
+			wantBody:   "method not allowed\n",
+		},
+		{
+			name:   "successful post",
+			method: http.MethodPost,
+			setup: func(t *testing.T) (*Server, func()) {
+				return startTestSendProxy(t, `{"ok":true}`)
+			},
+			writer:     func() http.ResponseWriter { return httptest.NewRecorder() },
+			wantStatus: http.StatusOK,
+			wantBody:   `{"ok":true}`,
+		},
+		{
+			name:   "proxy connection failure",
+			method: http.MethodPost,
+			setup: func(t *testing.T) (*Server, func()) {
+				listener, err := net.Listen("tcp4", "127.0.0.1:0")
+				if err != nil {
+					t.Fatalf("reserve proxy port: %v", err)
+				}
+				port := listener.Addr().(*net.TCPAddr).Port
+				_ = listener.Close()
+				return &Server{proxyPort: port}, func() {}
+			},
+			writer:     func() http.ResponseWriter { return httptest.NewRecorder() },
+			wantStatus: http.StatusBadGateway,
+			wantBody:   "proxy request failed:",
+		},
+		{
+			name:   "client disconnect during stream",
+			method: http.MethodPost,
+			setup: func(t *testing.T) (*Server, func()) {
+				return startTestSendProxy(t, strings.Repeat("x", 128<<10))
+			},
+			writer:     func() http.ResponseWriter { return &failingResponseWriter{} },
+			wantStatus: http.StatusOK,
+		},
+	}
 
-	var gotMethod string
-	var gotContentType string
-	var gotBody []byte
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, cleanup := tt.setup(t)
+			defer cleanup()
+			s.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+			req := httptest.NewRequest(tt.method, "/api/test/send", strings.NewReader(`{"prompt":"hello"}`))
+			w := tt.writer()
+			s.handleTestSend(w, req)
+
+			if got := responseStatus(w); got != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", got, tt.wantStatus)
+			}
+			if tt.wantBody != "" && !strings.Contains(responseBody(w), tt.wantBody) {
+				t.Fatalf("body = %q, want it to contain %q", responseBody(w), tt.wantBody)
+			}
+		})
+	}
+}
+
+func startTestSendProxy(t *testing.T, responseBody string) (*Server, func()) {
+	t.Helper()
+
 	proxy := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotMethod = r.Method
-		gotContentType = r.Header.Get("Content-Type")
-		gotBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true}`))
+		_, _ = w.Write([]byte(responseBody))
 	}))
 	listener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
@@ -206,30 +263,49 @@ func TestHandleTestSend_ForwardsRequest(t *testing.T) {
 	}
 	proxy.Listener = listener
 	proxy.Start()
-	defer proxy.Close()
 
-	s := &Server{proxyPort: proxy.Listener.Addr().(*net.TCPAddr).Port}
-	req := httptest.NewRequest(http.MethodPost, "/api/test/send", strings.NewReader(requestBody))
-	rr := httptest.NewRecorder()
+	return &Server{proxyPort: proxy.Listener.Addr().(*net.TCPAddr).Port}, proxy.Close
+}
 
-	s.handleTestSend(rr, req)
+type failingResponseWriter struct {
+	header http.Header
+	status int
+	writes int
+}
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+func (w *failingResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
 	}
-	if gotMethod != http.MethodPost {
-		t.Fatalf("forwarded method = %q, want %q", gotMethod, http.MethodPost)
+	return w.header
+}
+
+func (w *failingResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *failingResponseWriter) Write(p []byte) (int, error) {
+	if w.writes > 0 {
+		return 0, io.ErrClosedPipe
 	}
-	if gotContentType != "application/json" {
-		t.Fatalf("forwarded content type = %q, want application/json", gotContentType)
+	w.writes++
+	return len(p), nil
+}
+
+func responseStatus(w http.ResponseWriter) int {
+	switch w := w.(type) {
+	case *httptest.ResponseRecorder:
+		return w.Code
+	case *failingResponseWriter:
+		return w.status
+	default:
+		panic("unsupported response writer")
 	}
-	if string(gotBody) != requestBody {
-		t.Fatalf("forwarded body = %q, want %q", gotBody, requestBody)
+}
+
+func responseBody(w http.ResponseWriter) string {
+	if recorder, ok := w.(*httptest.ResponseRecorder); ok {
+		return recorder.Body.String()
 	}
-	if rr.Header().Get("Content-Type") != "application/json" {
-		t.Fatalf("response content type = %q, want application/json", rr.Header().Get("Content-Type"))
-	}
-	if rr.Body.String() != `{"ok":true}` {
-		t.Fatalf("response body = %q, want %q", rr.Body.String(), `{"ok":true}`)
-	}
+	return ""
 }

--- a/internal/gui/server_test.go
+++ b/internal/gui/server_test.go
@@ -1,11 +1,15 @@
 package gui
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -152,5 +156,80 @@ func TestHandleCatalogSync_UpstreamError(t *testing.T) {
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestHandleTestSend_MethodNotAllowed(t *testing.T) {
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/test/send", nil)
+	rr := httptest.NewRecorder()
+
+	s.handleTestSend(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleTestSend_RequestBodyTooLarge(t *testing.T) {
+	s := &Server{proxyPort: 1}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/test/send",
+		bytes.NewReader(bytes.Repeat([]byte("x"), maxTestRequestBody+1)),
+	)
+	rr := httptest.NewRecorder()
+
+	s.handleTestSend(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestHandleTestSend_ForwardsRequest(t *testing.T) {
+	const requestBody = `{"model":"test-model","messages":[{"role":"user","content":"hello"}]}`
+
+	var gotMethod string
+	var gotContentType string
+	var gotBody []byte
+	proxy := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for proxy: %v", err)
+	}
+	proxy.Listener = listener
+	proxy.Start()
+	defer proxy.Close()
+
+	s := &Server{proxyPort: proxy.Listener.Addr().(*net.TCPAddr).Port}
+	req := httptest.NewRequest(http.MethodPost, "/api/test/send", strings.NewReader(requestBody))
+	rr := httptest.NewRecorder()
+
+	s.handleTestSend(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("forwarded method = %q, want %q", gotMethod, http.MethodPost)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("forwarded content type = %q, want application/json", gotContentType)
+	}
+	if string(gotBody) != requestBody {
+		t.Fatalf("forwarded body = %q, want %q", gotBody, requestBody)
+	}
+	if rr.Header().Get("Content-Type") != "application/json" {
+		t.Fatalf("response content type = %q, want application/json", rr.Header().Get("Content-Type"))
+	}
+	if rr.Body.String() != `{"ok":true}` {
+		t.Fatalf("response body = %q, want %q", rr.Body.String(), `{"ok":true}`)
 	}
 }


### PR DESCRIPTION
## What

Three fixes for the GUI "Test model" feature:

1. **Dropdown was empty** — `populateModels()` read from `/api/metrics` which only contains models that have already been proxied. Now reads from `/api/proxy/config` and shows `model_overrides` + `model_family_overrides` entries — actual routable model IDs, not routing scenarios.

2. **"Refresh catalog" silently failed** — the GUI server was initialized without `CatalogDir` or `CatalogSourceURL`, so `POST /api/catalog/sync` returned 503. `main.go` now passes these to the GUI server.

3. **"Send" returned 404** — `sendTest()` called `/v1/messages` on the GUI port (3445) instead of the proxy port (3456), and direct cross-origin fetch to the proxy port was blocked by CORS. Added `POST /api/test/send` on the GUI server which proxies the request to the proxy server-side — same-origin, no CORS needed.

## Testing

- All 9 GUI tests pass
- Manually verified: dropdown shows configured models, catalog refresh works, send gets a response