### PR TITLE
fix: handle function_call in Responses streaming (muse-spark-1.2-contributor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ node_modules/
 
 # Generated Windows resource files (built by go-winres in CI)
 *.syso
+.trunk/plugins/*

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -3,11 +3,13 @@
 This file defines the review standards for routatic-proxy. It is designed for LLM-based review tools, CI/CD pipelines, and human reviewers. Each check is tagged with its layer and severity.
 
 **Severity:**
+
 - **BLOCKER** — must fix before merge
 - **REQUIRED** — should fix, merge only with justification
 - **ADVISORY** — best practice, consider
 
 **Layers:**
+
 - `[T]` — Technical (Go idioms, safety, concurrency)
 - `[L]` — Logical (correctness, edge cases, data flow)
 - `[B]` — Business/Architecture (domain invariants, config, release)
@@ -18,85 +20,85 @@ This file defines the review standards for routatic-proxy. It is designed for LL
 
 ### 1.1 Go Idioms
 
-| # | Check | Severity | Source |
-|---|-------|----------|--------|
-| T1 | Exported symbols have doc comments (`// Package`, `// TypeName`, `// FuncName`) | REQUIRED | CONTRIBUTING.md |
-| T2 | Constructors use `New<TypeName>` pattern, return pointer, apply defaults for nil/zero params | REQUIRED | `rules/auto-detected/CONSTRUCTOR_PATTERN.md` |
-| T3 | `context.Context` is the first parameter in functions that accept it | REQUIRED | `rules/auto-detected/CONTEXT_PROPAGATION.md` |
-| T4 | Per-attempt contexts use `context.WithTimeout`; `cancel()` is always called (defer or explicit) | REQUIRED | `rules/auto-detected/CONTEXT_PROPAGATION.md` |
-| T5 | Loop boundaries check `ctx.Err()` to respect cancellation | REQUIRED | `rules/auto-detected/CONTEXT_PROPAGATION.md` |
-| T6 | Errors use `fmt.Errorf("context: %w", err)` wrapping, never bare `return err` | REQUIRED | `rules/auto-detected/ERROR_HANDLING.md` |
-| T7 | Sentinel errors declared as `var ErrX = errors.New("...")` at package level | ADVISORY | `rules/auto-detected/ERROR_HANDLING.md` |
-| T8 | Error classification via `func IsXError(err error) bool` helpers, not `strings.Contains` | REQUIRED | `rules/auto-detected/ERROR_HANDLING.md` |
-| T9 | Polymorphic Anthropic fields (`system`, `content`) use `json.RawMessage` with accessor methods | REQUIRED | `rules/auto-detected/JSON_RAWMESSAGE.md` |
-| T10 | Accessors try simplest format first (string before array), fallback to raw bytes | REQUIRED | `rules/auto-detected/JSON_RAWMESSAGE.md` |
-| T11 | Logging uses `log/slog` with key-value pairs, never `log.Printf` or `fmt.Println` for diagnostics | REQUIRED | `rules/auto-detected/SLOG_LOGGING.md` |
-| T12 | Log levels: Debug=routine, Info=significant events, Warn=recoverable issues, Error=failures | REQUIRED | `rules/auto-detected/SLOG_LOGGING.md` |
-| T13 | Nil logger defaults to `slog.Default()` | ADVISORY | `rules/auto-detected/SLOG_LOGGING.md` |
-| T14 | `sync.Mutex` embedded in structs, `mu.Lock()` / `defer mu.Unlock()` pattern | REQUIRED | `rules/auto-detected/SYNC_MUTEX.md` |
-| T15 | Separate mutexes for independent state (not one big lock) | ADVISORY | `rules/auto-detected/SYNC_MUTEX.md` |
-| T16 | Use `sync.RWMutex` when reads dominate writes | ADVISORY | `rules/auto-detected/SYNC_MUTEX.md` |
-| T17 | Ensure `gofmt` compliance (run `make lint`) | BLOCKER | CONTRIBUTING.md |
-| T18 | All files compile with `CGO_ENABLED=0 go build` (default) | BLOCKER | Makefile |
+| #   | Check                                                                                             | Severity | Source                                       |
+| --- | ------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------- |
+| T1  | Exported symbols have doc comments (`// Package`, `// TypeName`, `// FuncName`)                   | REQUIRED | CONTRIBUTING.md                              |
+| T2  | Constructors use `New<TypeName>` pattern, return pointer, apply defaults for nil/zero params      | REQUIRED | `rules/auto-detected/CONSTRUCTOR_PATTERN.md` |
+| T3  | `context.Context` is the first parameter in functions that accept it                              | REQUIRED | `rules/auto-detected/CONTEXT_PROPAGATION.md` |
+| T4  | Per-attempt contexts use `context.WithTimeout`; `cancel()` is always called (defer or explicit)   | REQUIRED | `rules/auto-detected/CONTEXT_PROPAGATION.md` |
+| T5  | Loop boundaries check `ctx.Err()` to respect cancellation                                         | REQUIRED | `rules/auto-detected/CONTEXT_PROPAGATION.md` |
+| T6  | Errors use `fmt.Errorf("context: %w", err)` wrapping, never bare `return err`                     | REQUIRED | `rules/auto-detected/ERROR_HANDLING.md`      |
+| T7  | Sentinel errors declared as `var ErrX = errors.New("...")` at package level                       | ADVISORY | `rules/auto-detected/ERROR_HANDLING.md`      |
+| T8  | Error classification via `func IsXError(err error) bool` helpers, not `strings.Contains`          | REQUIRED | `rules/auto-detected/ERROR_HANDLING.md`      |
+| T9  | Polymorphic Anthropic fields (`system`, `content`) use `json.RawMessage` with accessor methods    | REQUIRED | `rules/auto-detected/JSON_RAWMESSAGE.md`     |
+| T10 | Accessors try simplest format first (string before array), fallback to raw bytes                  | REQUIRED | `rules/auto-detected/JSON_RAWMESSAGE.md`     |
+| T11 | Logging uses `log/slog` with key-value pairs, never `log.Printf` or `fmt.Println` for diagnostics | REQUIRED | `rules/auto-detected/SLOG_LOGGING.md`        |
+| T12 | Log levels: Debug=routine, Info=significant events, Warn=recoverable issues, Error=failures       | REQUIRED | `rules/auto-detected/SLOG_LOGGING.md`        |
+| T13 | Nil logger defaults to `slog.Default()`                                                           | ADVISORY | `rules/auto-detected/SLOG_LOGGING.md`        |
+| T14 | `sync.Mutex` embedded in structs, `mu.Lock()` / `defer mu.Unlock()` pattern                       | REQUIRED | `rules/auto-detected/SYNC_MUTEX.md`          |
+| T15 | Separate mutexes for independent state (not one big lock)                                         | ADVISORY | `rules/auto-detected/SYNC_MUTEX.md`          |
+| T16 | Use `sync.RWMutex` when reads dominate writes                                                     | ADVISORY | `rules/auto-detected/SYNC_MUTEX.md`          |
+| T17 | Ensure `gofmt` compliance (run `make lint`)                                                       | BLOCKER  | CONTRIBUTING.md                              |
+| T18 | All files compile with `CGO_ENABLED=0 go build` (default)                                         | BLOCKER  | Makefile                                     |
 
 ### 1.2 Memory & Resource Safety
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| T19 | `defer` is not used inside `for`/`for-range` loops (runs on function return, leaks resources) | BLOCKER | TOCTOU + leak pattern |
-| T20 | HTTP response bodies are closed explicitly (not deferred in loops) | BLOCKER | Resource leak |
-| T21 | Test-bind-then-close (TOCTOU) patterns are absent — listeners are bound once and kept | BLOCKER | Race condition |
-| T22 | `defer cancel()` or explicit `cancel()` present for every `context.WithTimeout`/`WithCancel` | REQUIRED | Context leak |
-| T23 | No goroutine leaks: goroutines have a shutdown signal (ctx.Done(), channel close, WaitGroup) | REQUIRED | Production reliability |
-| T24 | No `panic()` in library code; recover only at top-level HTTP handler boundaries | REQUIRED | Crash safety |
+| #   | Check                                                                                         | Severity | Rationale              |
+| --- | --------------------------------------------------------------------------------------------- | -------- | ---------------------- |
+| T19 | `defer` is not used inside `for`/`for-range` loops (runs on function return, leaks resources) | BLOCKER  | TOCTOU + leak pattern  |
+| T20 | HTTP response bodies are closed explicitly (not deferred in loops)                            | BLOCKER  | Resource leak          |
+| T21 | Test-bind-then-close (TOCTOU) patterns are absent — listeners are bound once and kept         | BLOCKER  | Race condition         |
+| T22 | `defer cancel()` or explicit `cancel()` present for every `context.WithTimeout`/`WithCancel`  | REQUIRED | Context leak           |
+| T23 | No goroutine leaks: goroutines have a shutdown signal (ctx.Done(), channel close, WaitGroup)  | REQUIRED | Production reliability |
+| T24 | No `panic()` in library code; recover only at top-level HTTP handler boundaries               | REQUIRED | Crash safety           |
 
 ### 1.3 Frontend (HTML/CSS/JS)
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| T25 | No external CDN scripts or stylesheets — all assets bundled via `//go:embed` | REQUIRED | Offline capability, CSP, supply-chain |
-| T26 | CSP header restricts `default-src 'self'`; only `'unsafe-inline'` for scripts and styles | REQUIRED | XSS mitigation |
-| T27 | No inline `onclick`/`onchange` handlers referencing undefined functions (check against app.js) | REQUIRED | Silent failures |
-| T28 | `data-i18n` keys exist in `TRANSLATIONS.en` (and `TRANSLATIONS.zh` if Chinese) | REQUIRED | i18n completeness |
-| T29 | Translations use `t(key)` function, not direct string references | REQUIRED | I18n correctness |
-| T30 | No `confirm()`/`prompt()`/`alert()` in production code — use modal or `<select>` instead | ADVISORY | UX quality |
-| T31 | Loading states shown during data fetches (spinner or skeleton) | ADVISORY | UX quality |
-| T32 | `/api/*` endpoints accessed by the frontend correspond to real backend handlers | REQUIRED | 404 errors |
+| #   | Check                                                                                          | Severity | Rationale                             |
+| --- | ---------------------------------------------------------------------------------------------- | -------- | ------------------------------------- |
+| T25 | No external CDN scripts or stylesheets — all assets bundled via `//go:embed`                   | REQUIRED | Offline capability, CSP, supply-chain |
+| T26 | CSP header restricts `default-src 'self'`; only `'unsafe-inline'` for scripts and styles       | REQUIRED | XSS mitigation                        |
+| T27 | No inline `onclick`/`onchange` handlers referencing undefined functions (check against app.js) | REQUIRED | Silent failures                       |
+| T28 | `data-i18n` keys exist in `TRANSLATIONS.en` (and `TRANSLATIONS.zh` if Chinese)                 | REQUIRED | i18n completeness                     |
+| T29 | Translations use `t(key)` function, not direct string references                               | REQUIRED | I18n correctness                      |
+| T30 | No `confirm()`/`prompt()`/`alert()` in production code — use modal or `<select>` instead       | ADVISORY | UX quality                            |
+| T31 | Loading states shown during data fetches (spinner or skeleton)                                 | ADVISORY | UX quality                            |
+| T32 | `/api/*` endpoints accessed by the frontend correspond to real backend handlers                | REQUIRED | 404 errors                            |
 
 ### 1.4 Configuration & Secrets
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| T33 | API keys loaded from env vars or config file, never hardcoded | BLOCKER | Security |
-| T34 | Config values support `${VAR}` env interpolation | REQUIRED | `internal/config/loader.go` |
-| T35 | Provider-specific keys (`*_API_KEY`) take precedence over global; documented precedence chain | REQUIRED | CLAUDE.md |
-| T36 | Port numbers are configurable via env var or CLI flag, not hardcoded | ADVISORY | Deploy flexibility |
-| T37 | Config file writes are atomic (write temp, rename) | REQUIRED | Crash safety |
+| #   | Check                                                                                         | Severity | Rationale                   |
+| --- | --------------------------------------------------------------------------------------------- | -------- | --------------------------- |
+| T33 | API keys loaded from env vars or config file, never hardcoded                                 | BLOCKER  | Security                    |
+| T34 | Config values support `${VAR}` env interpolation                                              | REQUIRED | `internal/config/loader.go` |
+| T35 | Provider-specific keys (`*_API_KEY`) take precedence over global; documented precedence chain | REQUIRED | CLAUDE.md                   |
+| T36 | Port numbers are configurable via env var or CLI flag, not hardcoded                          | ADVISORY | Deploy flexibility          |
+| T37 | Config file writes are atomic (write temp, rename)                                            | REQUIRED | Crash safety                |
 
 ### 1.5 Documentation Completeness
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| T38 | Every exported symbol has a `// <Name>` doc comment — packages, types, funcs, consts, vars | REQUIRED | CONTRIBUTING.md, godoc |
-| T39 | Package-level doc comments describe the package's responsibility, not its file contents | REQUIRED | Go convention |
-| T40 | Non-obvious logic has inline comments explaining *why*, not *what* | REQUIRED | Maintainability |
-| T41 | Config changes (new fields, changed defaults, removed keys) update the example config and CLAUDE.md | REQUIRED | First-run UX, LLM accuracy |
-| T42 | API endpoint changes update any user-facing docs (README, ARCHITECTURE, CLAUDE.md) | REQUIRED | Alignment — code vs docs |
-| T43 | CHANGELOG or release notes updated for user-facing changes (new features, breaking changes, deprecations) | REQUIRED | Release readiness |
-| T44 | `docs/` directory or inline `.md` files in the affected package are updated to reflect the change | ADVISORY | Discoverability |
-| T45 | Deprecated symbols use `// Deprecated:` doc comment with migration path | ADVISORY | API hygiene |
+| #   | Check                                                                                                     | Severity | Rationale                  |
+| --- | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------- |
+| T38 | Every exported symbol has a `// <Name>` doc comment — packages, types, funcs, consts, vars                | REQUIRED | CONTRIBUTING.md, godoc     |
+| T39 | Package-level doc comments describe the package's responsibility, not its file contents                   | REQUIRED | Go convention              |
+| T40 | Non-obvious logic has inline comments explaining _why_, not _what_                                        | REQUIRED | Maintainability            |
+| T41 | Config changes (new fields, changed defaults, removed keys) update the example config and CLAUDE.md       | REQUIRED | First-run UX, LLM accuracy |
+| T42 | API endpoint changes update any user-facing docs (README, ARCHITECTURE, CLAUDE.md)                        | REQUIRED | Alignment — code vs docs   |
+| T43 | CHANGELOG or release notes updated for user-facing changes (new features, breaking changes, deprecations) | REQUIRED | Release readiness          |
+| T44 | `docs/` directory or inline `.md` files in the affected package are updated to reflect the change         | ADVISORY | Discoverability            |
+| T45 | Deprecated symbols use `// Deprecated:` doc comment with migration path                                   | ADVISORY | API hygiene                |
 
 ### 1.6 Duplication & Reuse
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| T46 | New code first searches for existing helpers, types, or packages that already serve the purpose — no reinventing | REQUIRED | DRY, consistency |
-| T47 | Shared logic (field mapping, type conversion, JSON construction) is extracted to named helpers, not duplicated inline | REQUIRED | Single source of truth |
-| T48 | Repeated field-map patterns between types use a helper function, not copy-paste blocks | REQUIRED | `internal/catalog/migrate.go` precedent |
-| T49 | New scenarios, fallbacks, or model configs use existing mechanisms (scenario map, config struct, catalog), not inline conditionals | REQUIRED | Config-driven architecture |
-| T50 | Common transformations (Anthropic↔OpenAI field renames, token math, cost lookups) use the existing `internal/transformer/` or `internal/catalog/` packages — no ad-hoc reimplementation | REQUIRED | Correctness, maintainability |
-| T51 | New types reuse existing project types (e.g. `pkg/types.Message`), not inline structs | REQUIRED | API contract integrity |
-| T52 | Existing constructor, error, logger, and mutex patterns are followed — not one-off alternatives | ADVISORY | `rules/auto-detected/` consistency |
+| #   | Check                                                                                                                                                                                   | Severity | Rationale                               |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------------------------------------- |
+| T46 | New code first searches for existing helpers, types, or packages that already serve the purpose — no reinventing                                                                        | REQUIRED | DRY, consistency                        |
+| T47 | Shared logic (field mapping, type conversion, JSON construction) is extracted to named helpers, not duplicated inline                                                                   | REQUIRED | Single source of truth                  |
+| T48 | Repeated field-map patterns between types use a helper function, not copy-paste blocks                                                                                                  | REQUIRED | `internal/catalog/migrate.go` precedent |
+| T49 | New scenarios, fallbacks, or model configs use existing mechanisms (scenario map, config struct, catalog), not inline conditionals                                                      | REQUIRED | Config-driven architecture              |
+| T50 | Common transformations (Anthropic↔OpenAI field renames, token math, cost lookups) use the existing `internal/transformer/` or `internal/catalog/` packages — no ad-hoc reimplementation | REQUIRED | Correctness, maintainability            |
+| T51 | New types reuse existing project types (e.g. `pkg/types.Message`), not inline structs                                                                                                   | REQUIRED | API contract integrity                  |
+| T52 | Existing constructor, error, logger, and mutex patterns are followed — not one-off alternatives                                                                                         | ADVISORY | `rules/auto-detected/` consistency      |
 
 ---
 
@@ -104,39 +106,39 @@ This file defines the review standards for routatic-proxy. It is designed for LL
 
 ### 2.1 Correctness
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| L1 | Map value mutations re-assign to map: `v.Field = x; m[key] = v` (value type semantics in Go) | BLOCKER | Silent data loss |
-| L2 | All branches of conditional assignments are complete — no omitted fields | REQUIRED | Data inconsistency |
-| L3 | Fallback chain iteration correctly identifies the primary model (index 0) vs fallbacks | REQUIRED | Routing correctness |
-| L4 | Circuit breaker counts only retryable errors (5xx), not 4xx or client cancellation | REQUIRED | `internal/router/fallback.go` |
-| L5 | Stream idle timeout is per-`Read`, not server-level `WriteTimeout` | REQUIRED | CLAUDE.md stream policy |
-| L6 | Client disconnects during stream are logged at Debug, not Error | REQUIRED | CLAUDE.md stream policy |
-| L7 | `hasToolUsage` checks only unambiguous tool-calling patterns, not everyday words like "bash" | REQUIRED | False positives |
-| L8 | Model fallbacks carry correct config (provider, temperature, max_tokens) — not just model_id | REQUIRED | Config-driven routing |
+| #   | Check                                                                                        | Severity | Rationale                     |
+| --- | -------------------------------------------------------------------------------------------- | -------- | ----------------------------- |
+| L1  | Map value mutations re-assign to map: `v.Field = x; m[key] = v` (value type semantics in Go) | BLOCKER  | Silent data loss              |
+| L2  | All branches of conditional assignments are complete — no omitted fields                     | REQUIRED | Data inconsistency            |
+| L3  | Fallback chain iteration correctly identifies the primary model (index 0) vs fallbacks       | REQUIRED | Routing correctness           |
+| L4  | Circuit breaker counts only retryable errors (5xx), not 4xx or client cancellation           | REQUIRED | `internal/router/fallback.go` |
+| L5  | Stream idle timeout is per-`Read`, not server-level `WriteTimeout`                           | REQUIRED | CLAUDE.md stream policy       |
+| L6  | Client disconnects during stream are logged at Debug, not Error                              | REQUIRED | CLAUDE.md stream policy       |
+| L7  | `hasToolUsage` checks only unambiguous tool-calling patterns, not everyday words like "bash" | REQUIRED | False positives               |
+| L8  | Model fallbacks carry correct config (provider, temperature, max_tokens) — not just model_id | REQUIRED | Config-driven routing         |
 
 ### 2.2 Edge Cases
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| L9 | Nil `history.History` or `metrics.Metrics` returns zero values, not panics | REQUIRED | CLAUDE.md nil safety |
-| L10 | Empty model chain returns an informative error, not panic/empty response | REQUIRED | First-run UX |
-| L11 | Zero token count, zero cost, empty trend data render as `—` not `$NaN` or `undefined` | REQUIRED | Analytics dashboard |
-| L12 | Headless mode (`--headless`, `serve`) does not attempt GUI operations | REQUIRED | Cross-platform |
-| L13 | Port-scan fallback (GUI port 3445→3454) notifies user, doesn't silently pick different port | ADVISORY | User awareness |
-| L14 | JSON body is limited with `http.MaxBytesReader` before parsing | REQUIRED | DOS prevention |
-| L15 | SSE stream transformers handle partial/incomplete JSON chunks without panic | REQUIRED | Streaming robustness |
+| #   | Check                                                                                       | Severity | Rationale            |
+| --- | ------------------------------------------------------------------------------------------- | -------- | -------------------- |
+| L9  | Nil `history.History` or `metrics.Metrics` returns zero values, not panics                  | REQUIRED | CLAUDE.md nil safety |
+| L10 | Empty model chain returns an informative error, not panic/empty response                    | REQUIRED | First-run UX         |
+| L11 | Zero token count, zero cost, empty trend data render as `—` not `$NaN` or `undefined`       | REQUIRED | Analytics dashboard  |
+| L12 | Headless mode (`--headless`, `serve`) does not attempt GUI operations                       | REQUIRED | Cross-platform       |
+| L13 | Port-scan fallback (GUI port 3445→3454) notifies user, doesn't silently pick different port | ADVISORY | User awareness       |
+| L14 | JSON body is limited with `http.MaxBytesReader` before parsing                              | REQUIRED | DOS prevention       |
+| L15 | SSE stream transformers handle partial/incomplete JSON chunks without panic                 | REQUIRED | Streaming robustness |
 
 ### 2.3 Data Flow
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| L16 | Analytics cost query uses `SUM(tokens * COALESCE(rate, 0))` not `SUM(tokens) * rate` | BLOCKER | Per-model pricing |
-| L17 | JSON field names in Go struct tags match what the frontend reads | BLOCKER | KPI correctness |
-| L18 | Frontend references backend struct fields by their JSON tag, not Go field name | BLOCKER | Serialization mismatch |
-| L19 | Auto-detected scenario keys in FallbackModule match config model keys (no hardcoded subset) | REQUIRED | Feature detection |
-| L20 | Fallback save patch sends `{fallbacks: {scenario1: [...], ...}}` matching actual config structure | REQUIRED | Config integrity |
-| L21 | Catalog resolution silently degrades with a warning log when catalog is unavailable | REQUIRED | Debuggability |
+| #   | Check                                                                                             | Severity | Rationale              |
+| --- | ------------------------------------------------------------------------------------------------- | -------- | ---------------------- |
+| L16 | Analytics cost query uses `SUM(tokens * COALESCE(rate, 0))` not `SUM(tokens) * rate`              | BLOCKER  | Per-model pricing      |
+| L17 | JSON field names in Go struct tags match what the frontend reads                                  | BLOCKER  | KPI correctness        |
+| L18 | Frontend references backend struct fields by their JSON tag, not Go field name                    | BLOCKER  | Serialization mismatch |
+| L19 | Auto-detected scenario keys in FallbackModule match config model keys (no hardcoded subset)       | REQUIRED | Feature detection      |
+| L20 | Fallback save patch sends `{fallbacks: {scenario1: [...], ...}}` matching actual config structure | REQUIRED | Config integrity       |
+| L21 | Catalog resolution silently degrades with a warning log when catalog is unavailable               | REQUIRED | Debuggability          |
 
 ---
 
@@ -144,44 +146,44 @@ This file defines the review standards for routatic-proxy. It is designed for LL
 
 ### 3.1 Routing Invariants
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| B1 | Model routing is config-driven, not code-driven — adding a model requires zero Go changes | BLOCKER | CLAUDE.md architecture |
-| B2 | Scenario detection priority is: Long Context > Complex > Think > Background > Default | REQUIRED | `internal/router/scenarios.go` |
-| B3 | Streaming requests use fast models (Qwen3.7 Plus) for better TTFT | REQUIRED | CLAUDE.md |
-| B4 | Vision requests route to vision-capable models; non-vision models reject image content | REQUIRED | Capability check |
-| B5 | Cost-based routing filters by constraints (tools, vision, reasoning, context) before sorting by price | REQUIRED | `internal/router/selector.go` |
-| B6 | `respect_requested_model` bypasses scenario routing; provider-qualified refs that fail catalog resolution return error | REQUIRED | `internal/router/model_router.go` |
+| #   | Check                                                                                                                  | Severity | Rationale                         |
+| --- | ---------------------------------------------------------------------------------------------------------------------- | -------- | --------------------------------- |
+| B1  | Model routing is config-driven, not code-driven — adding a model requires zero Go changes                              | BLOCKER  | CLAUDE.md architecture            |
+| B2  | Scenario detection priority is: Long Context > Complex > Think > Background > Default                                  | REQUIRED | `internal/router/scenarios.go`    |
+| B3  | Streaming requests use fast models (Qwen3.7 Plus) for better TTFT                                                      | REQUIRED | CLAUDE.md                         |
+| B4  | Vision requests route to vision-capable models; non-vision models reject image content                                 | REQUIRED | Capability check                  |
+| B5  | Cost-based routing filters by constraints (tools, vision, reasoning, context) before sorting by price                  | REQUIRED | `internal/router/selector.go`     |
+| B6  | `respect_requested_model` bypasses scenario routing; provider-qualified refs that fail catalog resolution return error | REQUIRED | `internal/router/model_router.go` |
 
 ### 3.2 Provider & Model Integrity
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| B7 | Anthropic tool format disabled models (`anthropic_tools_disabled: true`) route through Chat Completions transform | REQUIRED | CLAUDE.md |
-| B8 | Bedrock xAI models get `/openai` path appended; other Bedrock models use standard path | REQUIRED | `internal/provider/aws_bedrock.go` |
-| B9 | Catalog schema: models keyed as `provider/model-name`, resolved via `Resolve`/`ResolveShort` | REQUIRED | `internal/catalog/resolve.go` |
-| B10 | Catalog seed prices are idempotent — update only where `cost_input_per_m IS NULL OR 0` | REQUIRED | `internal/storage/database.go` |
-| B11 | Free-tier models seed-price matching: specific entries first, `-free` generic catch-all as fallback | ADVISORY | `seed_prices.json` ordering |
+| #   | Check                                                                                                             | Severity | Rationale                          |
+| --- | ----------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------- |
+| B7  | Anthropic tool format disabled models (`anthropic_tools_disabled: true`) route through Chat Completions transform | REQUIRED | CLAUDE.md                          |
+| B8  | Bedrock xAI models get `/openai` path appended; other Bedrock models use standard path                            | REQUIRED | `internal/provider/aws_bedrock.go` |
+| B9  | Catalog schema: models keyed as `provider/model-name`, resolved via `Resolve`/`ResolveShort`                      | REQUIRED | `internal/catalog/resolve.go`      |
+| B10 | Catalog seed prices are idempotent — update only where `cost_input_per_m IS NULL OR 0`                            | REQUIRED | `internal/storage/database.go`     |
+| B11 | Free-tier models seed-price matching: specific entries first, `-free` generic catch-all as fallback               | ADVISORY | `seed_prices.json` ordering        |
 
 ### 3.3 Release & Build
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| B12 | `make build` runs `build-css` before `go build` (Tailwind CSS generation) | BLOCKER | Frontend asset delivery |
-| B13 | `make test` runs with `-race` detector | REQUIRED | CONTRIBUTING.md |
-| B14 | `make lint` checks `gofmt` and `go vet` | REQUIRED | CONTRIBUTING.md |
-| B15 | Beta releases auto-generated on push to `main`; production releases manual on `releases` branch | REQUIRED | CLAUDE.md |
-| B16 | Version follows `vX.Y.Z` for production, `vX.Y.Z-beta.TIMESTAMP` for beta | REQUIRED | CLAUDE.md |
-| B17 | Docker image builds with `CGO_ENABLED=0` for portability | REQUIRED | Cross-platform |
+| #   | Check                                                                                           | Severity | Rationale               |
+| --- | ----------------------------------------------------------------------------------------------- | -------- | ----------------------- |
+| B12 | `make build` runs `build-css` before `go build` (Tailwind CSS generation)                       | BLOCKER  | Frontend asset delivery |
+| B13 | `make test` runs with `-race` detector                                                          | REQUIRED | CONTRIBUTING.md         |
+| B14 | `make lint` checks `gofmt` and `go vet`                                                         | REQUIRED | CONTRIBUTING.md         |
+| B15 | Beta releases auto-generated on push to `main`; production releases manual on `releases` branch | REQUIRED | CLAUDE.md               |
+| B16 | Version follows `vX.Y.Z` for production, `vX.Y.Z-beta.TIMESTAMP` for beta                       | REQUIRED | CLAUDE.md               |
+| B17 | Docker image builds with `CGO_ENABLED=0` for portability                                        | REQUIRED | Cross-platform          |
 
 ### 3.4 API Contract
 
-| # | Check | Severity | Rationale |
-|---|-------|----------|-----------|
-| B18 | `POST /v1/messages` accepts and returns Anthropic Messages API format | BLOCKER | Claude Code compatibility |
-| B19 | SSE events are transformed in-flight, not buffered | REQUIRED | CLAUDE.md |
-| B20 | `/health` returns 200 with `{"status":"ok"}` | REQUIRED | Health checks |
-| B21 | Dashboard `/api/*` endpoints are under `internal/gui/` and require no auth (local-only) | REQUIRED | Design decision |
+| #   | Check                                                                                   | Severity | Rationale                 |
+| --- | --------------------------------------------------------------------------------------- | -------- | ------------------------- |
+| B18 | `POST /v1/messages` accepts and returns Anthropic Messages API format                   | BLOCKER  | Claude Code compatibility |
+| B19 | SSE events are transformed in-flight, not buffered                                      | REQUIRED | CLAUDE.md                 |
+| B20 | `/health` returns 200 with `{"status":"ok"}`                                            | REQUIRED | Health checks             |
+| B21 | Dashboard `/api/*` endpoints are under `internal/gui/` and require no auth (local-only) | REQUIRED | Design decision           |
 
 ---
 
@@ -189,20 +191,20 @@ This file defines the review standards for routatic-proxy. It is designed for LL
 
 These are always judgement calls. A documented repo standard overrides any smell check.
 
-| # | Smell | What to look for | Severity |
-|---|-------|------------------|----------|
-| S1 | **Mysterious Name** | Function/variable/type name doesn't reveal what it does or holds | ADVISORY |
-| S2 | **Duplicated Code** | Same logic shape in more than one hunk or file → check T46–T48 | ADVISORY |
-| S3 | **Feature Envy** | Method reaches into another object's data more than its own | ADVISORY |
-| S4 | **Data Clumps** | Same fields/params travelling together ← extract to a type | ADVISORY |
-| S5 | **Primitive Obsession** | String for a domain concept that deserves its own small type | ADVISORY |
-| S6 | **Repeated Switches** | Same switch/if-cascade on same type recurs across the change | ADVISORY |
-| S7 | **Shotgun Surgery** | One logical change forces scattered edits across many files | ADVISORY |
-| S8 | **Divergent Change** | One file modified for several unrelated reasons | ADVISORY |
-| S9 | **Speculative Generality** | Abstraction/params/hooks for needs the spec doesn't have | ADVISORY |
-| S10 | **Message Chains** | Long `a.b().c().d()` navigation | ADVISORY |
-| S11 | **Middle Man** | Class/function that mostly just delegates onward | ADVISORY |
-| S12 | **Refused Bequest** | Subclass/implementer ignores most of what it inherits | ADVISORY |
+| #   | Smell                      | What to look for                                                 | Severity |
+| --- | -------------------------- | ---------------------------------------------------------------- | -------- |
+| S1  | **Mysterious Name**        | Function/variable/type name doesn't reveal what it does or holds | ADVISORY |
+| S2  | **Duplicated Code**        | Same logic shape in more than one hunk or file → check T46–T48   | ADVISORY |
+| S3  | **Feature Envy**           | Method reaches into another object's data more than its own      | ADVISORY |
+| S4  | **Data Clumps**            | Same fields/params travelling together ← extract to a type       | ADVISORY |
+| S5  | **Primitive Obsession**    | String for a domain concept that deserves its own small type     | ADVISORY |
+| S6  | **Repeated Switches**      | Same switch/if-cascade on same type recurs across the change     | ADVISORY |
+| S7  | **Shotgun Surgery**        | One logical change forces scattered edits across many files      | ADVISORY |
+| S8  | **Divergent Change**       | One file modified for several unrelated reasons                  | ADVISORY |
+| S9  | **Speculative Generality** | Abstraction/params/hooks for needs the spec doesn't have         | ADVISORY |
+| S10 | **Message Chains**         | Long `a.b().c().d()` navigation                                  | ADVISORY |
+| S11 | **Middle Man**             | Class/function that mostly just delegates onward                 | ADVISORY |
+| S12 | **Refused Bequest**        | Subclass/implementer ignores most of what it inherits            | ADVISORY |
 
 ---
 
@@ -264,20 +266,24 @@ Report them side by side, never reranked into a single score — a change can pa
 
 **Universal rules (all files):** T38–T45 (documentation), T46 (search before invent), T47 (extract shared logic), T48 (no copy-paste mapping), T50 (reuse transformer/catalog), T51 (reuse project types), T52 (follow established patterns), S2 (no duplicated code), S6 (no repeated switches), S7 (shotgun surgery).
 
-| File / Package | Applicable Rules |
-|----------------|-----------------|
-| `internal/router/` | T3, T4, T5, T6, T14, T15, L3, L4, L8, B1–B6 |
-| `internal/handlers/` | T9, T10, T11, T24, L15, B18, B19, B20 |
-| `internal/transformer/` | T9, T10, L15, B18 |
-| `internal/client/` | T4, T6, T22, B7 |
-| `internal/provider/` | T3, T4, T6, B8 |
-| `internal/gui/` | T25–T32, T36, L9, L13, L17–L20, B12, B21 |
-| `internal/storage/` | T1, L16, L21, B10, B11 |
-| `internal/catalog/` | L21, B9 |
-| `internal/config/` | T34, T35, T37 |
-| `internal/metrics/` | T14, T15, T23 |
-| `internal/server/` | T19, T20, T21, T26 |
-| `internal/daemon/` | T22, L12 |
-| `cmd/routatic-proxy/` | T17, T18, T36, L12, B12–B17 |
-| `internal/gui/assets/` | T25–T32 |
-| `pkg/types/` | T9, T10 |
+| File / Package          | Applicable Rules                            |
+| ----------------------- | ------------------------------------------- |
+| `internal/router/`      | T3, T4, T5, T6, T14, T15, L3, L4, L8, B1–B6 |
+| `internal/handlers/`    | T9, T10, T11, T24, L15, B18, B19, B20       |
+| `internal/transformer/` | T9, T10, L15, B18                           |
+| `internal/client/`      | T4, T6, T22, B7                             |
+| `internal/provider/`    | T3, T4, T6, B8                              |
+| `internal/gui/`         | T25–T32, T36, L9, L13, L17–L20, B12, B21    |
+| `internal/storage/`     | T1, L16, L21, B10, B11                      |
+| `internal/catalog/`     | L21, B9                                     |
+| `internal/config/`      | T34, T35, T37                               |
+| `internal/metrics/`     | T14, T15, T23                               |
+| `internal/server/`      | T19, T20, T21, T26                          |
+| `internal/daemon/`      | T22, L12                                    |
+| `cmd/routatic-proxy/`   | T17, T18, T36, L12, B12–B17                 |
+| `internal/gui/assets/`  | T25–T32                                     |
+| `pkg/types/`            | T9, T10                                     |
+
+## 7. Tests
+
+Tautological tests considered harmful

--- a/internal/provider/opencode_go_wireformat_test.go
+++ b/internal/provider/opencode_go_wireformat_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -175,5 +176,86 @@ func TestOpenCodeGoProvider_ExecuteResponses_Override(t *testing.T) {
 	}
 	if !strings.Contains(string(result.Body), "hi") {
 		t.Errorf("Execute() body = %s, want it to contain the assistant text", result.Body)
+	}
+}
+
+// TestOpenCodeGoProvider_ExecuteResponses_ToolRoundTrip sends a 3-message tool
+// round-trip (user text -> assistant tool_use -> user tool_result) and asserts
+// the request body the server receives contains a function_call item followed
+// by a function_call_output item for the same call id, and no item that is
+// neither typed nor role+content (the shape that 400s upstream).
+func TestOpenCodeGoProvider_ExecuteResponses_ToolRoundTrip(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.ResponsesResponse{
+			ID: "resp-tool", Object: "response", Created: 1, Model: "muse-spark-1.2-contributor",
+			Output: []types.ResponsesOutput{{
+				Type: "message", Role: "assistant",
+				Content: []types.ResponsesContent{{Type: "output_text", Text: "done"}},
+			}},
+			Usage: types.ResponsesUsage{InputTokens: 1, OutputTokens: 1},
+		})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIKey:     "test-key",
+		OpenCodeGo: config.OpenCodeGoConfig{BaseURL: "http://127.0.0.1:1", ResponsesBaseURL: server.URL},
+	}
+	p := NewOpenCodeGoProvider(config.NewAtomicConfig(cfg, ""))
+
+	model := config.ModelConfig{ModelID: "muse-spark-1.2-contributor", WireFormat: "responses"}
+	req := &core.NormalizedRequest{
+		Model: model.ModelID,
+		Messages: []core.NormalizedMessage{
+			{Role: "user", Blocks: []core.NormalizedContentBlock{{Type: "text", Text: "What's the weather?"}}},
+			{Role: "assistant", Blocks: []core.NormalizedContentBlock{
+				{Type: "text", Text: "Let me check."},
+				{Type: "tool_use", ID: "t1", Name: "get_weather", Input: json.RawMessage(`{"location":"SF"}`)},
+			}},
+			{Role: "user", Blocks: []core.NormalizedContentBlock{
+				{Type: "tool_result", ToolUseID: "t1", Content: json.RawMessage(`"72F"`)},
+			}},
+		},
+	}
+
+	if _, err := p.Execute(context.Background(), req, model); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var rr types.ResponsesRequest
+	if err := json.Unmarshal(gotBody, &rr); err != nil {
+		t.Fatalf("request body is not a valid ResponsesRequest: %v\nbody: %s", err, gotBody)
+	}
+
+	callIdx, outputIdx := -1, -1
+	for i, item := range rr.Input {
+		if item.Type == "" && (item.Role == "" || len(item.Content) == 0) {
+			t.Errorf("input[%d] is neither typed nor role+content: %+v", i, item)
+		}
+		switch item.Type {
+		case "function_call":
+			callIdx = i
+			if item.CallID != "t1" || item.Name != "get_weather" {
+				t.Errorf("function_call item = %+v, want call_id t1 / name get_weather", item)
+			}
+		case "function_call_output":
+			outputIdx = i
+			if item.CallID != "t1" {
+				t.Errorf("function_call_output item = %+v, want call_id t1", item)
+			}
+		}
+	}
+
+	if callIdx == -1 {
+		t.Error("no function_call item in request body")
+	}
+	if outputIdx == -1 {
+		t.Error("no function_call_output item in request body")
+	}
+	if callIdx != -1 && outputIdx != -1 && callIdx > outputIdx {
+		t.Errorf("function_call at %d must precede function_call_output at %d", callIdx, outputIdx)
 	}
 }

--- a/internal/transformer/normalized_bridge.go
+++ b/internal/transformer/normalized_bridge.go
@@ -2,6 +2,7 @@ package transformer
 
 import (
 	"encoding/json"
+	"log/slog"
 
 	"github.com/routatic/proxy/internal/config"
 	"github.com/routatic/proxy/internal/core"
@@ -102,6 +103,11 @@ func NormalizedToResponses(req *core.NormalizedRequest, model config.ModelConfig
 				})
 			default:
 				flushText()
+				slog.Warn(
+					"dropping unsupported Responses input block",
+					"type", block.Type,
+					"role", msg.Role,
+				)
 			}
 		}
 		flushText()

--- a/internal/transformer/normalized_bridge.go
+++ b/internal/transformer/normalized_bridge.go
@@ -58,40 +58,53 @@ func NormalizedToResponses(req *core.NormalizedRequest, model config.ModelConfig
 	// Convert messages. The Responses API rejects any input item that does not
 	// match a supported shape, so tool_use/tool_result blocks become typed
 	// items (function_call / function_call_output) instead of being folded
-	// into text. Text is emitted before tool items so an assistant message
-	// that leads with text keeps its natural ordering.
+	// into text. Walk the canonical block list directly to preserve chronology.
 	for _, msg := range req.Messages {
-		// Remaining text becomes a role-based item. The Responses API only
-		// knows user/assistant/developer roles; anything else maps to user.
-		if content := msg.TextContent(); content != "" {
-			role := msg.Role
-			if role != "user" && role != "assistant" && role != "developer" {
-				role = "user"
+		role := msg.Role
+		if role != "user" && role != "assistant" && role != "developer" {
+			role = "user"
+		}
+
+		var text string
+		flushText := func() {
+			if text == "" {
+				return
 			}
 			responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
 				Role:    role,
-				Content: rawJSONString(content),
+				Content: rawJSONString(text),
 			})
+			text = ""
 		}
 
-		// Assistant tool calls become function_call items.
-		for _, tc := range msg.ToolCallsList() {
-			responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
-				Type:      "function_call",
-				CallID:    tc.ID,
-				Name:      tc.Name,
-				Arguments: tc.Arguments,
-			})
+		toolResults := msg.ToolResultsList()
+		toolResultIndex := 0
+		for _, block := range msg.Blocks {
+			switch block.Type {
+			case "text":
+				text += block.Text
+			case "tool_use":
+				flushText()
+				responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
+					Type:      "function_call",
+					CallID:    block.ID,
+					Name:      block.Name,
+					Arguments: string(block.Input),
+				})
+			case "tool_result":
+				flushText()
+				tr := toolResults[toolResultIndex]
+				toolResultIndex++
+				responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
+					Type:   "function_call_output",
+					CallID: tr.ToolCallID,
+					Output: rawJSONString(tr.Content),
+				})
+			default:
+				flushText()
+			}
 		}
-
-		// Tool results become function_call_output items.
-		for _, tr := range msg.ToolResultsList() {
-			responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
-				Type:   "function_call_output",
-				CallID: tr.ToolCallID,
-				Output: rawJSONString(tr.Content),
-			})
-		}
+		flushText()
 	}
 
 	// Convert tools.

--- a/internal/transformer/normalized_bridge.go
+++ b/internal/transformer/normalized_bridge.go
@@ -55,20 +55,43 @@ func NormalizedToResponses(req *core.NormalizedRequest, model config.ModelConfig
 		})
 	}
 
-	// Convert messages.
+	// Convert messages. The Responses API rejects any input item that does not
+	// match a supported shape, so tool_use/tool_result blocks become typed
+	// items (function_call / function_call_output) instead of being folded
+	// into text. Text is emitted before tool items so an assistant message
+	// that leads with text keeps its natural ordering.
 	for _, msg := range req.Messages {
-		input := types.ResponsesInput{Role: msg.Role}
-		content := msg.TextContent()
+		// Remaining text becomes a role-based item. The Responses API only
+		// knows user/assistant/developer roles; anything else maps to user.
+		if content := msg.TextContent(); content != "" {
+			role := msg.Role
+			if role != "user" && role != "assistant" && role != "developer" {
+				role = "user"
+			}
+			responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
+				Role:    role,
+				Content: rawJSONString(content),
+			})
+		}
 
-		// For assistant messages with tool calls, serialize as text.
+		// Assistant tool calls become function_call items.
 		for _, tc := range msg.ToolCallsList() {
-			content += "[Tool: " + tc.Name + "(" + tc.Arguments + ")]"
+			responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
+				Type:      "function_call",
+				CallID:    tc.ID,
+				Name:      tc.Name,
+				Arguments: tc.Arguments,
+			})
 		}
 
-		if content != "" {
-			input.Content = rawJSONString(content)
+		// Tool results become function_call_output items.
+		for _, tr := range msg.ToolResultsList() {
+			responsesReq.Input = append(responsesReq.Input, types.ResponsesInput{
+				Type:   "function_call_output",
+				CallID: tr.ToolCallID,
+				Output: rawJSONString(tr.Content),
+			})
 		}
-		responsesReq.Input = append(responsesReq.Input, input)
 	}
 
 	// Convert tools.

--- a/internal/transformer/normalized_bridge_responses_test.go
+++ b/internal/transformer/normalized_bridge_responses_test.go
@@ -1,0 +1,124 @@
+package transformer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/routatic/proxy/internal/config"
+	"github.com/routatic/proxy/internal/core"
+)
+
+// TestNormalizedToResponses_ToolResultOnlyMessage pins the regression that
+// 400s muse-spark-1.2-contributor: a user message whose only content is a
+// tool_result used to emit {"role":"user"} with no content, which the
+// Responses API rejects.
+func TestNormalizedToResponses_ToolResultOnlyMessage(t *testing.T) {
+	req := &core.NormalizedRequest{
+		Model: "muse-spark-1.2-contributor",
+		Messages: []core.NormalizedMessage{{
+			Role: "user",
+			Blocks: []core.NormalizedContentBlock{{
+				Type: "tool_result", ToolUseID: "t1",
+				Content: json.RawMessage(`"42"`),
+			}},
+		}},
+	}
+
+	responsesReq := NormalizedToResponses(req, config.ModelConfig{ModelID: "muse-spark-1.2-contributor"})
+
+	if len(responsesReq.Input) != 1 {
+		t.Fatalf("input count = %d, want 1", len(responsesReq.Input))
+	}
+	item := responsesReq.Input[0]
+	if item.Type != "function_call_output" {
+		t.Errorf("item type = %q, want function_call_output", item.Type)
+	}
+	if item.CallID != "t1" {
+		t.Errorf("call_id = %q, want t1", item.CallID)
+	}
+	if string(item.Output) != `"42"` {
+		t.Errorf("output = %s, want \"42\"", item.Output)
+	}
+	if item.Role != "" {
+		t.Errorf("role = %q, want empty for a typed item", item.Role)
+	}
+}
+
+// TestNormalizedToResponses_AssistantToolUseMessage verifies tool_use blocks
+// become typed function_call items instead of being folded into text.
+func TestNormalizedToResponses_AssistantToolUseMessage(t *testing.T) {
+	req := &core.NormalizedRequest{
+		Model: "muse-spark-1.2-contributor",
+		Messages: []core.NormalizedMessage{{
+			Role: "assistant",
+			Blocks: []core.NormalizedContentBlock{{
+				Type: "tool_use", ID: "t1", Name: "get_weather",
+				Input: json.RawMessage(`{"location":"SF"}`),
+			}},
+		}},
+	}
+
+	responsesReq := NormalizedToResponses(req, config.ModelConfig{ModelID: "muse-spark-1.2-contributor"})
+
+	if len(responsesReq.Input) != 1 {
+		t.Fatalf("input count = %d, want 1", len(responsesReq.Input))
+	}
+	item := responsesReq.Input[0]
+	if item.Type != "function_call" {
+		t.Errorf("item type = %q, want function_call", item.Type)
+	}
+	if item.CallID != "t1" {
+		t.Errorf("call_id = %q, want t1", item.CallID)
+	}
+	if item.Name != "get_weather" {
+		t.Errorf("name = %q, want get_weather", item.Name)
+	}
+	if item.Arguments != `{"location":"SF"}` {
+		t.Errorf("arguments = %q, want the raw JSON", item.Arguments)
+	}
+}
+
+// TestNormalizedToResponses_ThinkingOnlyMessage verifies a message whose only
+// content is thinking emits no input item.
+func TestNormalizedToResponses_ThinkingOnlyMessage(t *testing.T) {
+	req := &core.NormalizedRequest{
+		Model: "muse-spark-1.2-contributor",
+		Messages: []core.NormalizedMessage{{
+			Role:   "assistant",
+			Blocks: []core.NormalizedContentBlock{{Type: "thinking", Thinking: "hmm"}},
+		}},
+	}
+
+	responsesReq := NormalizedToResponses(req, config.ModelConfig{ModelID: "muse-spark-1.2-contributor"})
+
+	if len(responsesReq.Input) != 0 {
+		t.Fatalf("input count = %d, want 0", len(responsesReq.Input))
+	}
+}
+
+// TestNormalizedToResponses_RoleMapping verifies only the roles the Responses
+// API knows survive; system/tool text maps to user.
+func TestNormalizedToResponses_RoleMapping(t *testing.T) {
+	req := &core.NormalizedRequest{
+		Model: "muse-spark-1.2-contributor",
+		Messages: []core.NormalizedMessage{
+			{Role: "system", Blocks: []core.NormalizedContentBlock{{Type: "text", Text: "sys"}}},
+			{Role: "tool", Blocks: []core.NormalizedContentBlock{{Type: "text", Text: "tool"}}},
+			{Role: "developer", Blocks: []core.NormalizedContentBlock{{Type: "text", Text: "dev"}}},
+			{Role: "user", Blocks: []core.NormalizedContentBlock{{Type: "text", Text: "usr"}}},
+			{Role: "assistant", Blocks: []core.NormalizedContentBlock{{Type: "text", Text: "ast"}}},
+		},
+	}
+
+	responsesReq := NormalizedToResponses(req, config.ModelConfig{ModelID: "muse-spark-1.2-contributor"})
+
+	want := []string{"user", "user", "developer", "user", "assistant"}
+	if len(responsesReq.Input) != len(want) {
+		t.Fatalf("input count = %d, want %d", len(responsesReq.Input), len(want))
+	}
+	for i, role := range want {
+		if got := responsesReq.Input[i].Role; got != role {
+			t.Errorf("input[%d] role = %q, want %q", i, got, role)
+		}
+	}
+}

--- a/internal/transformer/responses.go
+++ b/internal/transformer/responses.go
@@ -2,7 +2,6 @@ package transformer
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/routatic/proxy/internal/config"
@@ -38,14 +37,19 @@ func (t *RequestTransformer) TransformToResponses(
 			case "image":
 				textParts = append(textParts, "[Image]")
 			case "tool_use":
-				textParts = append(textParts, fmt.Sprintf("[Tool: %s(%s)]", block.Name, string(block.Input)))
-			case "tool_result":
-				// For Responses API, tool results are separate items
-				toolContent := block.TextContent()
-				content, _ := json.Marshal(toolContent)
+				// Tool calls are typed items, not text.
 				input = append(input, types.ResponsesInput{
-					Role:    "tool",
-					Content: content,
+					Type:      "function_call",
+					CallID:    block.ID,
+					Name:      block.Name,
+					Arguments: string(block.Input),
+				})
+			case "tool_result":
+				// Tool results are typed items, not {"role":"tool"} messages.
+				input = append(input, types.ResponsesInput{
+					Type:   "function_call_output",
+					CallID: block.ToolUseID,
+					Output: rawJSONString(block.TextContent()),
 				})
 			}
 		}

--- a/internal/transformer/responses.go
+++ b/internal/transformer/responses.go
@@ -29,6 +29,21 @@ func (t *RequestTransformer) TransformToResponses(
 	for _, msg := range anthropicReq.Messages {
 		blocks := msg.ContentBlocks()
 		var textParts []string
+		flushText := func() {
+			if len(textParts) == 0 {
+				return
+			}
+			var sb strings.Builder
+			for _, p := range textParts {
+				sb.WriteString(p)
+			}
+			content, _ := json.Marshal(sb.String())
+			input = append(input, types.ResponsesInput{
+				Role:    msg.Role,
+				Content: content,
+			})
+			textParts = nil
+		}
 
 		for _, block := range blocks {
 			switch block.Type {
@@ -37,6 +52,7 @@ func (t *RequestTransformer) TransformToResponses(
 			case "image":
 				textParts = append(textParts, "[Image]")
 			case "tool_use":
+				flushText()
 				// Tool calls are typed items, not text.
 				input = append(input, types.ResponsesInput{
 					Type:      "function_call",
@@ -45,6 +61,7 @@ func (t *RequestTransformer) TransformToResponses(
 					Arguments: string(block.Input),
 				})
 			case "tool_result":
+				flushText()
 				// Tool results are typed items, not {"role":"tool"} messages.
 				input = append(input, types.ResponsesInput{
 					Type:   "function_call_output",
@@ -54,18 +71,7 @@ func (t *RequestTransformer) TransformToResponses(
 			}
 		}
 
-		if len(textParts) > 0 {
-			var sb strings.Builder
-			for _, p := range textParts {
-				sb.WriteString(p)
-			}
-			text := sb.String()
-			content, _ := json.Marshal(text)
-			input = append(input, types.ResponsesInput{
-				Role:    msg.Role,
-				Content: content,
-			})
-		}
+		flushText()
 	}
 
 	req := &types.ResponsesRequest{

--- a/internal/transformer/responses_ordering_test.go
+++ b/internal/transformer/responses_ordering_test.go
@@ -1,0 +1,81 @@
+package transformer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/routatic/proxy/internal/config"
+	"github.com/routatic/proxy/internal/core"
+	"github.com/routatic/proxy/pkg/types"
+)
+
+func TestTransformToResponses_PreservesContentBlockOrder(t *testing.T) {
+	req := &types.MessageRequest{
+		Messages: []types.Message{{
+			Role: "assistant",
+			Content: json.RawMessage(`[
+				{"type":"text","text":"Before"},
+				{"type":"tool_use","id":"call_1","name":"lookup","input":{"q":"one"}},
+				{"type":"text","text":"After"}
+			]`),
+		}},
+	}
+
+	responsesReq, err := NewRequestTransformer().TransformToResponses(
+		req,
+		config.ModelConfig{ModelID: "gpt-5"},
+	)
+	if err != nil {
+		t.Fatalf("TransformToResponses error: %v", err)
+	}
+
+	if len(responsesReq.Input) != 3 {
+		t.Fatalf("input count = %d, want 3", len(responsesReq.Input))
+	}
+	if got := responsesInputText(t, responsesReq.Input[0]); got != "Before" {
+		t.Errorf("input[0] text = %q, want Before", got)
+	}
+	if got := responsesReq.Input[1]; got.Type != "function_call" || got.CallID != "call_1" {
+		t.Errorf("input[1] = %+v, want function_call call_1", got)
+	}
+	if got := responsesInputText(t, responsesReq.Input[2]); got != "After" {
+		t.Errorf("input[2] text = %q, want After", got)
+	}
+}
+
+func TestNormalizedToResponses_PreservesContentBlockOrder(t *testing.T) {
+	req := &core.NormalizedRequest{
+		Messages: []core.NormalizedMessage{{
+			Role: "user",
+			Blocks: []core.NormalizedContentBlock{
+				{
+					Type:      "tool_result",
+					ToolUseID: "call_1",
+					Content:   json.RawMessage(`"result"`),
+				},
+				{Type: "text", Text: "After result"},
+			},
+		}},
+	}
+
+	responsesReq := NormalizedToResponses(req, config.ModelConfig{ModelID: "gpt-5"})
+
+	if len(responsesReq.Input) != 2 {
+		t.Fatalf("input count = %d, want 2", len(responsesReq.Input))
+	}
+	if got := responsesReq.Input[0]; got.Type != "function_call_output" || got.CallID != "call_1" {
+		t.Errorf("input[0] = %+v, want function_call_output call_1", got)
+	}
+	if got := responsesInputText(t, responsesReq.Input[1]); got != "After result" {
+		t.Errorf("input[1] text = %q, want After result", got)
+	}
+}
+
+func responsesInputText(t *testing.T, input types.ResponsesInput) string {
+	t.Helper()
+	var text string
+	if err := json.Unmarshal(input.Content, &text); err != nil {
+		t.Fatalf("unmarshal input content %s: %v", input.Content, err)
+	}
+	return text
+}

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -815,7 +815,9 @@ func (h *StreamHandler) ProxyResponsesStream(
 	contentIndex := 0
 	var lineBuf []byte
 	contentStarted := false
-	stopSent := false
+	reasoningStarted := false
+	hasToolUse := false
+	startedToolCalls := make(map[string]int)
 	readBuf := readBufPool.Get().(*[]byte)
 	defer readBufPool.Put(readBuf)
 
@@ -834,7 +836,7 @@ func (h *StreamHandler) ProxyResponsesStream(
 			for i := 0; i < n; i++ {
 				b := (*readBuf)[i]
 				if b == '\n' {
-					if err := h.processResponsesSSELine(w, flusher, lineBuf, &contentIndex, &contentStarted, &stopSent, originalModel); err != nil {
+					if err := h.processResponsesSSELine(w, flusher, lineBuf, &contentIndex, &contentStarted, &reasoningStarted, &hasToolUse, startedToolCalls, originalModel); err != nil {
 						return err
 					}
 					lineBuf = lineBuf[:0]
@@ -846,7 +848,7 @@ func (h *StreamHandler) ProxyResponsesStream(
 
 		if err == io.EOF {
 			if len(lineBuf) > 0 {
-				if err := h.processResponsesSSELine(w, flusher, lineBuf, &contentIndex, &contentStarted, &stopSent, originalModel); err != nil {
+				if err := h.processResponsesSSELine(w, flusher, lineBuf, &contentIndex, &contentStarted, &reasoningStarted, &hasToolUse, startedToolCalls, originalModel); err != nil {
 					return err
 				}
 			}
@@ -863,6 +865,9 @@ func (h *StreamHandler) ProxyResponsesStream(
 		}
 	}
 
+	// Close any open text block, then any tool_use blocks the upstream left
+	// open (e.g. abort mid-call), in ascending index order, so content_block_stop
+	// always precedes the terminal message_delta.
 	if contentStarted {
 		stopEvent := types.MessageEvent{
 			Type:  "content_block_stop",
@@ -872,19 +877,36 @@ func (h *StreamHandler) ProxyResponsesStream(
 			return ErrClientDisconnected
 		}
 	}
+	if len(startedToolCalls) > 0 {
+		indices := make([]int, 0, len(startedToolCalls))
+		for _, blockIdx := range startedToolCalls {
+			indices = append(indices, blockIdx)
+		}
+		sort.Ints(indices)
+		for _, blockIdx := range indices {
+			stopEvent := types.MessageEvent{
+				Type:  "content_block_stop",
+				Index: &blockIdx,
+			}
+			if err := writeSSEEvent(w, stopEvent); err != nil {
+				return ErrClientDisconnected
+			}
+		}
+	}
 
-	if !stopSent {
-		msgDelta := types.MessageEvent{
-			Type: "message_delta",
-			Delta: &types.Delta{
-				StopReason: "end_turn",
-			},
-			Usage: &types.Usage{InputTokens: 0, OutputTokens: 0},
-		}
-		if err := writeSSEEvent(w, msgDelta); err != nil {
-			return ErrClientDisconnected
-		}
-		stopSent = true
+	stopReason := "end_turn"
+	if hasToolUse {
+		stopReason = "tool_use"
+	}
+	msgDelta := types.MessageEvent{
+		Type: "message_delta",
+		Delta: &types.Delta{
+			StopReason: stopReason,
+		},
+		Usage: &types.Usage{InputTokens: 0, OutputTokens: 0},
+	}
+	if err := writeSSEEvent(w, msgDelta); err != nil {
+		return ErrClientDisconnected
 	}
 
 	stopEvent := types.MessageEvent{
@@ -904,7 +926,9 @@ func (h *StreamHandler) processResponsesSSELine(
 	line []byte,
 	contentIndex *int,
 	contentStarted *bool,
-	stopSent *bool,
+	reasoningStarted *bool,
+	hasToolUse *bool,
+	startedToolCalls map[string]int,
 	originalModel string,
 ) error {
 	line = bytes.TrimSpace(line)
@@ -950,24 +974,99 @@ func (h *StreamHandler) processResponsesSSELine(
 		flusher.Flush()
 	}
 
-	if chunk.Type == "response.completed" || chunk.Type == "response.done" {
-		if !*stopSent {
-			msgDelta := types.MessageEvent{
-				Type: "message_delta",
-				Delta: &types.Delta{
-					StopReason: "end_turn",
-				},
-				Usage: usageInfoToAnthropic(nil),
+	// A function_call output item becomes an Anthropic tool_use block. Close any
+	// open text block first so content block indices stay contiguous; when no
+	// text preceded the call, the tool block keeps the current index.
+	if chunk.Type == "response.output_item.added" {
+		fc, ok := responsesOutputItem(chunk)
+		if !ok || fc.Type != "function_call" {
+			return nil
+		}
+		if fc.ID == "" {
+			return nil
+		}
+		closed, err := closeOpenBlock(w, *contentIndex, contentStarted, reasoningStarted)
+		if err != nil {
+			return ErrClientDisconnected
+		}
+		if closed {
+			*contentIndex++
+		}
+		startedToolCalls[fc.ID] = *contentIndex
+		*hasToolUse = true
+
+		toolID := fc.CallID
+		if toolID == "" {
+			toolID = fmt.Sprintf("toolu_%s", generateID())
+		}
+		startEvent := types.MessageEvent{
+			Type:  "content_block_start",
+			Index: contentIndex,
+			ContentBlock: &types.ContentBlock{
+				Type:  "tool_use",
+				ID:    toolID,
+				Name:  fc.Name,
+				Input: json.RawMessage(`{}`),
+			},
+		}
+		if err := writeSSEEvent(w, startEvent); err != nil {
+			return ErrClientDisconnected
+		}
+		flusher.Flush()
+	}
+
+	// Incremental arguments for an open function_call.
+	if chunk.Type == "response.function_call_arguments.delta" && chunk.Delta != "" {
+		if blockIdx, exists := startedToolCalls[chunk.ItemID]; exists {
+			delta := types.Delta{
+				Type:        "input_json_delta",
+				PartialJSON: chunk.Delta,
 			}
-			if err := writeSSEEvent(w, msgDelta); err != nil {
+			event := types.MessageEvent{
+				Type:  "content_block_delta",
+				Index: &blockIdx,
+				Delta: &delta,
+			}
+			if err := writeSSEEvent(w, event); err != nil {
 				return ErrClientDisconnected
 			}
-			*stopSent = true
+			flusher.Flush()
+		}
+	}
+
+	// A completed function_call closes its tool_use block.
+	if chunk.Type == "response.output_item.done" {
+		fc, ok := responsesOutputItem(chunk)
+		if !ok || fc.Type != "function_call" {
+			return nil
+		}
+		if blockIdx, exists := startedToolCalls[fc.ID]; exists {
+			stopEvent := types.MessageEvent{
+				Type:  "content_block_stop",
+				Index: &blockIdx,
+			}
+			if err := writeSSEEvent(w, stopEvent); err != nil {
+				return ErrClientDisconnected
+			}
+			delete(startedToolCalls, fc.ID)
 			flusher.Flush()
 		}
 	}
 
 	return nil
+}
+
+// responsesOutputItem returns the output item carried by an output_item event.
+// opencode.ai's Responses endpoint puts the item in the "item" field while the
+// OpenAI reference format uses an "output" array; accept both.
+func responsesOutputItem(chunk types.ResponsesChunk) (types.ResponsesOutput, bool) {
+	if chunk.Item != nil {
+		return *chunk.Item, true
+	}
+	if len(chunk.Output) > 0 {
+		return chunk.Output[0], true
+	}
+	return types.ResponsesOutput{}, false
 }
 
 // ProxyGeminiStream takes a Gemini streaming response and writes Anthropic-format SSE.

--- a/internal/transformer/stream.go
+++ b/internal/transformer/stream.go
@@ -975,8 +975,8 @@ func (h *StreamHandler) processResponsesSSELine(
 	}
 
 	// A function_call output item becomes an Anthropic tool_use block. Close any
-	// open text block first so content block indices stay contiguous; when no
-	// text preceded the call, the tool block keeps the current index.
+	// open text block first, then reserve and advance a unique index for the
+	// tool block so subsequent and overlapping calls cannot reuse it.
 	if chunk.Type == "response.output_item.added" {
 		fc, ok := responsesOutputItem(chunk)
 		if !ok || fc.Type != "function_call" {
@@ -992,7 +992,8 @@ func (h *StreamHandler) processResponsesSSELine(
 		if closed {
 			*contentIndex++
 		}
-		startedToolCalls[fc.ID] = *contentIndex
+		blockIdx := *contentIndex
+		startedToolCalls[fc.ID] = blockIdx
 		*hasToolUse = true
 
 		toolID := fc.CallID
@@ -1001,7 +1002,7 @@ func (h *StreamHandler) processResponsesSSELine(
 		}
 		startEvent := types.MessageEvent{
 			Type:  "content_block_start",
-			Index: contentIndex,
+			Index: &blockIdx,
 			ContentBlock: &types.ContentBlock{
 				Type:  "tool_use",
 				ID:    toolID,
@@ -1012,6 +1013,7 @@ func (h *StreamHandler) processResponsesSSELine(
 		if err := writeSSEEvent(w, startEvent); err != nil {
 			return ErrClientDisconnected
 		}
+		*contentIndex++
 		flusher.Flush()
 	}
 

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -1430,3 +1430,199 @@ func TestProxyStream_NoDuplicateToolStopsOnErrorAfterFinishReason(t *testing.T) 
 		t.Errorf("penultimate event = %+v, want message_delta with stop_reason tool_use", got)
 	}
 }
+
+// TestProxyResponsesStream_ToolCall verifies that a function_call output item in
+// a Responses stream becomes an Anthropic tool_use block with incremental
+// input_json_delta arguments and stop_reason tool_use.
+func TestProxyResponsesStream_ToolCall(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"type":"response.output_item.added","output":[{"type":"function_call","id":"fc_1","call_id":"call_abc","name":"get_weather","arguments":"","status":"in_progress"}]}`,
+		`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"city\":"}`,
+		`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"\"Paris\"}"}`,
+		`{"type":"response.output_item.done","output":[{"type":"function_call","id":"fc_1","call_id":"call_abc","name":"get_weather","arguments":"{\"city\":\"Paris\"}","status":"completed"}]}`,
+		`{"type":"response.completed"}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyResponsesStream(w, body, "muse-spark-1.2-contributor", ctx, 0, cancel); err != nil {
+		t.Fatalf("ProxyResponsesStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// message_start, tool_start(idx=0), 2x input_json_delta, tool_stop(idx=0),
+	// message_delta, message_stop = 7
+	if len(events) != 7 {
+		t.Fatalf("expected 7 events, got %d: %+v", len(events), events)
+	}
+
+	if events[1].Type != "content_block_start" {
+		t.Errorf("event[1].Type = %q, want content_block_start", events[1].Type)
+	}
+	if events[1].ContentBlock == nil || events[1].ContentBlock.Type != "tool_use" {
+		t.Errorf("event[1].ContentBlock = %+v, want tool_use", events[1].ContentBlock)
+	}
+	if events[1].ContentBlock.ID != "call_abc" {
+		t.Errorf("event[1].ContentBlock.ID = %q, want call_abc", events[1].ContentBlock.ID)
+	}
+	if events[1].ContentBlock.Name != "get_weather" {
+		t.Errorf("event[1].ContentBlock.Name = %q, want get_weather", events[1].ContentBlock.Name)
+	}
+	if events[1].Index == nil || *events[1].Index != 0 {
+		t.Errorf("event[1].Index = %v, want 0", events[1].Index)
+	}
+
+	if events[2].Delta == nil || events[2].Delta.Type != "input_json_delta" || events[2].Delta.PartialJSON != `{"city":` {
+		t.Errorf("event[2] = %+v, want input_json_delta `{\"city\":`", events[2])
+	}
+	if events[3].Delta == nil || events[3].Delta.Type != "input_json_delta" || events[3].Delta.PartialJSON != `"Paris"}` {
+		t.Errorf("event[3] = %+v, want input_json_delta `\"Paris\"}`", events[3])
+	}
+
+	if events[4].Type != "content_block_stop" {
+		t.Errorf("event[4].Type = %q, want content_block_stop", events[4].Type)
+	}
+
+	if events[5].Type != "message_delta" {
+		t.Errorf("event[5].Type = %q, want message_delta", events[5].Type)
+	}
+	if events[5].Delta == nil || events[5].Delta.StopReason != "tool_use" {
+		t.Errorf("event[5].Delta.StopReason = %q, want tool_use", events[5].Delta.StopReason)
+	}
+	if events[6].Type != "message_stop" {
+		t.Errorf("event[6].Type = %q, want message_stop", events[6].Type)
+	}
+}
+
+// TestProxyResponsesStream_TextThenToolCall verifies that a text block followed
+// by a function_call produces contiguous indices (text=0, tool=1) and that both
+// blocks are closed before the terminal message_delta.
+func TestProxyResponsesStream_TextThenToolCall(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"type":"response.output_text.delta","delta":"I'll fetch it now."}`,
+		`{"type":"response.output_item.added","output":[{"type":"function_call","id":"fc_9","call_id":"call_xyz","name":"search","arguments":"","status":"in_progress"}]}`,
+		`{"type":"response.function_call_arguments.delta","item_id":"fc_9","delta":"{\"q\":\"go\"}"}`,
+		`{"type":"response.output_item.done","output":[{"type":"function_call","id":"fc_9","call_id":"call_xyz","name":"search","arguments":"{\"q\":\"go\"}","status":"completed"}]}`,
+		`{"type":"response.completed"}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyResponsesStream(w, body, "muse-spark-1.2-contributor", ctx, 0, cancel); err != nil {
+		t.Fatalf("ProxyResponsesStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// message_start, text_start(0), text_delta, text_stop(0), tool_start(1),
+	// args_delta(1), tool_stop(1), message_delta, message_stop = 9
+	if len(events) != 9 {
+		t.Fatalf("expected 9 events, got %d: %+v", len(events), events)
+	}
+
+	if events[1].ContentBlock == nil || events[1].ContentBlock.Type != "text" {
+		t.Errorf("event[1] = %+v, want text block start", events[1])
+	}
+	if events[1].Index == nil || *events[1].Index != 0 {
+		t.Errorf("event[1].Index = %v, want 0", events[1].Index)
+	}
+
+	if events[3].Type != "content_block_stop" {
+		t.Errorf("event[3].Type = %q, want content_block_stop (text close)", events[3].Type)
+	}
+
+	if events[4].ContentBlock == nil || events[4].ContentBlock.Type != "tool_use" {
+		t.Errorf("event[4] = %+v, want tool_use block start", events[4])
+	}
+	if events[4].Index == nil || *events[4].Index != 1 {
+		t.Errorf("event[4].Index = %v, want 1", events[4].Index)
+	}
+
+	if events[5].Delta == nil || events[5].Delta.Type != "input_json_delta" {
+		t.Errorf("event[5] = %+v, want input_json_delta", events[5])
+	}
+
+	if events[7].Type != "message_delta" || events[7].Delta == nil || events[7].Delta.StopReason != "tool_use" {
+		t.Errorf("event[7] = %+v, want message_delta stop_reason tool_use", events[7])
+	}
+}
+
+// TestProxyResponsesStream_TextOnlyStillWorks guards the pre-existing text-only
+// behavior: stop_reason stays end_turn and no tool blocks are emitted.
+func TestProxyResponsesStream_TextOnlyStillWorks(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"type":"response.output_text.delta","delta":"Four"}`,
+		`{"type":"response.completed"}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyResponsesStream(w, body, "muse-spark-1.2-contributor", ctx, 0, cancel); err != nil {
+		t.Fatalf("ProxyResponsesStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// message_start, text_start, text_delta, text_stop, message_delta, message_stop = 6
+	if len(events) != 6 {
+		t.Fatalf("expected 6 events, got %d: %+v", len(events), events)
+	}
+	if events[4].Type != "message_delta" || events[4].Delta == nil || events[4].Delta.StopReason != "end_turn" {
+		t.Errorf("event[4] = %+v, want message_delta stop_reason end_turn", events[4])
+	}
+}
+
+// TestProxyResponsesStream_ToolCall_ItemField matches the event shape opencode.ai's
+// Responses endpoint actually sends: output_item events carry the item in the
+// "item" field (not an "output" array), and arguments arrive via
+// function_call_arguments.delta keyed by item_id.
+func TestProxyResponsesStream_ToolCall_ItemField(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"type":"response.output_item.added","sequence_number":4,"output_index":2,"item":{"id":"fc_abc","type":"function_call","status":"in_progress","name":"get_weather","call_id":"call_xyz"}}`,
+		`{"type":"response.function_call_arguments.delta","sequence_number":11,"output_index":2,"item_id":"fc_abc","delta":"{\"city\":\"Paris\"}"}`,
+		`{"type":"response.output_item.done","sequence_number":13,"output_index":2,"item":{"id":"fc_abc","type":"function_call","status":"completed","name":"get_weather","call_id":"call_xyz","arguments":"{\"city\":\"Paris\"}"}}`,
+		`{"type":"response.completed"}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyResponsesStream(w, body, "muse-spark-1.2-contributor", ctx, 0, cancel); err != nil {
+		t.Fatalf("ProxyResponsesStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+
+	// message_start, tool_start(idx=0), args_delta, tool_stop(idx=0),
+	// message_delta, message_stop = 6
+	if len(events) != 6 {
+		t.Fatalf("expected 6 events, got %d: %+v", len(events), events)
+	}
+	if events[1].ContentBlock == nil || events[1].ContentBlock.Type != "tool_use" {
+		t.Fatalf("event[1] = %+v, want tool_use block start", events[1])
+	}
+	if events[1].ContentBlock.ID != "call_xyz" || events[1].ContentBlock.Name != "get_weather" {
+		t.Errorf("event[1] tool_use = %+v, want id call_xyz name get_weather", events[1].ContentBlock)
+	}
+	if events[2].Delta == nil || events[2].Delta.Type != "input_json_delta" || events[2].Delta.PartialJSON != `{"city":"Paris"}` {
+		t.Errorf("event[2] = %+v, want input_json_delta `{\"city\":\"Paris\"}`", events[2])
+	}
+	if events[3].Type != "content_block_stop" {
+		t.Errorf("event[3].Type = %q, want content_block_stop", events[3].Type)
+	}
+	if events[4].Delta == nil || events[4].Delta.StopReason != "tool_use" {
+		t.Errorf("event[4] = %+v, want message_delta stop_reason tool_use", events[4])
+	}
+}

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -1498,6 +1498,40 @@ func TestProxyResponsesStream_ToolCall(t *testing.T) {
 	}
 }
 
+func TestProxyResponsesStream_OverlappingToolCallsUseDistinctIndices(t *testing.T) {
+	handler := NewStreamHandler()
+	w := newMockResponseWriter()
+	body := sseLines(
+		`{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"first"}}`,
+		`{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_2","call_id":"call_2","name":"second"}}`,
+		`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"a\":1}"}`,
+		`{"type":"response.function_call_arguments.delta","item_id":"fc_2","delta":"{\"b\":2}"}`,
+		`{"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"first"}}`,
+		`{"type":"response.output_item.done","item":{"type":"function_call","id":"fc_2","call_id":"call_2","name":"second"}}`,
+		`{"type":"response.completed"}`,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := handler.ProxyResponsesStream(w, body, "gpt-5", ctx, 0, cancel); err != nil {
+		t.Fatalf("ProxyResponsesStream error: %v", err)
+	}
+
+	events := parseSSEEvents(t, w.buf.String())
+	if len(events) != 9 {
+		t.Fatalf("expected 9 events, got %d: %+v", len(events), events)
+	}
+
+	wantIndices := []int{0, 1, 0, 1, 0, 1}
+	for i, want := range wantIndices {
+		event := events[i+1]
+		if event.Index == nil || *event.Index != want {
+			t.Errorf("event[%d] index = %v, want %d", i+1, event.Index, want)
+		}
+	}
+}
+
 // TestProxyResponsesStream_TextThenToolCall verifies that a text block followed
 // by a function_call produces contiguous indices (text=0, tool=1) and that both
 // blocks are closed before the terminal message_delta.

--- a/internal/transformer/stream_test.go
+++ b/internal/transformer/stream_test.go
@@ -1472,6 +1472,9 @@ func TestProxyResponsesStream_ToolCall(t *testing.T) {
 	if events[1].ContentBlock.Name != "get_weather" {
 		t.Errorf("event[1].ContentBlock.Name = %q, want get_weather", events[1].ContentBlock.Name)
 	}
+	if got := string(events[1].ContentBlock.Input); got != `{}` {
+		t.Errorf("event[1].ContentBlock.Input = %s, want {}", got)
+	}
 	if events[1].Index == nil || *events[1].Index != 0 {
 		t.Errorf("event[1].Index = %v, want 0", events[1].Index)
 	}
@@ -1523,12 +1526,43 @@ func TestProxyResponsesStream_OverlappingToolCallsUseDistinctIndices(t *testing.
 		t.Fatalf("expected 9 events, got %d: %+v", len(events), events)
 	}
 
-	wantIndices := []int{0, 1, 0, 1, 0, 1}
-	for i, want := range wantIndices {
+	wantEvents := []struct {
+		eventType string
+		index     int
+		deltaType string
+	}{
+		{eventType: "content_block_start", index: 0},
+		{eventType: "content_block_start", index: 1},
+		{eventType: "content_block_delta", index: 0, deltaType: "input_json_delta"},
+		{eventType: "content_block_delta", index: 1, deltaType: "input_json_delta"},
+		{eventType: "content_block_stop", index: 0},
+		{eventType: "content_block_stop", index: 1},
+	}
+	for i, want := range wantEvents {
 		event := events[i+1]
-		if event.Index == nil || *event.Index != want {
-			t.Errorf("event[%d] index = %v, want %d", i+1, event.Index, want)
+		if event.Type != want.eventType {
+			t.Errorf("event[%d].Type = %q, want %q", i+1, event.Type, want.eventType)
 		}
+		if event.Index == nil || *event.Index != want.index {
+			t.Errorf("event[%d].Index = %v, want %d", i+1, event.Index, want.index)
+		}
+		if want.eventType == "content_block_start" &&
+			(event.ContentBlock == nil || event.ContentBlock.Type != "tool_use") {
+			t.Errorf("event[%d].ContentBlock = %+v, want tool_use", i+1, event.ContentBlock)
+		}
+		if want.deltaType != "" &&
+			(event.Delta == nil || event.Delta.Type != want.deltaType) {
+			t.Errorf("event[%d].Delta = %+v, want %s", i+1, event.Delta, want.deltaType)
+		}
+	}
+
+	if events[7].Type != "message_delta" ||
+		events[7].Delta == nil ||
+		events[7].Delta.StopReason != "tool_use" {
+		t.Errorf("event[7] = %+v, want message_delta with tool_use stop reason", events[7])
+	}
+	if events[8].Type != "message_stop" {
+		t.Errorf("event[8].Type = %q, want message_stop", events[8].Type)
 	}
 }
 

--- a/pkg/types/zen.go
+++ b/pkg/types/zen.go
@@ -15,9 +15,17 @@ type ResponsesRequest struct {
 }
 
 // ResponsesInput represents a single input item in the Responses request.
+// The API accepts heterogeneous items: role-based messages (developer/user/
+// assistant) and typed items (function_call, function_call_output, reasoning).
+// Fields are omitempty so one struct covers every shape.
 type ResponsesInput struct {
-	Role    string          `json:"role"`
-	Content json.RawMessage `json:"content,omitempty"`
+	Type      string          `json:"type,omitempty"`
+	Role      string          `json:"role,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+	CallID    string          `json:"call_id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Arguments string          `json:"arguments,omitempty"`
+	Output    json.RawMessage `json:"output,omitempty"`
 }
 
 // ResponsesTool represents a tool definition for the Responses API.
@@ -70,7 +78,9 @@ type ResponsesUsage struct {
 type ResponsesChunk struct {
 	Type   string            `json:"type"`
 	ID     string            `json:"id,omitempty"`
+	ItemID string            `json:"item_id,omitempty"`
 	Delta  string            `json:"delta,omitempty"`
+	Item   *ResponsesOutput  `json:"item,omitempty"`
 	Output []ResponsesOutput `json:"output,omitempty"`
 	Usage  *ResponsesUsage   `json:"usage,omitempty"`
 }


### PR DESCRIPTION
The Responses streaming path only forwarded text deltas, so every streaming request to a model on `/v1/responses` (e.g. `muse-spark-1.2-contributor`, `grok-4.6`, `gpt-5.6-luna`) dropped its `tool_use` blocks and returned text + `end_turn`.

Claude Code always streams, so the model appeared to "stop immediately" without calling any tool.

#### Changes

- **Input:** `NormalizedToResponses` now emits typed `function_call`/`function_call_output` items instead of folding tool blocks into text; same fix in legacy `TransformToResponses` (Zen path). Handles empty text / thinking-only messages (no spurious item).
- **Streaming output:** `ProxyResponsesStream` now emits `tool_use` blocks from `function_call` output items (both `item` and `output` shapes), streams `input_json_delta`, closes blocks in index order, and reports `stop_reason: tool_use`.

#### Tests

- 4 new transformer streaming tests (including one matching the real upstream `item`-field event format)
- 4 new normalized-bridge tests (tool_result-only, tool_use, thinking-only, role mapping)
- 1 new provider round-trip test (3-message tool turn → no missing type/role)

#### Verification

- Live curl through the proxy with streaming + tool: now emits `content_block_start tool_use` + `input_json_delta` instead of `text → end_turn`
- Live Claude Code session: `list the files in this directory` now triggers tools (previously stopped immediately)
- `go test ./...` green

Note: `brew upgrade` will clobber the locally installed patched binary.