### PR TITLE
ci: add Windows code signing and resource generation to release workflows

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -125,33 +125,36 @@ jobs:
           echo "Built binaries:"
           ls -lh dist/
 
-      - name: Sign Windows binaries
-        if: env.WINDOWS_SIGN_CERT != ''
-        env:
-          WINDOWS_SIGN_CERT: ${{ secrets.WINDOWS_SIGN_CERT }}
-          WINDOWS_SIGN_KEY: ${{ secrets.WINDOWS_SIGN_KEY }}
+      - name: Package Windows binaries for signing
+        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
         run: |
-          brew install osslsigncode
+          mkdir -p signing
+          cp dist/routatic-proxy_windows-amd64.exe signing/
+          cp dist/routatic-proxy_windows-arm64.exe signing/
+          cd signing && zip ../windows-binaries.zip *.exe
 
-          # Decode certificate and key from base64 secrets
-          echo "$WINDOWS_SIGN_CERT" | base64 -d > /tmp/cert.pem
-          echo "$WINDOWS_SIGN_KEY" | base64 -d > /tmp/key.pem
+      - name: Sign Windows binaries (SignPath)
+        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        uses: signpath/github-action-submit-signing-request@ced31329c0317e779dad2eec2a7c3bb46ea1343e # v1
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: '5c4d4e48-c428-4e10-ab07-8db7f46cbec9'
+          project-slug: 'routatic-proxy'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'windows-exe'
+          github-artifact-id: 'windows-binaries'
+          input-artifact-path: 'windows-binaries.zip'
+          output-artifact-path: 'windows-binaries-signed.zip'
+          wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 300
 
-          for EXE in dist/routatic-proxy_windows-*.exe; do
-            echo "Signing ${EXE}..."
-            osslsigncode sign \
-              -certs /tmp/cert.pem \
-              -key /tmp/key.pem \
-              -t http://timestamp.digicert.com \
-              -n "Routatic Proxy" \
-              -url "https://github.com/routatic/proxy" \
-              -in "$EXE" \
-              -out "${EXE}.signed"
-            mv "${EXE}.signed" "$EXE"
-          done
-
-          # Clean up
-          rm -f /tmp/cert.pem /tmp/key.pem
+      - name: Replace with signed Windows binaries
+        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        run: |
+          unzip -o windows-binaries-signed.zip -d signed/
+          cp signed/routatic-proxy_windows-amd64.exe dist/routatic-proxy_windows-amd64.exe
+          cp signed/routatic-proxy_windows-arm64.exe dist/routatic-proxy_windows-arm64.exe
+          rm -rf signing signed windows-binaries.zip windows-binaries-signed.zip
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -69,6 +69,32 @@ jobs:
           echo "Production version: ${PROD_VERSION}"
           echo "Beta tag: ${BETA_VERSION}"
 
+      - name: Generate Windows resource files
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          go install github.com/tc-hib/go-winres@latest
+
+          # Parse version components (e.g., "0.5.3-beta.1" → "0.5.3.0")
+          CLEAN_VER=$(echo "$VERSION" | sed 's/-.*//')
+          MAJOR=$(echo "$CLEAN_VER" | cut -d. -f1)
+          MINOR=$(echo "$CLEAN_VER" | cut -d. -f2)
+          PATCH=$(echo "$CLEAN_VER" | cut -d. -f3)
+          FILE_VER="${MAJOR:-0}.${MINOR:-0}.${PATCH:-0}.0"
+
+          # Update version in winres.json
+          cd cmd/routatic-proxy
+          sed -i.bak "s/\"file_version\": \"0.0.0.0\"/\"file_version\": \"${FILE_VER}\"/" winres/winres.json
+          sed -i.bak "s/\"product_version\": \"0.0.0.0\"/\"product_version\": \"${FILE_VER}\"/" winres/winres.json
+          sed -i.bak "s/\"FileVersion\": \"0.0.0.0\"/\"FileVersion\": \"${VERSION}\"/" winres/winres.json
+          sed -i.bak "s/\"ProductVersion\": \"0.0.0.0\"/\"ProductVersion\": \"${VERSION}\"/" winres/winres.json
+          rm -f winres/winres.json.bak
+
+          # Generate .syso files for both Windows architectures
+          go-winres make --arch amd64 --out rsrc_windows_amd64.syso
+          go-winres make --arch arm64 --out rsrc_windows_arm64.syso
+          cd ../..
+
       - name: Build cross-platform binaries
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -98,6 +124,34 @@ jobs:
           echo ""
           echo "Built binaries:"
           ls -lh dist/
