### PR TITLE
fix: use env context for SignPath secret check in release workflows

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check signing availability
         id: signing
         env:
-          USE_SIGNPATH: ${{ secrets.USE_SIGNPATH }}
+          USE_SIGNPATH: ${{ vars.USE_SIGNPATH }}
         run: echo "enabled=$([ "$USE_SIGNPATH" = "true" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Get versions

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Check signing availability
         id: signing
         env:
-          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
-        run: echo "enabled=$([ -n "$SIGNPATH_API_TOKEN" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          USE_SIGNPATH: ${{ secrets.USE_SIGNPATH }}
+        run: echo "enabled=$([ "$USE_SIGNPATH" = "true" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Get versions
         id: version

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -131,13 +131,20 @@ jobs:
           echo "Built binaries:"
           ls -lh dist/
 
-      - name: Package Windows binaries for signing
+      - name: Stage Windows binaries for signing
         if: ${{ steps.signing.outputs.enabled == 'true' }}
         run: |
           mkdir -p signing
           cp dist/routatic-proxy_windows-amd64.exe signing/
           cp dist/routatic-proxy_windows-arm64.exe signing/
-          cd signing && zip ../windows-binaries.zip *.exe
+
+      - name: Upload unsigned Windows binaries
+        id: upload-unsigned
+        if: ${{ steps.signing.outputs.enabled == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-binaries-unsigned
+          path: signing/
 
       - name: Sign Windows binaries (SignPath)
         if: ${{ steps.signing.outputs.enabled == 'true' }}
@@ -148,19 +155,17 @@ jobs:
           project-slug: 'routatic-proxy'
           signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'windows-exe'
-          github-artifact-id: 'windows-binaries'
-          input-artifact-path: 'windows-binaries.zip'
-          output-artifact-path: 'windows-binaries-signed.zip'
+          github-artifact-id: '${{ steps.upload-unsigned.outputs.artifact-id }}'
           wait-for-completion: true
+          output-artifact-directory: 'signed'
           wait-for-completion-timeout-in-seconds: 300
 
       - name: Replace with signed Windows binaries
         if: ${{ steps.signing.outputs.enabled == 'true' }}
         run: |
-          unzip -o windows-binaries-signed.zip -d signed/
           cp signed/routatic-proxy_windows-amd64.exe dist/routatic-proxy_windows-amd64.exe
           cp signed/routatic-proxy_windows-arm64.exe dist/routatic-proxy_windows-arm64.exe
-          rm -rf signing signed windows-binaries.zip windows-binaries-signed.zip
+          rm -rf signing signed
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -36,8 +36,6 @@ jobs:
     name: Build & Release
     needs: validate
     runs-on: macos-latest
-    env:
-      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     outputs:
       beta_tag: ${{ steps.version.outputs.beta_tag }}
       prod_version: ${{ steps.version.outputs.prod_version }}
@@ -50,6 +48,12 @@ jobs:
         with:
           go-version: "1.25"
           cache: true
+
+      - name: Check signing availability
+        id: signing
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: echo "enabled=$([ -n "$SIGNPATH_API_TOKEN" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Get versions
         id: version
@@ -75,7 +79,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          go install github.com/tc-hib/go-winres@latest
+          go install github.com/tc-hib/go-winres@v0.3.3
 
           # Parse version components (e.g., "0.5.3-beta.1" → "0.5.3.0")
           CLEAN_VER=$(echo "$VERSION" | sed 's/-.*//')
@@ -128,7 +132,7 @@ jobs:
           ls -lh dist/
 
       - name: Package Windows binaries for signing
-        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ steps.signing.outputs.enabled == 'true' }}
         run: |
           mkdir -p signing
           cp dist/routatic-proxy_windows-amd64.exe signing/
@@ -136,7 +140,7 @@ jobs:
           cd signing && zip ../windows-binaries.zip *.exe
 
       - name: Sign Windows binaries (SignPath)