+
+      - name: Sign Windows binaries
+        if: env.WINDOWS_SIGN_CERT != ''
+        env:
+          WINDOWS_SIGN_CERT: ${{ secrets.WINDOWS_SIGN_CERT }}
+          WINDOWS_SIGN_KEY: ${{ secrets.WINDOWS_SIGN_KEY }}
+        run: |
+          brew install osslsigncode
+
+          # Decode certificate and key from base64 secrets
+          echo "$WINDOWS_SIGN_CERT" | base64 -d > /tmp/cert.pem
+          echo "$WINDOWS_SIGN_KEY" | base64 -d > /tmp/key.pem
+
+          for EXE in dist/routatic-proxy_windows-*.exe; do
+            echo "Signing ${EXE}..."
+            osslsigncode sign \
+              -certs /tmp/cert.pem \
+              -key /tmp/key.pem \
+              -t http://timestamp.digicert.com \
+              -n "Routatic Proxy" \
+              -url "https://github.com/routatic/proxy" \
+              -in "$EXE" \
+              -out "${EXE}.signed"
+            mv "${EXE}.signed" "$EXE"
+          done
+
+          # Clean up
+          rm -f /tmp/cert.pem /tmp/key.pem
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,33 +123,36 @@ jobs:
           echo "Built binaries:"
           ls -lh dist/
 
-      - name: Sign Windows binaries
-        if: env.WINDOWS_SIGN_CERT != ''
-        env:
-          WINDOWS_SIGN_CERT: ${{ secrets.WINDOWS_SIGN_CERT }}
-          WINDOWS_SIGN_KEY: ${{ secrets.WINDOWS_SIGN_KEY }}
+      - name: Package Windows binaries for signing
+        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
         run: |
-          brew install osslsigncode
+          mkdir -p signing
+          cp dist/routatic-proxy_windows-amd64.exe signing/
+          cp dist/routatic-proxy_windows-arm64.exe signing/
+          cd signing && zip ../windows-binaries.zip *.exe
 
-          # Decode certificate and key from base64 secrets
-          echo "$WINDOWS_SIGN_CERT" | base64 -d > /tmp/cert.pem
-          echo "$WINDOWS_SIGN_KEY" | base64 -d > /tmp/key.pem
+      - name: Sign Windows binaries (SignPath)
+        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        uses: signpath/github-action-submit-signing-request@ced31329c0317e779dad2eec2a7c3bb46ea1343e # v1
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: '5c4d4e48-c428-4e10-ab07-8db7f46cbec9'
+          project-slug: 'routatic-proxy'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'windows-exe'
+          github-artifact-id: 'windows-binaries'
+          input-artifact-path: 'windows-binaries.zip'
+          output-artifact-path: 'windows-binaries-signed.zip'
+          wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 300
 
-          for EXE in dist/routatic-proxy_windows-*.exe; do
-            echo "Signing ${EXE}..."
-            osslsigncode sign \
-              -certs /tmp/cert.pem \
-              -key /tmp/key.pem \
-              -t http://timestamp.digicert.com \
-              -n "Routatic Proxy" \
-              -url "https://github.com/routatic/proxy" \
-              -in "$EXE" \
-              -out "${EXE}.signed"
-            mv "${EXE}.signed" "$EXE"
-          done
-
-          # Clean up
-          rm -f /tmp/cert.pem /tmp/key.pem
+      - name: Replace with signed Windows binaries
+        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        run: |
+          unzip -o windows-binaries-signed.zip -d signed/
+          cp signed/routatic-proxy_windows-amd64.exe dist/routatic-proxy_windows-amd64.exe
+          cp signed/routatic-proxy_windows-arm64.exe dist/routatic-proxy_windows-arm64.exe
+          rm -rf signing signed windows-binaries.zip windows-binaries-signed.zip
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,31 @@ jobs:
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
           echo "Releasing as $TAG"
 
+      - name: Generate Windows resource files
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          go install github.com/tc-hib/go-winres@latest
+
+          # Parse version components (e.g., "0.5.3" → "0.5.3.0")
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          FILE_VER="${MAJOR:-0}.${MINOR:-0}.${PATCH:-0}.0"
+
+          # Update version in winres.json
+          cd cmd/routatic-proxy
+          sed -i.bak "s/\"file_version\": \"0.0.0.0\"/\"file_version\": \"${FILE_VER}\"/" winres/winres.json
+          sed -i.bak "s/\"product_version\": \"0.0.0.0\"/\"product_version\": \"${FILE_VER}\"/" winres/winres.json
+          sed -i.bak "s/\"FileVersion\": \"0.0.0.0\"/\"FileVersion\": \"${VERSION}\"/" winres/winres.json
+          sed -i.bak "s/\"ProductVersion\": \"0.0.0.0\"/\"ProductVersion\": \"${VERSION}\"/" winres/winres.json
+          rm -f winres/winres.json.bak
+
+          # Generate .syso files for both Windows architectures
+          go-winres make --arch amd64 --out rsrc_windows_amd64.syso
+          go-winres make --arch arm64 --out rsrc_windows_arm64.syso
+          cd ../..
+
       - name: Build cross-platform binaries
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -97,6 +122,34 @@ jobs:
           echo ""
           echo "Built binaries:"
           ls -lh dist/
+
+      - name: Sign Windows binaries
+        if: env.WINDOWS_SIGN_CERT != ''
+        env:
+          WINDOWS_SIGN_CERT: ${{ secrets.WINDOWS_SIGN_CERT }}
+          WINDOWS_SIGN_KEY: ${{ secrets.WINDOWS_SIGN_KEY }}
+        run: |
+          brew install osslsigncode
+
+          # Decode certificate and key from base64 secrets
+          echo "$WINDOWS_SIGN_CERT" | base64 -d > /tmp/cert.pem
+          echo "$WINDOWS_SIGN_KEY" | base64 -d > /tmp/key.pem
+
+          for EXE in dist/routatic-proxy_windows-*.exe; do
+            echo "Signing ${EXE}..."
+            osslsigncode sign \
+              -certs /tmp/cert.pem \
+              -key /tmp/key.pem \
+              -t http://timestamp.digicert.com \
+              -n "Routatic Proxy" \
+              -url "https://github.com/routatic/proxy" \
+              -in "$EXE" \
+              -out "${EXE}.signed"
+            mv "${EXE}.signed" "$EXE"
+          done
+
+          # Clean up
+          rm -f /tmp/cert.pem /tmp/key.pem
 
       - name: Generate checksums
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ router.test
 .playwright-mcp
 .gstack/
 node_modules/
+
+# Generated Windows resource files (built by go-winres in CI)
+*.syso

--- a/cmd/routatic-proxy/winres/winres.json
+++ b/cmd/routatic-proxy/winres/winres.json
@@ -1,0 +1,47 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "Routatic.Proxy",
+          "version": "0.0.0.0"
+        },
+        "description": "Routatic Proxy - AI Model Router",
+        "minimum-os": "win7",
+        "execution-level": "asInvoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": true,
+        "gdi-scaling": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "AI model routing proxy for Claude Code",
+            "CompanyName": "Routatic",
+            "FileDescription": "Routatic Proxy - AI Model Router",
+            "FileVersion": "0.0.0.0",
+            "InternalName": "routatic-proxy",
+            "LegalCopyright": "Copyright (c) 2024-2026 Routatic",
+            "OriginalFilename": "routatic-proxy.exe",
+            "ProductName": "Routatic Proxy",
+            "ProductVersion": "0.0.0.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/routatic-proxy/winres/winres.xml
+++ b/cmd/routatic-proxy/winres/winres.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    type="win32"
+    name="Routatic.Proxy"
+    version="0.0.0.0"
+    processorArchitecture="*"/>
+  <description>Routatic Proxy - AI Model Router</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 / 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
 ## Summary

  - Add Windows version info and application manifest via go-winres (embeds publisher, product name, version, and OS compatibility into the .exe — reduces SmartScreen false positives)
  - Add SignPath code signing integration for Authenticode signatures on Windows binaries
  - Signing is gated on `SIGNPATH_API_TOKEN` secret — builds still succeed without it

  ## Context

  Fixes #52 — Windows Defender was quarantining the binary because it had no embedded metadata, no application manifest, and no digital signature. An unsigned, stripped Go binary that writes to the registry Run key looks suspicious to heuristic
  scanners.