-        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ steps.signing.outputs.enabled == 'true' }}
         uses: signpath/github-action-submit-signing-request@ced31329c0317e779dad2eec2a7c3bb46ea1343e # v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -151,7 +155,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 300
 
       - name: Replace with signed Windows binaries
-        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ steps.signing.outputs.enabled == 'true' }}
         run: |
           unzip -o windows-binaries-signed.zip -d signed/
           cp signed/routatic-proxy_windows-amd64.exe dist/routatic-proxy_windows-amd64.exe

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -266,7 +266,7 @@ jobs:
             if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "null" ]; then
               echo "Warning: AI changelog generation failed, using commit list instead" >&2
               echo "API response: $RESPONSE" >&2
-              CHANGELOG="## Commits\n\n$(git log \"${PREVIOUS_TAG}..HEAD\" --pretty=format:'- %s')"
+              CHANGELOG="## Commits\n\n$(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:'- %s')"
             fi
           else
             echo "No previous tag found, using commit list"

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -36,6 +36,8 @@ jobs:
     name: Build & Release
     needs: validate
     runs-on: macos-latest
+    env:
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     outputs:
       beta_tag: ${{ steps.version.outputs.beta_tag }}
       prod_version: ${{ steps.version.outputs.prod_version }}
@@ -126,7 +128,7 @@ jobs:
           ls -lh dist/
 
       - name: Package Windows binaries for signing
-        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
         run: |
           mkdir -p signing
           cp dist/routatic-proxy_windows-amd64.exe signing/
@@ -134,7 +136,7 @@ jobs:
           cd signing && zip ../windows-binaries.zip *.exe
 
       - name: Sign Windows binaries (SignPath)
-        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
         uses: signpath/github-action-submit-signing-request@ced31329c0317e779dad2eec2a7c3bb46ea1343e # v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -149,7 +151,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 300
 
       - name: Replace with signed Windows binaries
-        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
         run: |
           unzip -o windows-binaries-signed.zip -d signed/
           cp signed/routatic-proxy_windows-amd64.exe dist/routatic-proxy_windows-amd64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
     name: Build & Release
     needs: validate
     runs-on: macos-latest
+    env:
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
@@ -124,7 +126,7 @@ jobs:
           ls -lh dist/
 
       - name: Package Windows binaries for signing
-        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
         run: |
           mkdir -p signing
           cp dist/routatic-proxy_windows-amd64.exe signing/
@@ -132,7 +134,7 @@ jobs:
           cd signing && zip ../windows-binaries.zip *.exe
 
       - name: Sign Windows binaries (SignPath)
-        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
         uses: signpath/github-action-submit-signing-request@ced31329c0317e779dad2eec2a7c3bb46ea1343e # v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -147,7 +149,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 300
 
       - name: Replace with signed Windows binaries
-        if: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
         run: |
           unzip -o windows-binaries-signed.zip -d signed/
           cp signed/routatic-proxy_windows-amd64.exe dist/routatic-proxy_windows-amd64.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Check signing availability
         id: signing
         env:
-          USE_SIGNPATH: ${{ secrets.USE_SIGNPATH }}
+          USE_SIGNPATH: ${{ vars.USE_SIGNPATH }}
         run: echo "enabled=$([ "$USE_SIGNPATH" = "true" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Determine version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,13 +129,20 @@ jobs:
           echo "Built binaries:"
           ls -lh dist/
 
-      - name: Package Windows binaries for signing
+      - name: Stage Windows binaries for signing
         if: ${{ steps.signing.outputs.enabled == 'true' }}
         run: |
           mkdir -p signing
           cp dist/routatic-proxy_windows-amd64.exe signing/
           cp dist/routatic-proxy_windows-arm64.exe signing/
-          cd signing && zip ../windows-binaries.zip *.exe
+
+      - name: Upload unsigned Windows binaries
+        id: upload-unsigned
+        if: ${{ steps.signing.outputs.enabled == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-binaries-unsigned
+          path: signing/
 
       - name: Sign Windows binaries (SignPath)
         if: ${{ steps.signing.outputs.enabled == 'true' }}
@@ -146,19 +153,17 @@ jobs:
           project-slug: 'routatic-proxy'
           signing-policy-slug: 'release-signing'
           artifact-configuration-slug: 'windows-exe'
-          github-artifact-id: 'windows-binaries'
-          input-artifact-path: 'windows-binaries.zip'
-          output-artifact-path: 'windows-binaries-signed.zip'
+          github-artifact-id: '${{ steps.upload-unsigned.outputs.artifact-id }}'
           wait-for-completion: true
+          output-artifact-directory: 'signed'
           wait-for-completion-timeout-in-seconds: 300
 
       - name: Replace with signed Windows binaries
         if: ${{ steps.signing.outputs.enabled == 'true' }}
         run: |
-          unzip -o windows-binaries-signed.zip -d signed/
           cp signed/routatic-proxy_windows-amd64.exe dist/routatic-proxy_windows-amd64.exe
           cp signed/routatic-proxy_windows-arm64.exe dist/routatic-proxy_windows-arm64.exe
-          rm -rf signing signed windows-binaries.zip windows-binaries-signed.zip
+          rm -rf signing signed
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
             if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "null" ]; then
               echo "Warning: AI changelog generation failed, using commit list instead" >&2
               echo "API response: $RESPONSE" >&2
-              CHANGELOG="## Commits\n\n$(git log \"${PREVIOUS_TAG}..HEAD\" --pretty=format:'- %s')"
+              CHANGELOG="## Commits\n\n$(git log "${PREVIOUS_TAG}..HEAD" --pretty=format:'- %s')"
             fi
           else
             echo "No previous tag found, using commit list"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Check signing availability
         id: signing
         env:
-          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
-        run: echo "enabled=$([ -n "$SIGNPATH_API_TOKEN" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          USE_SIGNPATH: ${{ secrets.USE_SIGNPATH }}
+        run: echo "enabled=$([ "$USE_SIGNPATH" = "true" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Determine version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
     name: Build & Release
     needs: validate
     runs-on: macos-latest
-    env:
-      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
@@ -53,6 +51,12 @@ jobs:
         with:
           go-version: "1.25"
           cache: true
+
+      - name: Check signing availability
+        id: signing
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: echo "enabled=$([ -n "$SIGNPATH_API_TOKEN" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
       - name: Determine version
         id: version
@@ -74,7 +78,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          go install github.com/tc-hib/go-winres@latest
+          go install github.com/tc-hib/go-winres@v0.3.3
 
           # Parse version components (e.g., "0.5.3" → "0.5.3.0")
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
@@ -126,7 +130,7 @@ jobs:
           ls -lh dist/
 
       - name: Package Windows binaries for signing
-        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ steps.signing.outputs.enabled == 'true' }}
         run: |
           mkdir -p signing
           cp dist/routatic-proxy_windows-amd64.exe signing/
@@ -134,7 +138,7 @@ jobs:
           cd signing && zip ../windows-binaries.zip *.exe
 
       - name: Sign Windows binaries (SignPath)
-        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ steps.signing.outputs.enabled == 'true' }}
         uses: signpath/github-action-submit-signing-request@ced31329c0317e779dad2eec2a7c3bb46ea1343e # v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -149,7 +153,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 300
 
       - name: Replace with signed Windows binaries
-        if: ${{ env.SIGNPATH_API_TOKEN != '' }}
+        if: ${{ steps.signing.outputs.enabled == 'true' }}
         run: |
           unzip -o windows-binaries-signed.zip -d signed/
           cp signed/routatic-proxy_windows-amd64.exe dist/routatic-proxy_windows-amd64.exe


### PR DESCRIPTION
The 'secrets' context cannot be used in step-level if: conditions, which made the Release workflow fail to parse on workflow_dispatch. Map the secret to a job-level env var and check that instead.